### PR TITLE
feat: support open-telemetry write endpoint for OTLP protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/hashicorp/serf v0.9.6
 	github.com/hpcloud/tail v1.0.1-0.20170707194310-a927b6857fc7
 	github.com/influxdata/influxdb v1.9.5
+	github.com/influxdata/influxdb-observability/common v0.2.19
+	github.com/influxdata/influxdb-observability/otel2influx v0.2.19
 	github.com/influxdata/influxql v1.1.1-0.20210223160523-b6ab99450c93
 	github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b
 	github.com/jedib0t/go-pretty/v6 v6.4.4
@@ -34,17 +36,19 @@ require (
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/shirou/gopsutil/v3 v3.22.1
 	github.com/spf13/cobra v1.3.0
-	github.com/stretchr/testify v1.7.4
+	github.com/stretchr/testify v1.8.2
 	github.com/tinylib/msgp v1.1.7-0.20220719154719-f3635b96e483
 	github.com/valyala/fastjson v1.6.3
 	github.com/xlab/treeprint v1.1.0
 	go.etcd.io/bbolt v1.3.5
+	go.opentelemetry.io/collector/pdata v0.50.0
+	go.opentelemetry.io/collector/semconv v0.74.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	golang.org/x/text v0.4.0
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
-	google.golang.org/protobuf v1.27.1
+	google.golang.org/protobuf v1.28.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.1-0.20190411184413-94d9e492cc53
 )
 

--- a/lib/opentelemetry/logger.go
+++ b/lib/opentelemetry/logger.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	"github.com/openGemini/openGemini/lib/logger"
+)
+
+type otelLogger struct {
+	logger *logger.Logger
+}
+
+func (l *otelLogger) Debug(msg string, kv ...interface{}) {
+	l.logger.Debug(msg)
+}

--- a/lib/opentelemetry/otel_context.go
+++ b/lib/opentelemetry/otel_context.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	"io"
+	"sync"
+
+	"github.com/influxdata/influxdb-observability/otel2influx"
+	"github.com/openGemini/openGemini/lib/cpu"
+	"github.com/openGemini/openGemini/lib/errno"
+	"github.com/openGemini/openGemini/lib/logger"
+	"github.com/openGemini/openGemini/open_src/vm/protoparser/influx"
+)
+
+var otelContextPool sync.Pool
+var otelContextPoolCh = make(chan *otelConext, cpu.GetCpuNum())
+
+func GetOtelContext(r io.Reader) *otelConext {
+	select {
+	case octx := <-otelContextPoolCh:
+		octx.reset()
+		octx.br.Reset(r)
+		return octx
+	default:
+		if v := otelContextPool.Get(); v != nil {
+			octx := v.(*otelConext)
+			octx.reset()
+			octx.br.Reset(r)
+			return octx
+		}
+
+		octx := &otelConext{
+			ReqBuf: make([]byte, 0),
+
+			rowsBuff: make(influx.Rows, 0, 20),
+			logger:   logger.NewLogger(errno.ModuleUnknown),
+		}
+		octx.br.Reset(r)
+
+		log := &otelLogger{
+			logger: logger.NewLogger(errno.ModuleUnknown),
+		}
+		var err error
+		octx.PtraceWriter = otel2influx.NewOtelTracesToLineProtocol(log)
+		if err != nil {
+			panic(err)
+		}
+		// TODO: support MetricsSchemaTelegrafPrometheusV1, MetricsSchemaTelegrafPrometheusV2 and more
+		octx.PmetricWriter, err = otel2influx.NewOtelMetricsToLineProtocol(log, 1)
+		if err != nil {
+			panic(err)
+		}
+		octx.PlogWriter = otel2influx.NewOtelLogsToLineProtocol(log)
+		return octx
+	}
+}
+
+func PutOtelContext(octx *otelConext) {
+	octx.reset()
+	select {
+	case otelContextPoolCh <- octx:
+	default:
+		otelContextPool.Put(octx)
+	}
+}

--- a/lib/opentelemetry/otel_context_test.go
+++ b/lib/opentelemetry/otel_context_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/openGemini/openGemini/lib/cpu"
+)
+
+func TestOtelConext(t *testing.T) {
+	var buf = []byte{1, 2, 3}
+	reader := bufio.NewReader(bytes.NewReader(buf))
+
+	var o []*otelConext
+
+	for i := 0; i <= cpu.GetCpuNum()*2; i++ {
+		octx := GetOtelContext(reader)
+		o = append(o, octx)
+	}
+
+	for i := 0; i <= cpu.GetCpuNum()*2; i++ {
+		PutOtelContext(o[i])
+	}
+
+	// get from chan
+	for i := 0; i <= cpu.GetCpuNum(); i++ {
+		GetOtelContext(reader)
+	}
+	// get from pool
+	for i := 0; i <= cpu.GetCpuNum(); i++ {
+		GetOtelContext(reader)
+	}
+}

--- a/lib/opentelemetry/otlp_writer.go
+++ b/lib/opentelemetry/otlp_writer.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/influxdata/influxdb-observability/common"
+	"github.com/influxdata/influxdb-observability/otel2influx"
+	"github.com/openGemini/openGemini/lib/logger"
+	"github.com/openGemini/openGemini/open_src/vm/protoparser/influx"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+	"go.uber.org/zap"
+)
+
+type TracesWriter interface {
+	WriteTraces(ctx context.Context, md ptrace.Traces, w otel2influx.InfluxWriter) error
+}
+
+type MetricsWriter interface {
+	WriteMetrics(ctx context.Context, md pmetric.Metrics, w otel2influx.InfluxWriter) error
+}
+
+type LogsWriter interface {
+	WriteLogs(ctx context.Context, md plog.Logs, w otel2influx.InfluxWriter) error
+}
+
+type InfluxRowsWriter interface {
+	RetryWritePointRows(database, retentionPolicy string, points []influx.Row) error
+}
+
+type otelConext struct {
+	// read from request
+	br      bufio.Reader
+	ReqBuf  []byte
+	ptrace  ptraceotlp.Request
+	pmetric pmetricotlp.Request
+	plog    plogotlp.Request
+	err     error // this is parse error, http code: 400
+
+	// write to rows
+	PtraceWriter    TracesWriter
+	PmetricWriter   MetricsWriter
+	PlogWriter      LogsWriter
+	Writer          InfluxRowsWriter
+	Database        string
+	RetentionPolicy string
+	rowsBuff        influx.Rows // reuse influx.Rows every write request
+
+	logger *logger.Logger
+}
+
+func (octx *otelConext) Read(contentLength int) bool {
+	if octx.err != nil {
+		return false
+	}
+	if contentLength > cap(octx.ReqBuf) {
+		octx.ReqBuf = append(octx.ReqBuf, make([]byte, contentLength)...)
+	}
+	octx.ReqBuf = octx.ReqBuf[:contentLength]
+	n, err := io.ReadFull(&octx.br, octx.ReqBuf)
+	octx.ReqBuf = octx.ReqBuf[:n]
+	if err != nil {
+		if err != io.EOF {
+			octx.err = fmt.Errorf("cannot read influx line protocol data: %w", octx.err)
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+// Error returns the read or paser error, http code: 400
+func (octx *otelConext) Error() error {
+	if octx.err == io.EOF {
+		return nil
+	}
+	return octx.err
+}
+
+func (octx *otelConext) reset() {
+	octx.ReqBuf = octx.ReqBuf[:0]
+	octx.err = nil
+
+	octx.Database = ""
+	octx.RetentionPolicy = ""
+	octx.rowsBuff = octx.rowsBuff[:]
+}
+
+func (octx *otelConext) WriteTraces(ctx context.Context) error {
+	// TODO: only support proto, next step is json
+	octx.ptrace = ptraceotlp.NewRequest() // new every time
+	if err := octx.ptrace.UnmarshalProto(octx.ReqBuf); err != nil {
+		octx.err = err
+		return nil
+	}
+
+	err := octx.PtraceWriter.WriteTraces(ctx, octx.ptrace.Traces(), octx)
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to convert OTLP span to line protocol") {
+			octx.err = err
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (octx *otelConext) WriteMetrics(ctx context.Context) error {
+	// TODO: only support proto, next step is json
+	octx.pmetric = pmetricotlp.NewRequest() // new every time
+	if err := octx.pmetric.UnmarshalProto(octx.ReqBuf); err != nil {
+		octx.err = err
+		return nil
+	}
+
+	err := octx.PmetricWriter.WriteMetrics(ctx, octx.pmetric.Metrics(), octx)
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to convert OTLP metric to line protocol") {
+			octx.err = err
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (octx *otelConext) WriteLogs(ctx context.Context) error {
+	// TODO: only support proto, next step is json
+	octx.plog = plogotlp.NewRequest() // new every time
+	if err := octx.plog.UnmarshalProto(octx.ReqBuf); err != nil {
+		octx.err = err
+		return nil
+	}
+
+	err := octx.PlogWriter.WriteLogs(ctx, octx.plog.Logs(), octx)
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to convert OTLP log record to line protocol") {
+			octx.err = err
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// NewBatch impl otel2influx.InfluxWriter
+func (octx *otelConext) NewBatch() otel2influx.InfluxWriter {
+	return octx
+}
+
+// WritePoint impl otel2influx.InfluxWriterBatch
+func (octx *otelConext) WritePoint(ctx context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, vType common.InfluxMetricValueType) error {
+	r := influx.Row{
+		Timestamp: ts.UnixNano(),
+		Name:      strings.ReplaceAll(measurement, "/", "-"),
+	}
+	for k, v := range tags {
+		r.Tags = append(r.Tags, influx.Tag{
+			Key:   k,
+			Value: v,
+		})
+	}
+	for k, v := range fields {
+		k = getAttributeName(k)
+		switch value := v.(type) {
+		case float64:
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_Float,
+					Key:      k,
+					NumValue: value,
+				})
+		case int64:
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_Int,
+					Key:      k,
+					NumValue: float64(value),
+				},
+			)
+		case uint64:
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_Int,
+					Key:      k,
+					NumValue: float64(value),
+				},
+			)
+
+		case string:
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_String,
+					Key:      k,
+					StrValue: value,
+				},
+			)
+		case bool:
+			vb := float64(1)
+			if !value {
+				vb = float64(0)
+			}
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_Boolean,
+					Key:      k,
+					NumValue: vb,
+				},
+			)
+		case []interface{}:
+			val := fmt.Sprintf("%s", v)
+			r.Fields = append(r.Fields,
+				influx.Field{
+					Type:     influx.Field_Type_String,
+					Key:      k,
+					StrValue: val,
+				},
+			)
+		default:
+			octx.logger.Error("field type is not supported", zap.String("type", fmt.Sprintf("%T", v)), zap.Any("value", v))
+			return fmt.Errorf("field type is not supported, type: %T, value: %v", v, v)
+		}
+	}
+
+	return octx.Writer.RetryWritePointRows(octx.Database, octx.RetentionPolicy, influx.Rows{r})
+}
+
+// FlushBatch impl otel2influx.InfluxWriterBatch
+// TODO: new version
+func (octx *otelConext) FlushBatch(ctx context.Context) error {
+	defer func() {
+		octx.rowsBuff = octx.rowsBuff[:0]
+	}()
+	return octx.Writer.RetryWritePointRows(octx.Database, octx.RetentionPolicy, octx.rowsBuff)
+}
+
+var AttributeTelemetryKeys = map[string]struct{}{
+	semconv.AttributeTelemetrySDKName:     {},
+	semconv.AttributeTelemetrySDKLanguage: {},
+	semconv.AttributeTelemetrySDKVersion:  {},
+	semconv.AttributeTelemetryAutoVersion: {},
+}
+
+func getAttributeName(name string) string {
+	if _, ok := AttributeTelemetryKeys[name]; ok {
+		return name + "_1"
+	}
+	return name
+}

--- a/lib/opentelemetry/otlp_writer_test.go
+++ b/lib/opentelemetry/otlp_writer_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2022 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opentelemetry_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb-observability/otel2influx"
+	"github.com/openGemini/openGemini/lib/opentelemetry"
+	"github.com/openGemini/openGemini/open_src/vm/protoparser/influx"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+)
+
+type writer struct{}
+
+func (writer) RetryWritePointRows(database, retentionPolicy string, points []influx.Row) error {
+	// fmt.Println(database, retentionPolicy, points)
+	return nil
+}
+
+func TestOtelConext_WriteTraces_OK(t *testing.T) {
+	var genTraceData = func() ptraceotlp.Request {
+		var mockTraceData = `{"resourceSpans":[{"resource":{},"scopeSpans":[{"scope":{},"spans":[{"traceId":"01000000000000000000000000000000","spanId":"0200000000000000","parentSpanId":"","name":"test_span","startTimeUnixNano":"1678898440000000000","endTimeUnixNano":"1678898440000001000","attributes":[{"key":"cpu","value":{"intValue":"1"}},{"key":"event","value":{"stringValue":"test"}}],"status":{}}]}]}]}`
+
+		stringTime := "2023-03-15 16:40:40"
+		loc, _ := time.LoadLocation("UTC")
+		theTime, _ := time.ParseInLocation("2006-01-02 15:04:05", stringTime, loc)
+
+		req := ptraceotlp.NewRequest()
+		span1 := req.Traces().ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span1.SetName("test_span")
+		span1.SetTraceID(pcommon.NewTraceID([16]byte{1}))
+		span1.SetSpanID(pcommon.NewSpanID([8]byte{2}))
+		span1.SetParentSpanID(pcommon.NewSpanID([8]byte{0}))
+		span1.SetStartTimestamp(pcommon.Timestamp(theTime.UnixNano()))
+		span1.SetEndTimestamp(pcommon.Timestamp(theTime.UnixNano() + 1000))
+		span1.Attributes().InsertInt("cpu", 1)
+		span1.Attributes().InsertString("event", "test")
+
+		//	got, _ := req.MarshalJSON()
+		//	fmt.Println(string(got))
+
+		var mockReq = ptraceotlp.NewRequest()
+		err := mockReq.UnmarshalJSON([]byte(mockTraceData))
+		require.NoError(t, err)
+
+		require.Equal(t, req, mockReq)
+		return req
+	}
+
+	req := genTraceData()
+	buf, _ := req.MarshalProto()
+
+	reader := bufio.NewReader(bytes.NewReader(buf))
+	octx := opentelemetry.GetOtelContext(reader)
+	// do not put back to pool
+
+	require.True(t, octx.Read(len(buf)))
+
+	ctx := context.Background()
+	var w = &writer{}
+	octx.Writer = w
+	octx.Database = "db0"
+	octx.RetentionPolicy = "rp0"
+	err := octx.WriteTraces(ctx)
+	require.NoError(t, err)
+}
+
+type mockTraceWriterError struct{}
+
+func (mockTraceWriterError) WriteTraces(ctx context.Context, md ptrace.Traces, w otel2influx.InfluxWriter) error {
+	return errors.New("failed to convert OTLP span to line protocol")
+}
+
+func TestOtelConext_WriteTraces_WriteError(t *testing.T) {
+	reader := bufio.NewReader(bytes.NewReader([]byte{}))
+	octx := opentelemetry.GetOtelContext(reader)
+	// do not put back to pool
+
+	// mock write error
+	writeError := &mockTraceWriterError{}
+	octx.PtraceWriter = writeError
+
+	require.True(t, octx.Read(0))
+
+	ctx := context.Background()
+	var w = &writer{}
+	octx.Writer = w
+	octx.Database = "db0"
+	octx.RetentionPolicy = "rp0"
+	err := octx.WriteTraces(ctx)
+	require.NoError(t, err)
+	require.EqualError(t, octx.Error(), "failed to convert OTLP span to line protocol")
+}
+
+func TestOtelConext_WriteMetrics_OK(t *testing.T) {
+	var genMetricData = func() pmetricotlp.Request {
+		var mockMetricData = `{"resourceMetrics":[{"resource":{},"scopeMetrics":[{"scope":{},"metrics":[{"name":"test_metric","description":"this is description","unit":"ms","sum":{"dataPoints":[{"startTimeUnixNano":"1678812040000000000","timeUnixNano":"1678898440000000000","asInt":"1314520"}]}}]}]}]}`
+
+		//		stringTime := "2023-03-15 16:40:40"
+		//		loc, _ := time.LoadLocation("UTC")
+		//		theTime, _ := time.ParseInLocation("2006-01-02 15:04:05", stringTime, loc)
+		//
+		//		req := pmetricotlp.NewRequest()
+		//		metric1 := req.Metrics().ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		//		metric1.SetName("test_metric")
+		//		metric1.SetDescription("this is description")
+		//		metric1.SetUnit("ms")
+		//		data1 := metric1.Sum().DataPoints().AppendEmpty()
+		//		data1.SetIntVal(1314520)
+		//		data1.SetStartTimestamp(pcommon.Timestamp(theTime.Add(-24 * time.Hour).UnixNano()))
+		//		data1.SetTimestamp(pcommon.Timestamp(theTime.UnixNano()))
+
+		//	got, _ := req.MarshalJSON()
+		//	fmt.Println(string(got))
+
+		var mockReq = pmetricotlp.NewRequest()
+		err := mockReq.UnmarshalJSON([]byte(mockMetricData))
+		require.NoError(t, err)
+
+		return mockReq
+	}
+
+	req := genMetricData()
+	buf, _ := req.MarshalProto()
+
+	reader := bufio.NewReader(bytes.NewReader(buf))
+	octx := opentelemetry.GetOtelContext(reader)
+	// do not put back to pool
+	require.True(t, octx.Read(len(buf)))
+
+	ctx := context.Background()
+	var w = &writer{}
+	octx.Writer = w
+	octx.Database = "db0"
+	octx.RetentionPolicy = "rp0"
+	err := octx.WriteMetrics(ctx)
+	require.NoError(t, err)
+}
+
+type mockMetricWriterError struct{}
+
+func (mockMetricWriterError) WriteMetrics(ctx context.Context, md pmetric.Metrics, w otel2influx.InfluxWriter) error {
+	return errors.New("failed to convert OTLP metric to line protocol")
+}
+
+func TestOtelConext_WriteMetrics_WriteError(t *testing.T) {
+	reader := bufio.NewReader(bytes.NewReader([]byte{}))
+	octx := opentelemetry.GetOtelContext(reader)
+	// do not put back to pool
+
+	// mock write error
+	writeError := &mockMetricWriterError{}
+	octx.PmetricWriter = writeError
+
+	require.True(t, octx.Read(0))
+
+	ctx := context.Background()
+	var w = &writer{}
+	octx.Writer = w
+	octx.Database = "db0"
+	octx.RetentionPolicy = "rp0"
+	err := octx.WriteMetrics(ctx)
+	require.NoError(t, err)
+	require.EqualError(t, octx.Error(), "failed to convert OTLP metric to line protocol")
+}

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Disable mmap by default
-var disableMmap = false
+var disableMmap = true
 
 // MustReadAtCloser is rand-access read interface.
 type MustReadAtCloser interface {

--- a/open_src/influx/httpd/handler.go
+++ b/open_src/influx/httpd/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openGemini/openGemini/lib/logger"
 	meta "github.com/openGemini/openGemini/lib/metaclient"
 	"github.com/openGemini/openGemini/lib/netstorage"
+	"github.com/openGemini/openGemini/lib/opentelemetry"
 	"github.com/openGemini/openGemini/lib/statisticsPusher"
 	"github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
 	"github.com/openGemini/openGemini/lib/syscontrol"
@@ -237,6 +238,18 @@ func NewHandler(c config.Config) *Handler {
 		Route{
 			"prometheus-read", // Prometheus remote read
 			"POST", "/api/v1/prom/read", true, true, h.servePromRead,
+		},
+		Route{
+			"otlp-traces-write", // open-telemetry OTLP traces remote write
+			"POST", "/api/v1/otlp/traces", false, true, h.serveTracesWrite,
+		},
+		Route{
+			"otlp-metrics-write", // open-telemetry OTLP metrics remote write
+			"POST", "/api/v1/otlp/metrics", false, true, h.serveMetricsWrite,
+		},
+		Route{
+			"otlp-logs-write", // open-telemetry OTLP logs remote write
+			"POST", "/api/v1/otlp/logs", false, true, h.serveLogsWrite,
 		},
 		Route{ // sysCtrl
 			"sysCtrl",
@@ -1098,6 +1111,175 @@ func convertToEpoch(r *query.Result, epoch string) {
 			}
 		}
 	}
+}
+func (h *Handler) serveOTLP(w http.ResponseWriter, r *http.Request, user meta2.User) (io.ReadCloser, string, error) {
+	atomic.AddInt64(&statistics.HandlerStat.WriteRequests, 1)
+	atomic.AddInt64(&statistics.HandlerStat.ActiveWriteRequests, 1)
+	atomic.AddInt64(&statistics.HandlerStat.WriteRequestBytesIn, r.ContentLength)
+	defer func(start time.Time) {
+		d := time.Since(start).Nanoseconds()
+		atomic.AddInt64(&statistics.HandlerStat.ActiveWriteRequests, -1)
+		atomic.AddInt64(&statistics.HandlerStat.WriteRequestDuration, d)
+	}(time.Now())
+	h.requestTracker.Add(r, user)
+
+	database := r.URL.Query().Get("db")
+	if database == "" {
+		h.httpError(w, "database is required", http.StatusBadRequest)
+		return nil, "", fmt.Errorf("database is required")
+	}
+
+	if _, err := h.MetaClient.Database(database); err != nil {
+		h.httpError(w, err.Error(), http.StatusNotFound)
+		return nil, "", err
+	}
+
+	if h.Config.AuthEnabled {
+		if user == nil {
+			h.httpError(w, fmt.Sprintf("user is required to write to database %q", database), http.StatusForbidden)
+			err := errno.NewError(errno.HttpForbidden)
+			h.Logger.Error("write error: user is required to write to database", zap.Error(err), zap.String("db", database))
+			atomic.AddInt64(&statistics.HandlerStat.Write400ErrRequests, 1)
+			return nil, "", err
+		}
+
+		if err := h.WriteAuthorizer.AuthorizeWrite(user.ID(), database); err != nil {
+			err1 := errno.NewError(errno.HttpForbidden)
+			h.httpError(w, fmt.Sprintf("%q user is not authorized to write to database %q", user.ID(), database), http.StatusForbidden)
+			h.Logger.Error("write error:user is not authorized to write to database", zap.Error(err1), zap.String("db", database), zap.String("user", user.ID()))
+			atomic.AddInt64(&statistics.HandlerStat.Write400ErrRequests, 1)
+			return nil, "", err
+		}
+	}
+
+	body := r.Body
+	if h.Config.MaxBodySize > 0 {
+		body = truncateReader(body, int64(h.Config.MaxBodySize))
+	}
+
+	if r.ContentLength > 0 {
+		if h.Config.MaxBodySize > 0 && r.ContentLength > int64(h.Config.MaxBodySize) {
+			h.httpError(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+			return nil, "", fmt.Errorf(http.StatusText(http.StatusRequestEntityTooLarge))
+		}
+	}
+
+	return body, database, nil
+}
+
+// serveTracesWrite receives data in the openTelemetry collector and writes it
+// to the database
+func (h *Handler) serveTracesWrite(w http.ResponseWriter, r *http.Request, user meta2.User) {
+	body, database, err := h.serveOTLP(w, r, user)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	octx := opentelemetry.GetOtelContext(body)
+	octx.Writer = h.PointsWriter
+	octx.Database = database
+	octx.RetentionPolicy = r.URL.Query().Get("rp")
+	defer opentelemetry.PutOtelContext(octx)
+
+	for octx.Read(int(r.ContentLength)) {
+		// Convert the OTLP remote write request to Influx Points
+		start := time.Now()
+		err := octx.WriteTraces(ctx)
+		if err != nil {
+			h.Logger.Error("write otlp traces failed", zap.Error(err))
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			atomic.AddInt64(&statistics.HandlerStat.Write500ErrRequests, 1)
+			return
+		}
+		atomic.AddInt64(&statistics.HandlerStat.WriteRequestBytesReceived, int64(len(octx.ReqBuf)))
+		atomic.AddInt64(&statistics.HandlerStat.WriteScheduleUnMarshalDns, time.Since(start).Nanoseconds())
+	}
+
+	if err := octx.Error(); err != nil {
+		h.Logger.Error("write otlp traces error", zap.Error(err), zap.String("db", database))
+		h.httpError(w, err.Error(), http.StatusBadRequest)
+		atomic.AddInt64(&statistics.HandlerStat.Write400ErrRequests, 1)
+		return
+	}
+	h.writeHeader(w, http.StatusNoContent)
+}
+
+// serveMetricsWrite receives OTLP metrics data and writes it to the database
+func (h *Handler) serveMetricsWrite(w http.ResponseWriter, r *http.Request, user meta2.User) {
+	body, database, err := h.serveOTLP(w, r, user)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	octx := opentelemetry.GetOtelContext(body)
+	octx.Writer = h.PointsWriter
+	octx.Database = database
+	octx.RetentionPolicy = r.URL.Query().Get("rp")
+	defer opentelemetry.PutOtelContext(octx)
+
+	if octx.Read(int(r.ContentLength)) {
+		// Convert the OTLP remote write request to Influx Points
+		start := time.Now()
+		err := octx.WriteMetrics(ctx)
+		if err != nil {
+			h.Logger.Error("write otlp metrics failed", zap.Error(err))
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			atomic.AddInt64(&statistics.HandlerStat.Write500ErrRequests, 1)
+			return
+		}
+		atomic.AddInt64(&statistics.HandlerStat.WriteRequestBytesReceived, int64(len(octx.ReqBuf)))
+		atomic.AddInt64(&statistics.HandlerStat.WriteScheduleUnMarshalDns, time.Since(start).Nanoseconds())
+	}
+
+	if err := octx.Error(); err != nil {
+		h.Logger.Error("write otlp metrics error", zap.Error(err), zap.String("db", database))
+		h.httpError(w, err.Error(), http.StatusBadRequest)
+		atomic.AddInt64(&statistics.HandlerStat.Write400ErrRequests, 1)
+		return
+	}
+	h.writeHeader(w, http.StatusNoContent)
+}
+
+// serveLogsWrite receives OTLP logs data and writes it to the database
+func (h *Handler) serveLogsWrite(w http.ResponseWriter, r *http.Request, user meta2.User) {
+	body, database, err := h.serveOTLP(w, r, user)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	octx := opentelemetry.GetOtelContext(body)
+	octx.Writer = h.PointsWriter
+	octx.Database = database
+	octx.RetentionPolicy = r.URL.Query().Get("rp")
+	defer opentelemetry.PutOtelContext(octx)
+
+	for octx.Read(int(r.ContentLength)) {
+		// Convert the OTLP remote write request to Influx Points
+		start := time.Now()
+		err := octx.WriteLogs(ctx)
+		if err != nil {
+			h.Logger.Error("write otlp logs failed", zap.Error(err))
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			atomic.AddInt64(&statistics.HandlerStat.Write500ErrRequests, 1)
+			return
+		}
+		atomic.AddInt64(&statistics.HandlerStat.WriteRequestBytesReceived, int64(len(octx.ReqBuf)))
+		atomic.AddInt64(&statistics.HandlerStat.WriteScheduleUnMarshalDns, time.Since(start).Nanoseconds())
+	}
+
+	if err := octx.Error(); err != nil {
+		h.Logger.Error("write otlp logs error", zap.Error(err), zap.String("db", database))
+		h.httpError(w, err.Error(), http.StatusBadRequest)
+		atomic.AddInt64(&statistics.HandlerStat.Write400ErrRequests, 1)
+		return
+	}
+	h.writeHeader(w, http.StatusNoContent)
 }
 
 // servePromWrite receives data in the Prometheus remote write protocol and writes it


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Issue Number: ref #156 

### What is changed and how it works?

Support OTLP storage by supporting the following three APIs:

  1. api/v1/otlp/traces
  2. api/v1/otlp/metrics
  3. api/v1/otlp/logs

Currently implemented limitations are:
1. All types do not support reading compressed data
2. All types only support protocol unmarshal
3. Metrics only implement one conversion method(MetricsSchemaOtelV1)


> Thanks to influxdata's `influxdb-observability` implementation.

### How Has This Been Tested?

- [x] Test cases to be added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
