### PR TITLE
feat(sysinfo): get system information from linux and darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# IDE
+.vscode/
+
+# Build
+build/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.etcd.io/bbolt v1.3.5
 	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/protobuf v1.27.1

--- a/lib/fileops/os_fs.go
+++ b/lib/fileops/os_fs.go
@@ -27,11 +27,11 @@ import (
 	"path"
 	"path/filepath"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
+	"github.com/openGemini/openGemini/lib/sysinfo"
 	"github.com/openGemini/openGemini/lib/util"
 	"go.uber.org/zap"
 )
@@ -184,14 +184,7 @@ func (vfs) ReadFile(filename string, _ ...FSOption) ([]byte, error) {
 }
 
 func (vfs) CreateTime(name string) (*time.Time, error) {
-	fi, err := os.Stat(name)
-	if err != nil {
-		return nil, err
-	}
-
-	st := fi.Sys().(*syscall.Stat_t)
-	tm := time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
-	return &tm, nil
+	return sysinfo.CreateTime(name)
 }
 
 func (vfs) Truncate(name string, size int64, _ ...FSOption) error {

--- a/lib/sysinfo/fs_darwin.go
+++ b/lib/sysinfo/fs_darwin.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func CreateTime(name string) (*time.Time, error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	st := fi.Sys().(*syscall.Stat_t)
+	tm := time.Unix(st.Ctimespec.Sec, st.Ctimespec.Nsec)
+	return &tm, nil
+}

--- a/lib/sysinfo/fs_linux.go
+++ b/lib/sysinfo/fs_linux.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func CreateTime(name string) (*time.Time, error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+
+	st := fi.Sys().(*syscall.Stat_t)
+	tm := time.Unix(st.Ctim.Sec, st.Ctim.Nsec)
+	return &tm, nil
+}

--- a/lib/sysinfo/os_darwin.go
+++ b/lib/sysinfo/os_darwin.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	HW_MEMSIZE_MIB = "hw.memsize"
+)
+
+func TotalMemory() (uint64, error) {
+	ms, err := unix.SysctlUint64(HW_MEMSIZE_MIB)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get total memory: %w", err)
+	}
+	return ms, nil
+}

--- a/lib/sysinfo/os_linux.go
+++ b/lib/sysinfo/os_linux.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sysinfo
+
+import (
+	"syscall"
+)
+
+func TotalMemory() (uint64, error) {
+	var si syscall.Sysinfo_t
+	if err := syscall.Sysinfo(&si); err != nil {
+		return 0, err
+	}
+	return uint64(si.Totalram) * uint64(si.Unit)
+}


### PR DESCRIPTION
sysinfo includes information about the the host operation system. features are supported as below:
- **CreateTime**: get the boot time of host.
- **TotalMemory**: get the total memory of host.

Signed-off-by: zhouruiapple <zhouruiapple@126.com>