### PR TITLE
fix: inf writing should not be supported

### DIFF
--- a/open_src/vm/protoparser/influx/parser.go
+++ b/open_src/vm/protoparser/influx/parser.go
@@ -1167,7 +1167,7 @@ func parseFieldNumValue(s string) (float64, int32, error) {
 	}
 
 	f := fastfloat.ParseBestEffort(s)
-	if math.IsNaN(f) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
 		return 0, Field_Type_Unknown, fmt.Errorf("invalid number")
 	}
 


### PR DESCRIPTION
Signed-off-by: lihanxue <464104891@qq.com>

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### The Inf value is successfully written but cannot be queried
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

fix #55 

### Add Inf value writing failure judgment
The system can support scientific notations, and the problem is the overflow value 50.98e999 based on the system supporting float64 decimal which is written as +Inf. When querying such value, the JSON cannot decode Inf and Nan based on [RFC standard,](https://www.rfc-editor.org/rfc/rfc7159) so returning error of "unsupported value: +Inf". 

> Numeric values that cannot be represented in the grammar below (such as Infinity and NaN) are not permitted.


Such value is forbidden from being written to the system by adding Inf judgment during writing.

### test as issue
Insert overflow value with scientific notations like 50.98e999, return "invalid number" error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
