### PR TITLE
fix(TextIndex): exception scenario does not close idx, resulting in the inability to open again

### DIFF
--- a/engine/index/clv/index.go
+++ b/engine/index/clv/index.go
@@ -234,6 +234,7 @@ func NewTokenIndex(opts *Options) (*TokenIndex, error) {
 	var version uint32
 	version, err = idx.searchDicVersion()
 	if err != nil {
+		idx.Close()
 		return nil, err
 	}
 
@@ -246,6 +247,7 @@ func NewTokenIndex(opts *Options) (*TokenIndex, error) {
 	analyzerPath = analyzerPath + "directory"
 	idx.analyzer, err = GetAnalyzer(analyzerPath, opts.Measurement, opts.Field, version)
 	if err != nil {
+		idx.Close()
 		return nil, err
 	}
 
@@ -253,6 +255,7 @@ func NewTokenIndex(opts *Options) (*TokenIndex, error) {
 	if version == Unknown {
 		err = idx.writeDicVersion(idx.analyzer.Version())
 		if err != nil {
+			idx.Close()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
fix(TextIndex): exception scenario does not close idx, resulting in the inability to open again

Issue Number: close/fix/resolve/ref #204 

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
