### PR TITLE
fix: index out of range for descending query

### DIFF
--- a/engine/immutable/reader.go
+++ b/engine/immutable/reader.go
@@ -504,7 +504,7 @@ func appendIntegerColumn(nilBitmap []byte, bitmapOffset uint32, encData []byte, 
 
 		if !ctx.Ascending {
 			_ = reverseIntergerValues(values)
-			col.Bitmap = record.ReverseBitMap(col.Bitmap, bitmapOffset, rows)
+			col.Bitmap = record.ReverseBitMap(col.Bitmap, uint32(col.BitMapOffset), rows)
 		}
 
 		col.Len += rows
@@ -530,7 +530,7 @@ func appendFloatColumn(nilBitmap []byte, bitmapOffset uint32, encData []byte, ni
 		col.AppendBitmap(nilBitmap, int(bitmapOffset), rows, 0, rows)
 		if !ctx.Ascending {
 			_ = reverseFloatValues(values)
-			col.Bitmap = record.ReverseBitMap(col.Bitmap, bitmapOffset, rows)
+			col.Bitmap = record.ReverseBitMap(col.Bitmap, uint32(col.BitMapOffset), rows)
 		}
 
 		col.Len += rows
@@ -555,7 +555,7 @@ func appendBooleanColumn(nilBitmap []byte, bitmapOffset uint32, encData []byte, 
 		col.AppendBitmap(nilBitmap, int(bitmapOffset), rows, 0, rows)
 		if !ctx.Ascending {
 			values = reverseBooleanValues(values)
-			col.Bitmap = record.ReverseBitMap(col.Bitmap, bitmapOffset, len(values)+int(nilCount))
+			col.Bitmap = record.ReverseBitMap(col.Bitmap, uint32(col.BitMapOffset), len(values)+int(nilCount))
 		}
 
 		col.Len += rows

--- a/lib/record/column.go
+++ b/lib/record/column.go
@@ -324,7 +324,7 @@ func (cv *ColVal) reserveVal(size int) {
 
 func (cv *ColVal) reserveBitMap() {
 	bLen := len(cv.Bitmap)
-	if cv.Len/8 < bLen {
+	if (cv.Len+cv.BitMapOffset)/8 < bLen {
 		return
 	}
 	bCap := cap(cv.Bitmap)
@@ -336,11 +336,13 @@ func (cv *ColVal) reserveBitMap() {
 }
 
 func (cv *ColVal) setBitMap(index int) {
+	index += cv.BitMapOffset
 	cv.reserveBitMap()
 	cv.Bitmap[index>>3] |= BitMask[index&0x07]
 }
 
 func (cv *ColVal) resetBitMap(index int) {
+	index += cv.BitMapOffset
 	cv.reserveBitMap()
 	cv.Bitmap[index>>3] &= FlippedBitMask[index&0x07]
 }


### PR DESCRIPTION
Signed-off-by: smallYellowCat <dreamdeveloper@126.com>


### What problem does this PR solve?
When execute descending query and there is a ColVal with bitmapOffset>0 in the data, a panic may occur.

Issue Number: close #99

### What is changed and how it works?
Function logic problem, modify function parameters.

https://github.com/openGemini/openGemini/blob/71dbe9a19b58242ebd5a60d1a553f26b151c492c/engine/immutable/reader.go#L505-L508

`bitmapOffset` should be `uint32(col.BitMapOffset)`. Because what we want to flip is col's bitmap

### How Has This Been Tested?

- [x] TestDecodeColumnData

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules