### PR TITLE
fix: deadlock for spdy when rpc session close repeated

### DIFF
--- a/engine/executor/spdy/multiplexed_session_pool.go
+++ b/engine/executor/spdy/multiplexed_session_pool.go
@@ -166,11 +166,14 @@ func (c *MultiplexedSessionPool) create() (*MultiplexedSession, error) {
 
 func (c *MultiplexedSessionPool) Close() {
 	c.closeGuard.Lock()
-	if c.closed {
-		return
-	}
+	closed := c.closed
 	c.closed = true
 	c.closeGuard.Unlock()
+
+	if closed {
+		return
+	}
+
 	c.wg.Done()
 	HandleError(c.conn.Close())
 	close(c.queue)

--- a/engine/executor/spdy/rrcserver_test.go
+++ b/engine/executor/spdy/rrcserver_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openGemini/openGemini/engine/executor/spdy"
 	"github.com/openGemini/openGemini/lib/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -435,6 +436,17 @@ func SequenceRequest(t *testing.T, ip string) error {
 	spool.Close()
 	server.Stop()
 	return nil
+}
+
+func TestCloseAgain(t *testing.T) {
+	server, spool, err := StartServer("127.0.0.8:18081")
+	require.NoError(t, err)
+
+	spool.Close()
+	spool.Close()
+
+	require.False(t, spool.Available())
+	server.Stop()
 }
 
 func TestSequenceRequest(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: minazukie <minazukie2015@gmail.com>

### What problem does this PR solve?
fix deadlock for spdy when rpc session close repeated. 

Issue Number: close #106

### What is changed and how it works?

Fix rpc session does not release the lock when first close. And if close again, it will cause deadlock.
Now every time we call `Close`, we will release the lock.

### How Has This Been Tested?

- [x] TestCloseAgain

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules