### PR TITLE
fix: ts-monitor does not release file handle

### DIFF
--- a/app/ts-monitor/collector/report.go
+++ b/app/ts-monitor/collector/report.go
@@ -293,10 +293,7 @@ func (rb *ReportJob) tail(filename string, result chan []byte) error {
 	}
 
 	st := pusher.NewSnappyTail(timeout, rb.compress)
-	go func() {
-		<-rb.done
-		st.Close()
-	}()
+	defer st.Close()
 
 	err := st.Tail(filename, func(data []byte) {
 		defer func() {


### PR DESCRIPTION
Signed-off-by: shilinlee <836160610@qq.com>

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Issue Number: close #60 

### What is changed and how it works?

Close the file when function return

### How Has This Been Tested?

- [X] Test_Collect_MetricFiles

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
