### PR TITLE
fix: no error is returned when the index creation process fails

### DIFF
--- a/engine/index/tsi/index_builder.go
+++ b/engine/index/tsi/index_builder.go
@@ -286,13 +286,13 @@ func (iBuilder *IndexBuilder) CreateIndexIfNotExists(mmRows *dictpool.Dict) erro
 			} else {
 				*iRows = append(*iRows, indexRow{})
 			}
-			iRow := (*iRows)[len(*iRows)-1]
+			iRow := &(*iRows)[len(*iRows)-1]
 			iRow.Row = row
 			iRow.Wg = &wg
 
 			wg.Add(1)
 			idx := primaryIndex.(*MergeSetIndex)
-			idx.WriteRow(&iRow)
+			idx.WriteRow(iRow)
 		}
 	}
 	// Wait all rows in the batch finished.


### PR DESCRIPTION
### What problem does this PR solve?
no error is returned when the index creation process fails 

Issue Number: close #xxx

### What is changed and how it works?

iRow should be a point that could be changed in the error item.

### How Has This Been Tested?

- [x] test existed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules