### PR TITLE
feat : add query protection feature.

### DIFF
--- a/config/openGemini.conf
+++ b/config/openGemini.conf
@@ -66,6 +66,7 @@
   # https-enabled = false
   # https-certificate = ""
   # https-private-key = ""
+  # disable-query-without-time-filter = false
 
 [data]
   store-ingest-addr = "{{addr}}:8400"

--- a/open_src/influx/httpd/config/config.go
+++ b/open_src/influx/httpd/config/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	QueryMemoryLimitEnabled bool           `toml:"query-memory-limit-enabled"`
 	ChunkReaderParallel     int            `toml:"chunk-reader-parallel"`
 	ReadBlockSize           toml.Size      `toml:"read-block-size"`
+	DisableQueryWithoutTimeFilter bool           `toml:"disable-query-without-time-filter"`
 }
 
 // NewHttpConfig returns a new Config with default settings.
@@ -102,6 +103,7 @@ func NewConfig() Config {
 		QueryMemoryLimitEnabled: true,
 		ChunkReaderParallel:     cpu.GetCpuNum(),
 		ReadBlockSize:           toml.Size(DefaultBlockSize),
+		DisableQueryWithoutTimeFilter: false,
 	}
 }
 

--- a/open_src/influx/httpd/handler.go
+++ b/open_src/influx/httpd/handler.go
@@ -525,6 +525,14 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta2.
 		}*/
 
 	q, err := YyParser.GetQuery()
+	
+	var i int
+	for ; i < len(q.Statements); i++ {
+		if stmt, ok := q.Statements[i].(*influxql.SelectStatement); ok {
+			stmt.DisableWithoutTimeFilter = h.Config.DisableQueryWithoutTimeFilter
+			q.Statements[i] = stmt
+		}
+	}
 
 	if err != nil {
 		h.httpError(rw, "error parsing query: "+err.Error(), http.StatusBadRequest)

--- a/open_src/influx/influxql/ast.go
+++ b/open_src/influx/influxql/ast.go
@@ -1292,7 +1292,10 @@ type SelectStatement struct {
 
 	// Data sources (measurements) that fields are extracted from.
 	Sources Sources
-
+	
+	// Disable query if without time filter.
+	DisableWithoutTimeFilter bool
+	
 	// An expression evaluated on data point.
 	Condition Expr
 

--- a/open_src/influx/query/compile.go
+++ b/open_src/influx/query/compile.go
@@ -173,6 +173,10 @@ func (c *compiledStatement) preprocess(stmt *influxql.SelectStatement) error {
 	// Retrieve the fill option for the statement.
 	c.FillOption = stmt.Fill
 
+	if stmt.DisableWithoutTimeFilter && c.TimeRange.Min.IsZero() && c.TimeRange.Max.IsZero() {
+		return fmt.Errorf("must with a time range")
+	}
+	
 	// Resolve the min and max times now that we know if there is an interval or not.
 	if c.TimeRange.Min.IsZero() {
 		c.TimeRange.Min = time.Unix(0, influxql.MinTime).UTC()


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref https://github.com/openGemini/openGemini/issues/274

### What is changed and how it works?
Add query protection feature.
Query When the protection function is enabled, the query time range must be specified

### How Has This Been Tested?
When the configuration information disable-query-without-time-filter is true:
select * from NOAA_water_database
There is no time to filter, and an error message is returned.
select * from NOAA_water_database where time < now()
Time filtering, normal query.

When the configuration information disable-query-without-time-filter is false:
It can be queried with or without time filtering.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
