### PR TITLE
fix: always release the session to pool if the session occurred an error

### DIFF
--- a/engine/executor/spdy/transport/transport.go
+++ b/engine/executor/spdy/transport/transport.go
@@ -130,13 +130,13 @@ func (s *Transport) Send(data Codec) error {
 }
 
 func (s *Transport) Wait() error {
-	defer s.release()
-
 	err := s.responser.Apply()
 	if err != nil {
+		spdy.HandleError(s.responser.Session().Close())
 		return err
 	}
 
+	s.release()
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: nicehiro <wfy11235813@gmail.com>


### What is changed and how it works?
if the rpc session occurred an error, it will always release the session to pool. But we should not reuse the session in this abnormal case. Just close it.

### How Has This Been Tested?

- [x] existed test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules