### PR TITLE
fix: measurement cannot contain special characters

### DIFF
--- a/lib/errno/code.go
+++ b/lib/errno/code.go
@@ -40,8 +40,9 @@ const (
 	// ThirdPartyError errors returned by third-party packages
 	ThirdPartyError = 9008
 
-	ShortWrite = 9009
-	ShortRead  = 9010
+	ShortWrite         = 9009
+	ShortRead          = 9010
+	InvalidMeasurement = 9011
 )
 
 // network module error codes

--- a/lib/errno/message.go
+++ b/lib/errno/message.go
@@ -57,6 +57,7 @@ var messageMap = map[Errno]*Message{
 	ShortBufferSize:    newWarnMessage("invalid buffer size, expected greater than %d; actual %d", ModuleUnknown),
 	ShortWrite:         newWarnMessage("short write. succeeded in writing %d bytes, but expected %d bytes", ModuleUnknown),
 	ShortRead:          newWarnMessage("short read. succeeded in reading %d bytes, but expected %d bytes", ModuleUnknown),
+	InvalidMeasurement: newWarnMessage("invalid measurement name: %s", ModuleUnknown),
 
 	// write error codes
 	WriteNoShardGroup:               newWarnMessage("nil shard group", ModuleWrite),

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -218,6 +218,14 @@ func (r *DBPTCtx) putRpStat(rss *[]*proto2.RpShardStatus) {
 	r.RpStatusPool.Put(*rss)
 }
 
+func (r *DBPTCtx) String() string {
+	if r.DBPTStat == nil {
+		return ""
+	}
+
+	return r.DBPTStat.String()
+}
+
 // Client is used to execute commands on and read data from
 // a meta service cluster.
 type Client struct {

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -218,14 +218,6 @@ func (r *DBPTCtx) putRpStat(rss *[]*proto2.RpShardStatus) {
 	r.RpStatusPool.Put(*rss)
 }
 
-func (r *DBPTCtx) String() string {
-	if r.DBPTStat == nil {
-		return ""
-	}
-
-	return r.DBPTStat.String()
-}
-
 // Client is used to execute commands on and read data from
 // a meta service cluster.
 type Client struct {
@@ -661,6 +653,10 @@ func (c *Client) CreateMeasurement(database string, retentionPolicy string, mst 
 	}
 	if err != meta2.ErrMeasurementNotFound {
 		return nil, err
+	}
+
+	if !meta2.ValidMeasurementName(mst) {
+		return nil, errno.NewError(errno.InvalidMeasurement, mst)
 	}
 
 	cmd := &proto2.CreateMeasurementCommand{

--- a/lib/metaclient/meta_client_test.go
+++ b/lib/metaclient/meta_client_test.go
@@ -334,6 +334,28 @@ func TestClient_CreateDatabaseWithRetentionPolicy2(t *testing.T) {
 	require.EqualError(t, err, "shard key conflict")
 }
 
+func TestDBPTCtx_String(t *testing.T) {
+	ctx := &DBPTCtx{}
+	ctx.DBPTStat = &proto2.DBPtStatus{
+		DB:   proto.String("db0"),
+		PtID: proto.Uint32(100),
+		RpStats: []*proto2.RpShardStatus{{
+			RpName: proto.String("default"),
+			ShardStats: &proto2.ShardStatus{
+				ShardID:     proto.Uint64(101),
+				ShardSize:   proto.Uint64(102),
+				SeriesCount: proto.Int32(103),
+				MaxTime:     proto.Int64(104),
+			},
+		}, nil},
+	}
+
+	exp := `DB:"db0" PtID:100 RpStats:<RpName:"default" ShardStats:<ShardID:101 ShardSize:102 SeriesCount:103 MaxTime:104 > > RpStats:<nil> `
+	require.Equal(t, exp, ctx.String())
+	ctx.DBPTStat = nil
+	require.Equal(t, "", ctx.String())
+}
+
 func TestCreateMeasurement(t *testing.T) {
 	c := &Client{
 		cacheData: &meta2.Data{

--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -2308,17 +2308,24 @@ func UnmarshalTime(v int64) time.Time {
 
 // ValidName checks to see if the given name can would be valid for DB/RP name
 func ValidName(name string) bool {
+	return validName(name, `,:;./\`)
+}
+
+func ValidMeasurementName(name string) bool {
+	if name == "." || name == ".." {
+		return false
+	}
+	return validName(name, `,:;/\`)
+}
+
+func validName(name string, charactersNotSupport string) bool {
 	for _, r := range name {
 		if !unicode.IsPrint(r) {
 			return false
 		}
 	}
 
-	charactersNotSupport := []byte{',', ':', ';', '.'}
-
-	return name != "" &&
-		!strings.ContainsAny(name, `/\`) &&
-		!strings.ContainsAny(name, string(charactersNotSupport))
+	return name != "" && !strings.ContainsAny(name, charactersNotSupport)
 }
 
 func ValidShardKey(shardKeys []string) error {


### PR DESCRIPTION
Signed-off-by: andrew-sn <liu_sn@yeah.net>


### What is changed and how it works?
Measurement name cannot contain special characters like `,:;/\`. Because these characters will destroy the storage directory.

### How Has This Been Tested?

- [x] TestCreateMeasurement

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules