### PR TITLE
fix: ts-monitor not check index directory exist

### DIFF
--- a/app/ts-monitor/collector/node_monitor.go
+++ b/app/ts-monitor/collector/node_monitor.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -272,6 +273,13 @@ func (nc *NodeCollector) collectBasic(ctx context.Context) error {
 }
 
 func (nc *NodeCollector) collectIndexUsed() error {
+	files, err := filepath.Glob(fmt.Sprintf("%s/data/*/*/*/index", nc.conf.DiskPath))
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
 	duCmd := fmt.Sprintf(DuIndex, path.Clean(nc.conf.DiskPath))
 	// #nosec
 	res, err := exec.Command("/bin/sh", "-c", duCmd).Output()


### PR DESCRIPTION
Signed-off-by: 7StarH <1343153389@qq.com>

### What problem does this PR solve?
The `ts-monitor` collects disk space statistics used by `index files` every 10 seconds.
When the kernel does not access data, the index directory does not exist. During this period, the `ts-monitor` keeps printing error logs every 10 seconds.

Issue Number: close #97

### What is changed and how it works?
Before confirming disk space, check whether the folder exists. If no file exists, exit the task.

### How Has This Been Tested?

- [x] TestNodeCollector

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules