### PR TITLE
chore: return the kernel version when ping api

### DIFF
--- a/app/ts-sql/sql/server.go
+++ b/app/ts-sql/sql/server.go
@@ -115,6 +115,8 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *Logger.Logger) (a
 		metaUseTLS:    false,
 		config:        c,
 	}
+	s.httpService.Handler.Version = cmd.Version
+	s.httpService.Handler.BuildType = "OSS"
 	s.initMetaClientFn = s.initializeMetaClient
 
 	go openServer(c, logger)

--- a/open_src/influx/httpd/handler.go
+++ b/open_src/influx/httpd/handler.go
@@ -351,9 +351,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer atomic.AddInt64(&statistics.HandlerStat.ActiveRequests, -1)
 	start := time.Now()
 
-	// Add version and build header to all InfluxDB requests.
-	w.Header().Add("X-Influxdb-Version", h.Version)
-	w.Header().Add("X-Influxdb-Build", h.BuildType)
+	// Add version and build header to all Geminidb requests.
+	w.Header().Add("X-Geminidb-Version", h.Version)
+	w.Header().Add("X-Geminidb-Build", h.BuildType)
 
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof") && h.Config.PprofEnabled {
 		h.handleProfiles(w, r)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!-- #279 

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #279 

### What is changed and how it works?
Please describe how it works
```
curl -i -GET 'http://127.0.0.1:8086/ping'
HTTP/1.1 204 No Content
Content-Type: application/json
Request-Id: af2679b8-f9e1-11ed-8001-b6993de84a29
X-Geminidb-Build: OSS
X-Geminidb-Version: v1.0.2
X-Request-Id: af2679b8-f9e1-11ed-8001-b6993de84a29
Date: Wed, 24 May 2023 03:18:41 GMT
```


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
