### PR TITLE
fix(engine): fix some tag values missing when show tag values

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1264,7 +1264,7 @@ func (e *Engine) TagValues(db string, ptIDs []uint32, tagKeys map[string][][]byt
 					// Measurement name not found
 					continue
 				}
-				results[name] = make([][]string, len(tagKeys[name]))
+
 				appendValuesToMap(results, name, values)
 			}
 		}
@@ -1289,8 +1289,11 @@ func (e *Engine) TagValues(db string, ptIDs []uint32, tagKeys map[string][][]byt
 }
 
 func appendValuesToMap(results map[string][][]string, name string, values [][]string) {
+	if _, ok := results[name]; !ok {
+		results[name] = make([][]string, len(values))
+	}
 	for i := 0; i < len(values); i++ {
-		results[name][i] = strings.UnionSlice(values[i])
+		results[name][i] = strings.UnionSlice(append(results[name][i], values[i]...))
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

-->

Issue Number: close #33

## Problem Summary:
Some tag values missing when show tag values.

### What is changed and how it works?
Fix function Engine.TagValues and it works fine, please check it.