### PR TITLE
fix(TextIndex): create multi-textIndex failed

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -1074,13 +1074,17 @@ func IsRetryErrorForPtView(err error) bool {
 }
 
 func selectIndexList(columnToIndex map[string]int, indexList []*meta2.IndexInfor) ([]uint16, bool) {
-	index := make([]uint16, len(indexList))
-	for i, iCol := range indexList {
+	index := make([]uint16, 0, len(indexList))
+	for _, iCol := range indexList {
 		v, exist := columnToIndex[iCol.FieldName]
 		if !exist {
-			return nil, false
+			continue
 		}
-		index[i] = uint16(v)
+		index = append(index, uint16(v))
+	}
+
+	if len(index) == 0 {
+		return nil, false
 	}
 	return index, true
 }

--- a/engine/index/tsi/text_index.go
+++ b/engine/index/tsi/text_index.go
@@ -124,14 +124,18 @@ func (idx *TextIndex) CreateIndexIfNotExists(primaryIndex PrimaryIndex, row *inf
 	timestamp := row.Timestamp
 	// Find the field need to be created index.
 	for _, opt := range row.IndexOptions {
-		if opt.Oid == uint32(Text) {
-			if int(opt.IndexList[0]) < len(row.Tags) {
-				return 0, fmt.Errorf("cannot create text index for tag: %s", row.Tags[opt.IndexList[0]].Key)
+		if opt.Oid != uint32(Text) {
+			continue
+		}
+
+		for i := 0; i < len(opt.IndexList); i++ {
+			if int(opt.IndexList[i]) < len(row.Tags) {
+				return 0, fmt.Errorf("cannot create text index for tag: %s", row.Tags[opt.IndexList[i]].Key)
 			}
 
-			field = row.Fields[int(opt.IndexList[0])-len(row.Tags)]
+			field = row.Fields[int(opt.IndexList[i])-len(row.Tags)]
 			if field.Type != influx.Field_Type_String {
-				return 0, fmt.Errorf("field type must be string for TextIndex")
+				return 0, fmt.Errorf("field type must be string for TextIndex, field: %s", field.Key)
 			}
 
 			tokenIndex, ok := idx.fieldTable[row.Name][field.Key]
@@ -151,7 +155,6 @@ func (idx *TextIndex) CreateIndexIfNotExists(primaryIndex PrimaryIndex, row *inf
 			if err != nil {
 				return 0, err
 			}
-
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close/fix/resolve/ref #218

### What is changed and how it works?


### How Has This Been Tested?
create database test with  SHARD DURATION 12h
use test
create measurement mst(clientip string tag, logs string field, comment string field, index idx1 logs type text, index idx2 comment type text)
insert mst,clientip=124.64.22.145 logs="GET /french/frntpage.html",comments="Atoms are used within a program to denote distinguished values." 1681241201000000000
insert mst,clientip=124.64.22.145 logs="GET /french0/frntpage0.html",comment="Atoms are used within a program0 to denote distinguished values." 1681241202000000000

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
