### PR TITLE
fix: repair the syntax and logic errors in the Docker startup script

### DIFF
--- a/docker/scripts/build_config.sh
+++ b/docker/scripts/build_config.sh
@@ -5,17 +5,17 @@ domain=`echo $OPEN_GEMINI_DOMAIN`
 
 configMount=`echo $OPEN_GEMINI_CONFIG`
 if [[ "$configMount" == "" ]]; then
-	echo "Missing environment variable: CONFIG_MOUNT_PATH"
+	echo "Missing environment variable: OPEN_GEMINI_CONFIG"
 	exit 1
 fi
 
-if [[ !-f $configMount ]]; then
+if [[ ! -f $configMount ]]; then
 	echo "Configuration file does not exist: $configMount"
 	exit 1
 fi
 
 cp -f $configMount $config
-localAddr=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2}'|tr -d "addr:"`
+localAddr=`/sbin/ifconfig -a|grep inet|grep -v 127.0.0.1|grep -v inet6|awk '{print $2;exit}'|tr -d "addr:"`
 sed -i "s/{{addr}}/$localAddr/g" $config
 sed -i "s/{{domain}}/$domain/g" $config
 

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -22,13 +22,14 @@ function checkApp() {
 	app=$1
 
 	ok=`echo $OPEN_GEMINI_LAUNCH|grep "$app"`
-	if [ !-n "$ok" ]; then
+	if [ ! -n "$ok" ]; then
 		return
 	fi
 
 	n=`ps axu|grep "ts-$app"|grep -v grep|wc -l`
 	if [[ $n -eq 0 ]]; then
-		exit ""
+		echo "Process ts-$app has exited"
+		exit 1
 	fi
 }
 
@@ -40,9 +41,9 @@ startApp server
 while true; do
 
 	sleep 1s
-	startApp meta
-	startApp sql
-	startApp store
-	startApp server
+	checkApp meta
+	checkApp sql
+	checkApp store
+	checkApp server
 
 done


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?

修复 docker 启动脚本语法错误和逻辑错误的BUG

Issue Number: fix #112

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

1. 添加环境变量：
```
OPEN_GEMINI_CONFIG=/go/src/openGemini/config/openGemini.conf`
OPEN_GEMINI_DOMAIN=ts-meta
```
2. 运行脚本 sh start.sh
3. 执行 `ps axu|grep ts-meta` 可以看到进程正常运行

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
