### PR TITLE
fix: the index data mmap cannot be configured

### DIFF
--- a/app/ts-store/run/server.go
+++ b/app/ts-store/run/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openGemini/openGemini/lib/statisticsPusher"
 	stat "github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
 	"github.com/openGemini/openGemini/lib/syscontrol"
+	"github.com/openGemini/openGemini/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
 	"github.com/openGemini/openGemini/open_src/github.com/hashicorp/serf/serf"
 	"github.com/openGemini/openGemini/services/sherlock"
 	stream2 "github.com/openGemini/openGemini/services/stream"
@@ -144,6 +145,9 @@ func (s *Server) Open() error {
 	if err := s.transServer.Open(); err != nil {
 		return err
 	}
+
+	// set index mmap enable or disable before storage start.
+	fs.SetDisableMmap(!s.config.Data.EnableMmapRead)
 
 	startTime := time.Now()
 	storageNodeInfo := metaclient.StorageNodeInfo{

--- a/config/openGemini.conf
+++ b/config/openGemini.conf
@@ -92,11 +92,11 @@
   # snapshot-throughput-burst = "70m"
   # Whether to cache data blocks in hot shard
   cache-table-data-block = false
-  # Whether to cache meta blocks in hot shard
+  ## Whether to cache meta blocks in hot shard
   cache-table-meta-block = false
-  # Whether to use mmap ability
-  enable-mmap-read = false
-  # The limit of read cache use size, The unit is byte, less than or equal to 0 is unused, recommend 5368709120 if use
+  ## Whether to use mmap ability
+  # enable-mmap-read = false
+  ## The limit of read cache use size, The unit is byte, less than or equal to 0 is unused, recommend 5368709120 if use
   read-cache-limit = 0
   # write-concurrent-limit = 0
   # open-shard-limit = 0

--- a/engine/immutable/config.go
+++ b/engine/immutable/config.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"sync/atomic"
 
-	"github.com/openGemini/openGemini/lib/config"
 	"go.uber.org/zap"
 )
 
@@ -70,7 +69,6 @@ type Config struct {
 	fileSizeLimit         int64
 	maxChunkMetaItemSize  int
 	maxChunkMetaItemCount int
-	enableMmapRead        bool
 	// Whether to cache data blocks in hot shard
 	cacheDataBlock bool
 	// Whether to cache meta blocks in hot shard
@@ -83,7 +81,6 @@ func NewConfig() *Config {
 		maxRowsPerSegment:     MaxRowsPerSegment(),
 		maxChunkMetaItemSize:  DefaultMaxChunkMetaItemSize,
 		maxChunkMetaItemCount: DefaultMaxChunkMetaItemCount,
-		enableMmapRead:        !config.Is32BitPtr,
 		fileSizeLimit:         atomic.LoadInt64(&maxTSSPFileSize),
 		cacheDataBlock:        atomic.LoadInt32(&cacheDataBlock) > 0,
 		cacheMetaData:         atomic.LoadInt32(&cacheMetaData) > 0,

--- a/engine/immutable/fs_reader.go
+++ b/engine/immutable/fs_reader.go
@@ -23,14 +23,13 @@ import (
 
 	"github.com/openGemini/openGemini/engine/immutable/readcache"
 	"github.com/openGemini/openGemini/lib/bufferpool"
-	"github.com/openGemini/openGemini/lib/config"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/fileops"
 	"github.com/openGemini/openGemini/lib/util"
 	"go.uber.org/zap"
 )
 
-var mmapEn = !config.Is32BitPtr
+var mmapEn = false
 var readCacheEn = false
 
 func EnableMmapRead(en bool) {

--- a/engine/immutable/fs_reader_test.go
+++ b/engine/immutable/fs_reader_test.go
@@ -28,9 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFsReader_Read(t *testing.T) {
+func TestFsReader_Read_EnableMmap(t *testing.T) {
 	fn := t.TempDir() + "/test_diskreader.data"
 	var buf [4096]byte
+
+	EnableMmapRead(true)
+	defer EnableMmapRead(false)
 
 	fd, err := fileops.OpenFile(fn, os.O_CREATE|os.O_RDWR, 0640)
 	require.NoError(t, err)

--- a/engine/immutable/tssp_reader_test.go
+++ b/engine/immutable/tssp_reader_test.go
@@ -633,13 +633,17 @@ func TestFullCompacted(t *testing.T) {
 
 }
 
-func TestFileHandlesRef(t *testing.T) {
+func TestFileHandlesRef_EnableMmap(t *testing.T) {
 	sig := interruptsignal.NewInterruptSignal()
 	defer func() {
 		sig.Close()
 		fileops.RemoveAll(testDir)
 	}()
 	_ = fileops.RemoveAll(testDir)
+
+	EnableMmapRead(true)
+	defer EnableMmapRead(false)
+
 	conf := NewConfig()
 	tier := uint64(util.Hot)
 	lockPath := ""

--- a/lib/config/logger.go
+++ b/lib/config/logger.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// DefaultPath is default path for storing logs
-	DefaultPath = "/opt/openGemini/logs/"
+	DefaultPath = "/tmp/openGemini/logs/"
 
 	// DefaultLevel is the level of logs will be emitted
 	DefaultLevel = zap.InfoLevel

--- a/lib/config/store.go
+++ b/lib/config/store.go
@@ -48,7 +48,6 @@ const (
 	DefaultMaxConcurrentCompactions = 0
 
 	DefaultWriteColdDuration = 5 * time.Second
-	Is32BitPtr               = (^uintptr(0) >> 32) == 0
 
 	DefaultSnapshotThroughput      = 48 * MB
 	DefaultSnapshotThroughputBurst = 64 * MB
@@ -231,7 +230,7 @@ func NewStore() Store {
 		MemDataReadEnabled:           true,
 		CacheDataBlock:               false,
 		CacheMetaBlock:               false,
-		EnableMmapRead:               !Is32BitPtr,
+		EnableMmapRead:               false,
 		ReadCacheLimit:               toml.Size(readCacheLimit),
 		WriteConcurrentLimit:         0,
 		WalSyncInterval:              toml.Duration(DefaultWALSyncInterval),

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
@@ -1,19 +1,14 @@
 package fs
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/openGemini/openGemini/lib/fileops"
 )
 
-var disableMmap = flag.Bool("fs.disableMMap", is32BitPtr, "Whether to use pread() instead of mmap() for reading data files. "+
-	"By default mmap() is used for 64-bit arches and pread() is used for 32-bit arches, since they cannot read data files bigger than 2^32 bytes in memory. "+
-	"mmap() is usually faster for reading small data chunks than pread()")
-
-// Disable mmap for architectures with 32-bit pointers in order to be able to work with files exceeding 2^32 bytes.
-const is32BitPtr = (^uintptr(0) >> 32) == 0
+// Disable mmap by default
+var disableMmap = false
 
 // MustReadAtCloser is rand-access read interface.
 type MustReadAtCloser interface {
@@ -89,7 +84,7 @@ func MustOpenReaderAt(path string) *ReaderAt {
 	}
 	var r ReaderAt
 	r.f = f
-	if !*disableMmap {
+	if !disableMmap {
 		fi, err := f.Stat()
 		if err != nil {
 			MustClose(f)

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at_timing_test.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at_timing_test.go
@@ -16,10 +16,10 @@ func BenchmarkReaderAtMustReadAt(b *testing.B) {
 }
 
 func benchmarkReaderAtMustReadAt(b *testing.B, isMmap bool) {
-	prevDisableMmap := *disableMmap
-	*disableMmap = !isMmap
+	prevDisableMmap := disableMmap
+	disableMmap = !isMmap
 	defer func() {
-		*disableMmap = prevDisableMmap
+		disableMmap = prevDisableMmap
 	}()
 
 	path := "BenchmarkReaderAtMustReadAt"

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_mmap_darwin.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_mmap_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+// +build darwin
+
+package fs
+
+// SetDisableMmap disable mmap on darwin always.
+func SetDisableMmap(off bool) {}

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_mmap_unix.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_mmap_unix.go
@@ -1,0 +1,9 @@
+//go:build linux || freebsd
+// +build linux freebsd
+
+package fs
+
+// SetDisableMmap set disableMmap
+func SetDisableMmap(off bool) {
+	disableMmap = off
+}


### PR DESCRIPTION
Support disable mmap by configuration, because MacOS doesn't implement mmap methods.

Signed-off-by: shilinlee <836160610@qq.com>

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Issue Number: close #143 

### What is changed and how it works?
1. support mmap enable or disable by configuration.
2. disable mmap on darwin always.

BREAKING CHANGE: disable mmap by default.

### How Has This Been Tested?
- use default configuration, check whether the mmap config is disabled.
- set `enable-mmap-read = false` in config file, check whether the mmap config is disabled.
- set `enable-mmap-read = true` in config file, check whether the mmap config is enabled.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
