### PR TITLE
perf(index): improve write performance

### DIFF
--- a/engine/index/tsi/index_am.go
+++ b/engine/index/tsi/index_am.go
@@ -78,7 +78,7 @@ type IndexAmRoutine struct {
 
 	amOpen         func(index interface{}) error
 	amBuild        func(relation *IndexRelation) error
-	amInsert       func(index interface{}, primaryIndex PrimaryIndex, name []byte, row interface{}, version uint16) (uint64, error)
+	amInsert       func(index interface{}, primaryIndex PrimaryIndex, name []byte, row interface{}) (uint64, error)
 	amDelete       func(index interface{}, primaryIndex PrimaryIndex, name []byte, condition influxql.Expr, tr TimeRange) error
 	amScan         func(index interface{}, primaryIndex PrimaryIndex, span *tracing.Span, name []byte, opt *query.ProcessorOptions) (interface{}, error)
 	amScanrelation func(oid1 int, oid2 int, result1 interface{}, result2 interface{}) (interface{}, error)

--- a/engine/index/tsi/index_relation.go
+++ b/engine/index/tsi/index_relation.go
@@ -58,10 +58,10 @@ func (relation *IndexRelation) IndexBuild(name []byte, indexMap map[string]int) 
 	return relation.indexAmRoutine.amBuild(relation)
 }
 
-func (relation *IndexRelation) IndexInsert(name []byte, point interface{}, version uint16) error {
+func (relation *IndexRelation) IndexInsert(name []byte, point interface{}) error {
 	index := relation.indexAmRoutine.index
 	primaryIndex := relation.iBuilder.GetPrimaryIndex()
-	_, err := relation.indexAmRoutine.amInsert(index, primaryIndex, name, point, version)
+	_, err := relation.indexAmRoutine.amInsert(index, primaryIndex, name, point)
 	return err
 }
 
@@ -90,4 +90,5 @@ type PrimaryIndex interface {
 	CreateIndexIfNotExists(mmRows *dictpool.Dict) error
 	GetPrimaryKeys(name []byte, opt *query.ProcessorOptions) ([]uint64, error)
 	GetDeletePrimaryKeys(name []byte, condition influxql.Expr, tr TimeRange) ([]uint64, error)
+	Path() string
 }

--- a/engine/index/tsi/text_index.go
+++ b/engine/index/tsi/text_index.go
@@ -50,7 +50,7 @@ func (idx *TextIndex) Close() error {
 	return nil
 }
 
-func (idx *TextIndex) CreateIndexIfNotExists(primaryIndex PrimaryIndex, row *influx.Row, version uint16) (uint64, error) {
+func (idx *TextIndex) CreateIndexIfNotExists(primaryIndex PrimaryIndex, row *influx.Row) (uint64, error) {
 	//fmt.Println("TextIndex CreateIndexIfNotExists")
 	// TODO
 	return 0, nil
@@ -94,10 +94,10 @@ func TextOpen(index interface{}) error {
 	return textIndex.Open()
 }
 
-func TextInsert(index interface{}, primaryIndex PrimaryIndex, name []byte, row interface{}, version uint16) (uint64, error) {
+func TextInsert(index interface{}, primaryIndex PrimaryIndex, name []byte, row interface{}) (uint64, error) {
 	textIndex := index.(*TextIndex)
 	insertRow := row.(*influx.Row)
-	return textIndex.CreateIndexIfNotExists(primaryIndex, insertRow, version)
+	return textIndex.CreateIndexIfNotExists(primaryIndex, insertRow)
 }
 
 // upper function call should analyze result

--- a/engine/shard.go
+++ b/engine/shard.go
@@ -531,13 +531,15 @@ func (s *shard) writeRowsToTable(rows influx.Rows, binaryRows []byte) error {
 			tm = rows[i].Timestamp
 		}
 
-		ri.SeriesId, err = mergetIndex.GetSeriesIdBySeriesKey(rows[i].IndexKey, record.Str2bytes(rows[i].Name))
-		if err != nil {
-			return err
-		}
+		if !writeIndexRequired {
+			ri.SeriesId, err = mergetIndex.GetSeriesIdBySeriesKey(rows[i].IndexKey, record.Str2bytes(rows[i].Name))
+			if err != nil {
+				return err
+			}
 
-		if ri.SeriesId == 0 {
-			writeIndexRequired = true
+			if ri.SeriesId == 0 {
+				writeIndexRequired = true
+			}
 		}
 
 		atomic.AddInt64(&statistics.PerfStat.WriteFieldsCount, int64(rows[i].Fields.Len()))

--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -99,3 +99,16 @@ func (c *Corrector) TomlSize(v *toml.Size, def toml.Size) {
 		*v = def
 	}
 }
+
+func CeilToPower2(num uint32) uint32 {
+	if num > (1 << 31) {
+		return 1 << 31
+	}
+	num--
+	num |= num >> 1
+	num |= num >> 2
+	num |= num >> 4
+	num |= num >> 8
+	num |= num >> 16
+	return num + 1
+}

--- a/lib/util/util_test.go
+++ b/lib/util/util_test.go
@@ -81,3 +81,12 @@ func TestZeroToDefault(t *testing.T) {
 	assert.Equal(t, vString, "a")
 	assert.Equal(t, vTomlDuration, toml.Duration(1))
 }
+
+func TestCeilToPower2(t *testing.T) {
+	assert.Equal(t, uint32(1), util.CeilToPower2(1))
+	assert.Equal(t, uint32(2), util.CeilToPower2(2))
+	assert.Equal(t, uint32(4), util.CeilToPower2(3))
+	assert.Equal(t, uint32(8), util.CeilToPower2(5))
+	assert.Equal(t, uint32(16), util.CeilToPower2(9))
+	assert.Equal(t, uint32(32), util.CeilToPower2(26))
+}

--- a/open_src/vm/protoparser/influx/parser.go
+++ b/open_src/vm/protoparser/influx/parser.go
@@ -108,6 +108,7 @@ func (rs Rows) Swap(i, j int) {
 // Row is a single influx row.
 type Row struct {
 	Name         string
+	Version      uint16
 	Tags         PointTags
 	Fields       Fields
 	ShardKey     []byte


### PR DESCRIPTION
1. Reduce unnecessary method calls for GetSeriesIdBySeriesKey
2. Remove the lock in IndexBuilder
3. Concurrent creating index for rows

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Signed-off-by: zhenyuxie [511915741@qq.com](mailto:511915741@qq.com)
Issue Number: close/fix/reslove/ref #63 

### What is changed and how it works?

1. Reduce some unnecessary method invokes in shard.writeRowsToTable
2. Remove the big lock in IndexBuilder.CreateIndexIfNotExists.
3. Concurrent creating index for rows.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Just use origin unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
