### PR TITLE
fix: support for writing repeated fields

### DIFF
--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -28,7 +28,6 @@ import (
 	assert2 "github.com/influxdata/influxdb/pkg/testing/assert"
 	"github.com/influxdata/influxdb/toml"
 	"github.com/openGemini/openGemini/lib/errno"
-	"github.com/openGemini/openGemini/lib/netstorage"
 	"github.com/openGemini/openGemini/lib/record"
 	meta2 "github.com/openGemini/openGemini/open_src/influx/meta"
 	proto2 "github.com/openGemini/openGemini/open_src/influx/meta/proto"
@@ -355,7 +354,7 @@ func TestPointsWriter_updateSchemaIfNeeded(t *testing.T) {
 		}
 
 		for i, r := range rows {
-			_, _, err := wh.updateSchemaIfNeeded("db0", "rp0", &r, mi, mi.Name, fs)
+			_, _, err := wh.updateSchemaIfNeeded("db0", "rp0", &r, mi, mi.OriginName(), fs)
 
 			if errors[i] == "" {
 				assert.NoError(t, err)
@@ -459,7 +458,7 @@ func generateRows(num int, rows []influx.Row) []influx.Row {
 	return rows[:num]
 }
 
-func TestCheckFields(t *testing.T) {
+func TestCheckFields_Conflict(t *testing.T) {
 	fields := influx.Fields{
 		{
 			Key:  "foo",
@@ -483,20 +482,36 @@ func TestCheckFields(t *testing.T) {
 		},
 	}
 
-	_, err := fixFields(fields)
-	assert.EqualError(t, err, errno.NewError(errno.DuplicateField, "foo").Error())
+	fields, err := fixFields(fields)
+	assert.EqualError(t, err, "conflict field type: foo")
+	assert.Empty(t, nil, fields)
+}
 
-	fields[0].Key = "foo2"
-	fields, err = fixFields(fields)
+func TestCheckFields_Ignore(t *testing.T) {
+	fields := influx.Fields{
+		{
+			Key:      "foo",
+			Type:     influx.Field_Type_Float,
+			NumValue: 1,
+		},
+		{
+			Key:      "foo",
+			Type:     influx.Field_Type_Float,
+			NumValue: 2,
+		},
+		{
+			Key:  "zing",
+			Type: influx.Field_Type_String,
+		},
+	}
+
+	fields, err := fixFields(fields)
 	assert.NoError(t, err)
 	assert.Equal(t, influx.Fields{
 		{
-			Key:  "foo2",
-			Type: influx.Field_Type_Float,
-		},
-		{
-			Key:  "foo",
-			Type: influx.Field_Type_Int,
+			Key:      "foo",
+			Type:     influx.Field_Type_Float,
+			NumValue: 2,
 		},
 		{
 			Key:  "zing",
@@ -647,8 +662,8 @@ func TestPointsWriter_TimeRangeLimit(t *testing.T) {
 	assert.EqualError(t, err, exp)
 }
 
-func TestPointsWriter_WritePointRows_DuplicateFields(t *testing.T) {
-	streamDistribution = sameShard
+func TestPointsWriter_WritePointRows_DuplicateFields_TypeConflict(t *testing.T) {
+	streamDistribution = diffDis
 	pw := NewPointsWriter(time.Second * 10)
 	pw.MetaClient = NewMockMetaClient()
 	pw.TSDBStore = NewMockNetStore()
@@ -656,25 +671,29 @@ func TestPointsWriter_WritePointRows_DuplicateFields(t *testing.T) {
 	rows := []influx.Row{
 		{
 			Name: "mst_0000",
+			Tags: []influx.Tag{
+				{
+					Key:   "t1",
+					Value: "v1",
+				},
+			},
 			Fields: influx.Fields{
 				{
-					Key:  "foo",
-					Type: influx.Field_Type_Float,
+					Key:      "foo",
+					Type:     influx.Field_Type_Float,
+					NumValue: 1,
 				},
 				{
-					Key:  "foo",
-					Type: influx.Field_Type_String,
+					Key:      "foo",
+					Type:     influx.Field_Type_String,
+					StrValue: "str",
 				},
 			},
 			Timestamp: time.Now().UnixNano(),
 		},
 	}
 	err := pw.writePointRows("db0", "rp0", rows)
-	werr, ok := err.(netstorage.PartialWriteError)
-	if !ok {
-		t.Fatal(err)
-	}
-	require.EqualError(t, werr, "partial write: duplicate field: foo dropped=1")
+	require.EqualError(t, err, "partial write: conflict field type: foo dropped=1")
 }
 
 func TestPointsWriter_WritePointRows_DuplicateFields2(t *testing.T) {
@@ -690,12 +709,14 @@ func TestPointsWriter_WritePointRows_DuplicateFields2(t *testing.T) {
 			Name: "mst_0000",
 			Fields: influx.Fields{
 				{
-					Key:  "foo",
-					Type: influx.Field_Type_Float,
+					Key:      "foo",
+					Type:     influx.Field_Type_Float,
+					NumValue: 1,
 				},
 				{
-					Key:  "foo",
-					Type: influx.Field_Type_String,
+					Key:      "foo",
+					Type:     influx.Field_Type_Float,
+					NumValue: 2,
 				},
 			},
 			Timestamp: time.Now().UnixNano(),
@@ -712,11 +733,7 @@ func TestPointsWriter_WritePointRows_DuplicateFields2(t *testing.T) {
 		},
 	}
 	err := pw.writePointRows("db0", "rp0", rows)
-	werr, ok := err.(netstorage.PartialWriteError)
-	if !ok {
-		t.Fatal(err)
-	}
-	require.EqualError(t, werr, "partial write: duplicate field: foo dropped=1")
+	require.NoError(t, err)
 }
 
 func TestColumnToIndexUpdate(t *testing.T) {

--- a/coordinator/write_helper.go
+++ b/coordinator/write_helper.go
@@ -109,7 +109,7 @@ func (wh *writeHelper) updateSchemaIfNeeded(database, rp string, r *influx.Row, 
 					}
 				})
 
-				err = errno.NewError(errno.FieldTypeConflict, field.Key, r.Name, influx.FieldTypeString(field.Type),
+				err = errno.NewError(errno.FieldTypeConflict, field.Key, originName, influx.FieldTypeString(field.Type),
 					influx.FieldTypeString(fieldType)).SetModule(errno.ModuleWrite)
 				dropFieldIndex = append(dropFieldIndex, i)
 			}

--- a/engine/executor/spdy/transport/node_test.go
+++ b/engine/executor/spdy/transport/node_test.go
@@ -90,7 +90,7 @@ func TestNodeTimeOut(t *testing.T) {
 	cfg.ConnPoolSize = 4
 	spdy.SetDefaultConfiguration(cfg)
 	timeOut := spdy.TCPDialTimeout()
-	spdy.SetTCPDialTimeout(0)
+	spdy.SetTCPDialTimeout(-1)
 	defer spdy.SetTCPDialTimeout(timeOut)
 	node.pools[0] = nil
 

--- a/lib/errno/code.go
+++ b/lib/errno/code.go
@@ -223,7 +223,7 @@ const (
 
 	ErrUnmarshalPoints         = 5010
 	ErrWriteReadonly           = 5011
-	DuplicateField             = 5012
+	ParseFieldTypeConflict     = 5012
 	WritePointOutOfRP          = 5013
 	WritePointShardKeyTooLarge = 5014
 	EngineClosed               = 5015

--- a/lib/errno/message.go
+++ b/lib/errno/message.go
@@ -71,13 +71,13 @@ var messageMap = map[Errno]*Message{
 	WriteMapMetaShardInfo:           newWarnMessage("can't map meta.ShardInfo", ModuleWrite),
 	WritePointOutOfRP:               newWarnMessage("point time is expired, compared with rp duration", ModuleWrite),
 
-	ErrUnmarshalPoints:  newWarnMessage("unmarshal points error, err: %s", ModuleWrite),
-	ErrWriteReadonly:    newWarnMessage("this node is readonly status", ModuleWrite),
-	DuplicateField:      newWarnMessage("duplicate field: %s", ModuleWrite),
-	EngineClosed:        newWarnMessage("engine is closed", ModuleWrite),
-	WriteMissTagValue:   newWarnMessage("missing tag value for %q", ModuleWrite),
-	ErrorTagArrayFormat: newWarnMessage("error tag array format", ModuleWrite),
-	WriteErrorArray:     newWarnMessage("error tag array", ModuleWrite),
+	ErrUnmarshalPoints:     newWarnMessage("unmarshal points error, err: %s", ModuleWrite),
+	ErrWriteReadonly:       newWarnMessage("this node is readonly status", ModuleWrite),
+	ParseFieldTypeConflict: newWarnMessage("conflict field type: %s", ModuleWrite),
+	EngineClosed:           newWarnMessage("engine is closed", ModuleWrite),
+	WriteMissTagValue:      newWarnMessage("missing tag value for %q", ModuleWrite),
+	ErrorTagArrayFormat:    newWarnMessage("error tag array format", ModuleWrite),
+	WriteErrorArray:        newWarnMessage("error tag array", ModuleWrite),
 
 	// network module error codes
 	NoConnectionAvailable: newFatalMessage("no connections available, node: %v, %v", ModuleNetwork),

--- a/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
+++ b/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/fs/reader_at.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Disable mmap by default
-var disableMmap = false
+var disableMmap = true
 
 // MustReadAtCloser is rand-access read interface.
 type MustReadAtCloser interface {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix",reslove or "ref".
-->

Issue Number: close #xxx

### What is changed and how it works?

Support writing repeated fields, but only keep the value of the last field. e.g.
`mst,tag=1 f1=1,f2=2,f1=3,f3=4,f4=5,f3=6,f4=7,f4=8,f3=9,f2=10,f1=11` 
only keeps: `mst,tag=1 f4=8,f3=9,f2=10,f1=11`


### How Has This Been Tested?

- [x] existed test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
