### PR TITLE
fix: write fields with escape chars in line protocol

### DIFF
--- a/open_src/vm/protoparser/influx/parser_test.go
+++ b/open_src/vm/protoparser/influx/parser_test.go
@@ -71,6 +71,38 @@ func TestUnmarshalRows_error(t *testing.T) {
 	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], `missing tag value for "hostname"`)
 	req = "cpu,hostname=,region=eu-west-1 usage_user=58i,usage_system=2i 1622851200000000000\ncpu,hostname,region usage_user=47i,usage_system=93i 1622851200000000000\ncpu,hostname=host_2,region=eu-central-1  usage_user=93i,usage_system=39i 1622851200000000000\n"
 	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+
+	req = `cpu,host=server01 value="disk mem" 1610467200000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\ mem" 1610467300000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\ mem" 1610467400000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\\ mem" 1610467500000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\\\ mem" 1610467600000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\ mem\ host " 1610467700000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\ mem\\ host " 1610467800000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\ mem\\\ host " 1610467900000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\ mem\\\\ host " 1610468000000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\ mem\ host " 1610468100000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\ mem\\ host " 1610468200000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\\ mem\ host " 1610468300000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\\\\ mem\ host " 1610468400000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\" mem\\\"" 1610468500000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+	req = `cpu,host=server01 value="disk\" mem\\\" host\\" 1610468600000000000`
+	f(rows[:0], req, tagsPool[:0], fieldsPool[:0], "")
+
 }
 
 func TestNextUnquotedChar(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #167 

### What is changed and how it works?

Try to unquote string, since sometimes insert escape chars.

### How Has This Been Tested?

test report:

```
insert cpu,host=server01 value="disk mem" 1610467200000000000
insert cpu,host=server01 value="disk\ mem" 1610467300000000000
insert cpu,host=server01 value="disk\\ mem" 1610467400000000000
insert cpu,host=server01 value="disk\\\ mem" 1610467500000000000
insert cpu,host=server01 value="disk\\\\ mem" 1610467600000000000

insert cpu,host=server01 value="disk\ mem\ host " 1610467700000000000
insert cpu,host=server01 value="disk\ mem\\ host " 1610467800000000000
insert cpu,host=server01 value="disk\ mem\\\ host " 1610467900000000000
insert cpu,host=server01 value="disk\ mem\\\\ host " 1610468000000000000

insert cpu,host=server01 value="disk\\ mem\ host " 1610468100000000000
insert cpu,host=server01 value="disk\\ mem\\ host " 1610468200000000000

insert cpu,host=server01 value="disk\\\ mem\ host " 1610468300000000000
insert cpu,host=server01 value="disk\\\\ mem\ host " 1610468400000000000

insert cpu,host=server01 value="disk\" mem\\\"" 1610468500000000000
insert cpu,host=server01 value="disk\" mem\\\" host\\" 1610468600000000000

> select * from cpu
name: cpu
time                 host     value
----                 ----     -----
2021-01-12T16:00:00Z server01 disk mem
2021-01-12T16:01:40Z server01 disk\ mem
2021-01-12T16:03:20Z server01 disk\ mem
2021-01-12T16:05:00Z server01 disk\\ mem
2021-01-12T16:06:40Z server01 disk\\ mem
2021-01-12T16:08:20Z server01 disk\ mem\ host 
2021-01-12T16:10:00Z server01 disk\ mem\ host 
2021-01-12T16:11:40Z server01 disk\ mem\\ host 
2021-01-12T16:13:20Z server01 disk\ mem\\ host 
2021-01-12T16:15:00Z server01 disk\ mem\ host 
2021-01-12T16:16:40Z server01 disk\ mem\ host 
2021-01-12T16:18:20Z server01 disk\\ mem\ host 
2021-01-12T16:20:00Z server01 disk\\ mem\ host 
2021-01-12T16:21:40Z server01 disk" mem\"
2021-01-12T16:23:20Z server01 disk" mem\" host\
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
