### PR TITLE
fix(meta): fix search method of createIndexGroupIfNeeded to decide wh…

### DIFF
--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -1460,15 +1460,16 @@ func (data *Data) CreateIndexGroup(rpi *RetentionPolicyInfo, timestamp time.Time
 }
 
 func (data *Data) createIndexGroupIfNeeded(rpi *RetentionPolicyInfo, timestamp time.Time) *IndexGroupInfo {
-	if rpi.IndexGroups == nil {
+	if len(rpi.IndexGroups) == 0 {
 		return data.CreateIndexGroup(rpi, timestamp)
 	}
-	igIdx := sort.Search(len(rpi.IndexGroups), func(i int) bool {
-		if rpi.IndexGroups[i].Contains(timestamp) {
-			return true
+	var igIdx int
+	for igIdx = 0; igIdx < len(rpi.IndexGroups); igIdx++ {
+		if rpi.IndexGroups[igIdx].Contains(timestamp) {
+			break
 		}
-		return false
-	})
+	}
+
 	if igIdx < len(rpi.IndexGroups) && len(rpi.IndexGroups[igIdx].Indexes) >= int(data.ClusterPtNum) {
 		return &rpi.IndexGroups[igIdx]
 	}


### PR DESCRIPTION

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

-->
Signed-off-by: zhenyuxie 511915741@qq.com
Issue Number: close #41 

## Problem Summary:
The index group in openGemini like shard group, it is responsible for dividing the index data into corresponding time range. So, an index group only corresponds to a time range，that's to say a time range only corresponds to a index. But actually I found multiple indexes on the same time range. This bug causes index bloat, wasting performance and storage.

### What is changed and how it works?
I fixed the method createIndexGroupIfNeeded in data.go and avoid creating duplicate indexes on the same time range. It worked well.
