### PR TITLE
fix: fix query used regexpr with escape

### DIFF
--- a/engine/index/tsi/tag_filters.go
+++ b/engine/index/tsi/tag_filters.go
@@ -214,6 +214,7 @@ func (tf *tagFilter) Init(name, key, value []byte, isNegative, isRegexp bool) er
 	if tf.isRegexp {
 		prefix, expr = getRegexpPrefix(tf.value)
 		if len(expr) == 0 {
+			tf.value = append(tf.value[:0], prefix...)
 			// select /Ubuntu/ should return match value which contain Ubuntu
 			tf.reSuffixMatch = func(b []byte) bool {
 				return bytes.Contains(b, tf.value)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Signed-off-by: zhenyuxie [511915741@qq.com](mailto:511915741@qq.com)
Issue Number: close/fix/reslove/ref #91 

### What is changed and how it works?
I fixed the method Init in tag_filters.go. If used regexpr in tag filter, tf.value must be updated use prefix.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
