### PR TITLE
fix(TextIndex): do not expect to return any data when querying for special symbols

### DIFF
--- a/engine/index/clv/index.go
+++ b/engine/index/clv/index.go
@@ -649,15 +649,25 @@ func (idx *TokenIndex) Fuzzy(queryStr string) (*InvertIndex, error) {
 
 // if not found any matched text, need return a empty InvertIndex, not nil InvertIndex.
 func (idx *TokenIndex) Search(t QueryType, queryStr string) (*InvertIndex, error) {
-	if t == Match {
-		return idx.Match(queryStr)
-	} else if t == Match_Phrase {
-		return idx.MatchPhrase(queryStr)
-	} else if t == Fuzzy {
-		return idx.Fuzzy(queryStr)
+	var invert *InvertIndex
+	var err error
+	switch t {
+	case Match:
+		invert, err = idx.Match(queryStr)
+	case Match_Phrase:
+		invert, err = idx.MatchPhrase(queryStr)
+	case Fuzzy:
+		invert, err = idx.Fuzzy(queryStr)
+	default:
+		return nil, fmt.Errorf("cannot find the query type:%d", t)
 	}
 
-	return nil, fmt.Errorf("cannot find the query type:%d", t)
+	if invert == nil {
+		ii := NewInvertIndex()
+		invert = &ii
+	}
+
+	return invert, err
 }
 
 func removeDuplicateTimestamp(iss []InvertState) []InvertState {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
query some special symbols(eg.. blank space) on field which has full-text index, it return all the datas.


Issue Number: close/fix/resolve/ref #210 

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?
select * from mst where match(logs, ' ')

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
