### PR TITLE
fix: not list unformatted files when style check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,19 +51,32 @@ licence-check:
   			cat $$file | grep -qs $(COPYRIGHT_HEADER) || { echo $$file "has no licence header" >> licence-check.log; }; \
 	 	done
 	@if [ -f licence-check.log ]; \
-  		then \
-			cat  licence-check.log; \
-			rm -f licence-check.log; \
-			exit 1; \
+  	then \
+		cat  licence-check.log; \
+		rm -f licence-check.log; \
+		exit 1; \
 	else \
-		  	echo "licence check ok"; \
-		  	exit 0; \
+		echo "licence check ok"; \
+		exit 0; \
 	fi
 
 
 style-check: install-goimports-reviser
 	@echo "run style check for import pkg order"
-	for file in $$(find . -name '*.go'); do if ! goimports-reviser -project-name fuck -set-exit-status $$file; then exit 1; fi; done
+	@for file in $$(find . -name '*.go'); do goimports-reviser -project-name none-pjn $$file; done
+	@GIT_STATUS=`git status | grep "Changes not staged for commit"`; \
+		if [ "$$GIT_STATUS" = "" ]; \
+		then \
+			echo "code already go formatted"; \
+		else \
+			echo "style check failed, please format your code using goimports-reviser"; \
+			echo "ref: github.com/incu6us/goimports-reviser"; \
+			echo "git diff files:"; \
+			git diff --stat | tee; \
+			echo "git diff details: "; \
+			git diff | tee; \
+			exit 1; \
+		fi
 
 install-failpoint:
 	@$(GO) install github.com/pingcap/failpoint/failpoint-ctl


### PR DESCRIPTION
Signed-off-by: shilinlee <836160610@qq.com>

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Issue Number: close/fix/reslove/ref #xxx

### What is changed and how it works?

use github.com/incu6us/goimports-reviser to fromat code. And list the unformatted code files and diff details.

### How Has This Been Tested?

- [x] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
