### PR TITLE
fix: the bug for checking the file of create_time and modify_time

### DIFF
--- a/lib/fileops/file_ops_test.go
+++ b/lib/fileops/file_ops_test.go
@@ -243,9 +243,9 @@ func TestVFS(t *testing.T) {
 	st = st.Truncate(time.Second)
 	mt = mt.Truncate(time.Second)
 	cct := ct.Truncate(time.Second)
-	if st.UnixNano() != mt.UnixNano() || st.UnixNano() != cct.UnixNano() {
-		t.Fatalf("get create time fail, file(%v), atime:%v, mtime:%v, ctime:%v",
-			fileName, mt.String(), ct.String(), st.String())
+	if mt.Sub(st) > time.Second || cct.Sub(st) > time.Second {
+		t.Fatalf("get create time fail, file(%v), start_time:%v, modify_time:%v, create_time:%v",
+			fileName, st.String(), mt.String(), cct.String())
 	}
 
 	if err := fd.Close(); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

### What is changed and how it works?
fix: the bug for checking the file of create_time and modify_time

### How Has This Been Tested?

- [x] existed test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
