### PR TITLE
fix: ignore the 'time' fields for the line protocol

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -401,8 +401,16 @@ func dropFieldByIndex(r *influx.Row, dropFieldIndex []int) {
 	r.Fields = remainField
 }
 
-func checkFields(fields influx.Fields) error {
+// fixFields checks and fixes fields: gnore specified time fields
+func fixFields(fields influx.Fields) (influx.Fields, error) {
+	var lastIdx = -1
+	var timeLen = 0
 	for i := 0; i < len(fields); i++ {
+		if fields[i].Key == "time" {
+			lastIdx = i
+			timeLen++
+			continue
+		}
 		if i > 0 && fields[i-1].Key == fields[i].Key {
 			failpoint.Inject("skip-duplicate-field-check", func(val failpoint.Value) {
 				if strings2.EqualInterface(val, fields[i].Key) {
@@ -410,11 +418,15 @@ func checkFields(fields influx.Fields) error {
 				}
 			})
 
-			return errno.NewError(errno.DuplicateField, fields[i].Key)
+			return nil, errno.NewError(errno.DuplicateField, fields[i].Key)
 		}
 	}
+	if timeLen > 0 {
+		startIdx := lastIdx - timeLen + 1
+		fields = append(fields[0:startIdx], fields[startIdx+timeLen:]...)
+	}
 
-	return nil
+	return fields, nil
 }
 
 // RetryWritePointRows make sure sql client got the latest metadata.
@@ -550,9 +562,13 @@ func (w *PointsWriter) writeShardMap(database, retentionPolicy string, ctx *inje
 // if there is a stream aggregation, then map rows to mst.
 func (w *PointsWriter) routeAndMapOriginRows(
 	database, retentionPolicy string, rows []influx.Row, ctx *injestionCtx,
-) (partialErr error, dropped int, err error) {
+) (error, int, error) {
+	var partialErr error // the last write partial error
+	var dropped int      // number of missing poits due to write failures
+	var err error        // the error returned immediately
+
 	var isDropRow bool
-	var pErr error
+	var pErr error // the temporary error
 	var sh *meta2.ShardInfo
 
 	wh := ctx.getWriteHelper(w)
@@ -571,9 +587,8 @@ func (w *PointsWriter) routeAndMapOriginRows(
 			continue
 		}
 		sort.Sort(r.Fields)
-
-		if err := checkFields(r.Fields); err != nil {
-			partialErr = err
+		if r.Fields, pErr = fixFields(r.Fields); pErr != nil {
+			partialErr = pErr
 			dropped++
 			continue
 		}
@@ -588,7 +603,7 @@ func (w *PointsWriter) routeAndMapOriginRows(
 				err = nil
 				continue
 			}
-			return
+			return nil, dropped, err
 		}
 		r.Name = ctx.ms.Name
 
@@ -601,7 +616,7 @@ func (w *PointsWriter) routeAndMapOriginRows(
 					continue
 				}
 			} else {
-				return
+				return nil, dropped, err
 			}
 		}
 		atomic.AddInt64(&statistics.HandlerStat.WriteUpdateSchemaDuration, time.Since(start).Nanoseconds())
@@ -614,7 +629,7 @@ func (w *PointsWriter) routeAndMapOriginRows(
 		start = time.Now()
 		err, pErr, sh = w.updateShardGroupAndShardKey(database, retentionPolicy, r, ctx, false, nil, 0, false)
 		if err != nil {
-			return
+			return nil, dropped, err
 		}
 		if pErr != nil {
 			partialErr = pErr
@@ -630,17 +645,17 @@ func (w *PointsWriter) routeAndMapOriginRows(
 		if len(*ctx.getDstSis()) > 0 {
 			err = w.MapRowToMeasurement(ctx, sh.ID, originName, r)
 			if err != nil {
-				return
+				return nil, dropped, err
 			}
 		}
 
 		if err = w.MapRowToShard(ctx, id, r); err != nil {
-			return
+			return nil, dropped, err
 		}
 		atomic.AddInt64(&statistics.HandlerStat.FieldsWritten, int64(r.Fields.Len()))
 		atomic.AddInt64(&statistics.HandlerStat.WriteMapRowsDuration, time.Since(start).Nanoseconds())
 	}
-	return
+	return partialErr, dropped, nil
 }
 
 func (w *PointsWriter) updateSrcStreamDstShardIdMap(

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -457,7 +457,7 @@ func generateRows(num int, rows []influx.Row) []influx.Row {
 	return rows[:num]
 }
 
-func TestCheckFields(t *testing.T) {
+func TestFixFields(t *testing.T) {
 	fields := influx.Fields{
 		{
 			Key:  "foo",
@@ -467,14 +467,40 @@ func TestCheckFields(t *testing.T) {
 			Key:  "foo",
 			Type: influx.Field_Type_Int,
 		},
+		{
+			Key:  "time",
+			Type: influx.Field_Type_Int,
+		},
+		{
+			Key:  "time",
+			Type: influx.Field_Type_Int,
+		},
+		{
+			Key:  "zing",
+			Type: influx.Field_Type_String,
+		},
 	}
 
-	err := checkFields(fields)
+	_, err := fixFields(fields)
 	assert.EqualError(t, err, errno.NewError(errno.DuplicateField, "foo").Error())
 
 	fields[0].Key = "foo2"
-	err = checkFields(fields)
+	fields, err = fixFields(fields)
 	assert.NoError(t, err)
+	assert.Equal(t, influx.Fields{
+		{
+			Key:  "foo2",
+			Type: influx.Field_Type_Float,
+		},
+		{
+			Key:  "foo",
+			Type: influx.Field_Type_Int,
+		},
+		{
+			Key:  "zing",
+			Type: influx.Field_Type_String,
+		},
+	}, fields)
 }
 
 func TestStreamSymbolMarshalUnmarshal(t *testing.T) {

--- a/open_src/vm/protoparser/influx/parser.go
+++ b/open_src/vm/protoparser/influx/parser.go
@@ -219,11 +219,6 @@ func (r *Row) CheckValid() error {
 	if len(r.Fields) == 0 {
 		return ErrPointMustHaveAField
 	}
-	for i := range r.Fields {
-		if r.Fields[i].Key == "time" {
-			return ErrPointInvalidTimeField
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->
Insert datas as bellow
```
> insert tab,_dataType="0x01",_source="12.3.5.2" data_area="single",value=10,time=1677916975303254166
```
Return ERR: {"error":"parse fail, time of field key is unsupported"}

### What is changed and how it works?
Ignore the 'time' fields for the line protocol

### How Has This Been Tested?
test file：points_writer_test.go

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
