### PR TITLE
fix: the Map-Key memory has changed, can not find the value in the map correctly through the key

### DIFF
--- a/engine/index/tsi/text_index.go
+++ b/engine/index/tsi/text_index.go
@@ -89,10 +89,12 @@ func (idx *TextIndex) NewTokenIndex(idxPath, measurement, field string) error {
 	txtIdxPath := path.Join(idxPath, TextDirectory)
 	fieldName := make([]byte, len(field))
 	copy(fieldName, field)
+	mstName := make([]byte, len(measurement))
+	copy(mstName, measurement)
 
 	opts := clv.Options{
 		Path:        txtIdxPath,
-		Measurement: measurement,
+		Measurement: string(mstName),
 		Field:       string(fieldName),
 		Lock:        idx.lock,
 	}
@@ -100,11 +102,11 @@ func (idx *TextIndex) NewTokenIndex(idxPath, measurement, field string) error {
 	if err != nil {
 		return err
 	}
-	if _, ok := idx.fieldTable[measurement]; !ok {
-		idx.fieldTable[measurement] = make(map[string]*clv.TokenIndex)
+	if _, ok := idx.fieldTable[string(mstName)]; !ok {
+		idx.fieldTable[string(mstName)] = make(map[string]*clv.TokenIndex)
 	}
 
-	idx.fieldTable[measurement][string(fieldName)] = tokenIndex
+	idx.fieldTable[string(mstName)][string(fieldName)] = tokenIndex
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
Due to the modification of the memory of the Map-key(string type), can not find the corresponding value in the map correctly through the key

Issue Number: fix #266

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
