### PR TITLE
fix(TextIndex): concurrent opening of mergesets in the same directory will fail

### DIFF
--- a/engine/index/clv/collector.go
+++ b/engine/index/clv/collector.go
@@ -18,12 +18,10 @@ package clv
 
 import (
 	"fmt"
-	"path"
 	"sync"
 	"sync/atomic"
 
 	"github.com/openGemini/openGemini/lib/config"
-	"github.com/openGemini/openGemini/open_src/github.com/VictoriaMetrics/VictoriaMetrics/lib/mergeset"
 )
 
 var Qmax = 7
@@ -186,12 +184,7 @@ func (d *collector) saveDictionaryToMergeset() error {
 	d.genItemsFromCollectTree(d.root, 0, b, dicItems)
 	d.genItemsByVersion(nextVersion, dicItems)
 
-	tb, err := mergeset.OpenTable(path.Join(d.path, d.measurement, d.field), nil, nil, getLockFilePath(d.path))
-	if err != nil {
-		return err
-	}
-	defer tb.MustClose()
-	return tb.AddItems(dicItems.items)
+	return saveAnalyzerToMergeSet(d.path, d.measurement, d.field, dicItems.items)
 }
 
 func (d *collector) saveDictionary() {

--- a/engine/index/tsi/text_index.go
+++ b/engine/index/tsi/text_index.go
@@ -202,16 +202,16 @@ func (idx *TextIndex) CreateIndexIfNotExists(primaryIndex PrimaryIndex, row *inf
 func (idx *TextIndex) SearchByTokenIndex(name string, sids []uint64, n *influxql.BinaryExpr) (*clv.InvertIndex, error) {
 	key, ok := n.LHS.(*influxql.VarRef)
 	if !ok {
-		return nil, fmt.Errorf("The type of LHS value is wrong.")
+		return nil, fmt.Errorf("the type of LHS value is wrong")
 	}
 	value, ok := n.RHS.(*influxql.StringLiteral)
 	if !ok {
-		return nil, fmt.Errorf("The type of RHS value is wrong.")
+		return nil, fmt.Errorf("the type of RHS value is wrong")
 	}
 
 	tokenIndex, ok := idx.fieldTable[name][key.Val]
 	if !ok {
-		return nil, fmt.Errorf("The field(%s) of measurement(%s) has no text index.", key.Val, name)
+		return nil, fmt.Errorf("the field(%s) of measurement(%s) has no text index", key.Val, name)
 	}
 
 	switch n.Op {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
concurrent opening of mergesets in the same directory will fail.

Issue Number: fix #266 

### What is changed and how it works?
When opening mergeSet, the same lock was added.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
