### PR TITLE
feat: add query protection feature

### DIFF
--- a/app/ts-sql/sql/server.go
+++ b/app/ts-sql/sql/server.go
@@ -162,6 +162,7 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *Logger.Logger) (a
 	s.initStatisticsPusher()
 	s.httpService.Handler.StatisticsPusher = s.statisticsPusher
 	syscontrol.SetQueryParallel(int64(c.HTTP.ChunkReaderParallel))
+	syscontrol.SetTimeFilterProtection(c.HTTP.TimeFilterProtection)
 	executor.SetPipelineExecutorResourceManagerParas(int64(c.Common.MemoryLimitSize), time.Duration(c.Common.MemoryWaitTime))
 	executor.IgnoreEmptyTag = c.Common.IgnoreEmptyTag
 

--- a/config/openGemini.conf
+++ b/config/openGemini.conf
@@ -66,6 +66,7 @@
   # https-enabled = false
   # https-certificate = ""
   # https-private-key = ""
+  # time-filter-protection = false
 
 [data]
   store-ingest-addr = "{{addr}}:8400"

--- a/lib/syscontrol/syscontrol_test.go
+++ b/lib/syscontrol/syscontrol_test.go
@@ -151,3 +151,21 @@ func TestQuerySeriesLimit(t *testing.T) {
 	limit := GetQuerySeriesLimit()
 	assert.Equal(t, limit, 123)
 }
+
+func TestSetTimeFilterProtection(t *testing.T) {
+	SysCtrl.MetaClient = &mockMetaClient{}
+	SysCtrl.NetStore = &mockStorage{}
+	var req netstorage.SysCtrlRequest
+	req.SetMod("time_filter_protection")
+	req.SetParam(map[string]string{
+		"enabled": "true",
+	})
+	var sb strings.Builder
+	require.NoError(t, ProcessRequest(req, &sb))
+	require.Contains(t, sb.String(), "success")
+	sb.Reset()
+
+	SetTimeFilterProtection(false)
+	enable := GetTimeFilterProtection()
+	assert.Equal(t, enable, false)
+}

--- a/open_src/influx/httpd/config/config.go
+++ b/open_src/influx/httpd/config/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	QueryMemoryLimitEnabled bool           `toml:"query-memory-limit-enabled"`
 	ChunkReaderParallel     int            `toml:"chunk-reader-parallel"`
 	ReadBlockSize           toml.Size      `toml:"read-block-size"`
+	TimeFilterProtection    bool           `toml:"time-filter-protection"`
 }
 
 // NewHttpConfig returns a new Config with default settings.
@@ -102,6 +103,7 @@ func NewConfig() Config {
 		QueryMemoryLimitEnabled: true,
 		ChunkReaderParallel:     cpu.GetCpuNum(),
 		ReadBlockSize:           toml.Size(DefaultBlockSize),
+		TimeFilterProtection:    false,
 	}
 }
 

--- a/open_src/influx/httpd/service.go
+++ b/open_src/influx/httpd/service.go
@@ -213,7 +213,7 @@ func (s *Service) Close() error {
 func (s *Service) Err() <-chan error { return s.err }
 
 // Addr returns the listener's address. Returns nil if listener is closed.
-//test func, so return 0 index addr
+// test func, so return 0 index addr
 func (s *Service) Addr() net.Addr {
 	if s.Ln[0] != nil {
 		return s.Ln[0].Addr()
@@ -223,7 +223,7 @@ func (s *Service) Addr() net.Addr {
 
 // BoundHTTPAddr returns the string version of the address that the HTTP server is listening on.
 // This is useful if you start an ephemeral server in test with bind address localhost:0.
-//test func, so return 0 index addr
+// test func, so return 0 index addr
 func (s *Service) BoundHTTPAddr() string {
 	return s.Ln[0].Addr().String()
 }

--- a/open_src/influx/influxql/ast.go
+++ b/open_src/influx/influxql/ast.go
@@ -1898,8 +1898,8 @@ func (s *SelectStatement) RewriteFields(m FieldMapper, batchEn bool, hasJoin boo
 //
 // Conditions that can currently be simplified are:
 //
-//     - host =~ /^foo$/ becomes host = 'foo'
-//     - host !~ /^foo$/ becomes host != 'foo'
+//   - host =~ /^foo$/ becomes host = 'foo'
+//   - host !~ /^foo$/ becomes host != 'foo'
 //
 // Note: if the regex contains groups, character classes, repetition or
 // similar, it's likely it won't be rewritten. In order to support rewriting

--- a/open_src/influx/query/compile.go
+++ b/open_src/influx/query/compile.go
@@ -146,6 +146,8 @@ func Compile(stmt *influxql.SelectStatement, opt CompileOptions) (Statement, err
 	return c, nil
 }
 
+var TimeFilterProtection bool
+
 // preprocess retrieves and records the global attributes of the current statement.
 func (c *compiledStatement) preprocess(stmt *influxql.SelectStatement) error {
 	c.Ascending = stmt.TimeAscending()
@@ -172,6 +174,9 @@ func (c *compiledStatement) preprocess(stmt *influxql.SelectStatement) error {
 
 	// Retrieve the fill option for the statement.
 	c.FillOption = stmt.Fill
+	if TimeFilterProtection && c.TimeRange.Min.IsZero() && c.TimeRange.Max.IsZero() {
+		return fmt.Errorf("disabled the query because without specifying the time filter")
+	}
 
 	// Resolve the min and max times now that we know if there is an interval or not.
 	if c.TimeRange.Min.IsZero() {


### PR DESCRIPTION
### What problem does this PR solve?
close #274 

### What is changed and how it works?
> add query protection feature.
- When query protection is enabled, queries that do not have time limits will return errors.

### How Has This Been Tested?
1. When configuring the message time-filter-protection = true:

1.1 An error message will be returned if the time range is not limited.
```sql
select * from [measurement] 
```

1.2 A time limit can be smoothly queried.
 ```sql
select * from [measurement] where time < now()
```

2. When configuring the message time-filter-protection = false:
- The query is not affected by the time range or not.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
