### PR TITLE
fix: check the error for function `indexBuilder.Scan`

### DIFF
--- a/engine/iterators.go
+++ b/engine/iterators.go
@@ -113,7 +113,7 @@ func (s *shard) CreateCursor(ctx context.Context, schema *executor.QuerySchema) 
 		return nil, err
 	}
 	if result == nil {
-    	s.log.Info("get index result empty")
+		s.log.Info("get index result empty")
 		return nil, nil
 	}
 	tagSets := result.(tsi.GroupSeries)


### PR DESCRIPTION
Signed-off-by: huguowei1996 <1277309034@qq.com>


### What is changed and how it works?
fix: check the error for function `indexBuilder.Scan`, if error is not nil, return error immediately.

### How Has This Been Tested?

- [x] exist test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules