### PR TITLE
fix: shard mu RLock and Lock conflict

### DIFF
--- a/engine/iterators.go
+++ b/engine/iterators.go
@@ -159,22 +159,18 @@ func (s *shard) CreateCursor(ctx context.Context, schema *executor.QuerySchema) 
 
 func (s *shard) cloneMeasurementReaders(mm string) *immutable.MmsReaders {
 	var readers immutable.MmsReaders
-	s.mu.RLock()
 	orders := s.immTables.GetFilesRef(mm, true)
 	unOrder := s.immTables.GetFilesRef(mm, false)
 	readers.Orders = append(readers.Orders, orders...)
 	readers.OutOfOrders = append(readers.OutOfOrders, unOrder...)
-	s.mu.RUnlock()
 
 	return &readers
 }
 
 func (s *shard) cloneMeasurementReadersByTime(mm string, ascending bool, tr record.TimeRange) *immutable.MmsReaders {
 	var readers immutable.MmsReaders
-	s.mu.RLock()
 	orders := s.immTables.GetFilesRefByAscending(mm, true, ascending, tr)
 	unOrder := s.immTables.GetFilesRef(mm, false)
-	s.mu.RUnlock()
 	readers.Orders = append(readers.Orders, orders...)
 	readers.OutOfOrders = append(readers.OutOfOrders, unOrder...)
 


### PR DESCRIPTION
Signed-off-by: jwcesign <jwcesign@gmail.com>

### What problem does this PR solve?
This may stuck rp task or other shard get Lock staff.

Issue Number: close #95

### What is changed and how it works?
shard CreateLogicPlan already get shard mu RLock.

### How Has This Been Tested?

- [x] existed test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules