### PR TITLE
feat: support show continuous queries

### DIFF
--- a/app/ts-store/run/server_test.go
+++ b/app/ts-store/run/server_test.go
@@ -404,6 +404,9 @@ func (client *MockMetaClient) ShowSubscriptions() models.Rows {
 func (client *MockMetaClient) ShowRetentionPolicies(database string) (models.Rows, error) {
 	return nil, nil
 }
+func (client *MockMetaClient) ShowContinuousQueries() (models.Rows, error) {
+	return nil, nil
+}
 func (client *MockMetaClient) GetAliveShards(database string, sgi *meta2.ShardGroupInfo) []int {
 	return nil
 }

--- a/coordinator/shard_mapper_test.go
+++ b/coordinator/shard_mapper_test.go
@@ -290,6 +290,10 @@ func (m mocShardMapperMetaClient) ShowRetentionPolicies(database string) (models
 	return nil, nil
 }
 
+func (m mocShardMapperMetaClient) ShowContinuousQueries() (models.Rows, error) {
+	return nil, nil
+}
+
 func (m mocShardMapperMetaClient) GetAliveShards(database string, sgi *meta.ShardGroupInfo) []int {
 	aliveShardIdxes := make([]int, 0, len(sgi.Shards))
 	for i := range sgi.Shards {

--- a/engine/shard_test.go
+++ b/engine/shard_test.go
@@ -3575,6 +3575,9 @@ func (client *MockMetaClient) ShowSubscriptions() models.Rows {
 func (client *MockMetaClient) ShowRetentionPolicies(database string) (models.Rows, error) {
 	return nil, nil
 }
+func (client *MockMetaClient) ShowContinuousQueries() (models.Rows, error) {
+	return nil, nil
+}
 func (client *MockMetaClient) GetAliveShards(database string, sgi *meta2.ShardGroupInfo) []int {
 	return nil
 }

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -188,6 +188,7 @@ type MetaClient interface {
 	ShowShardGroups() models.Rows
 	ShowSubscriptions() models.Rows
 	ShowRetentionPolicies(database string) (models.Rows, error)
+	ShowContinuousQueries() (models.Rows, error)
 	GetAliveShards(database string, sgi *meta2.ShardGroupInfo) []int
 	NewDownSamplePolicy(database, name string, info *meta2.DownSamplePolicyInfo) error
 	DropDownSamplePolicy(database, name string, dropAll bool) error
@@ -719,6 +720,12 @@ func (c *Client) ShowRetentionPolicies(database string) (models.Rows, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.cacheData.ShowRetentionPolicies(database)
+}
+
+func (c *Client) ShowContinuousQueries() (models.Rows, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.cacheData.ShowContinuousQueries()
 }
 
 func (c *Client) Schema(database string, retentionPolicy string, mst string) (fields map[string]int32,

--- a/lib/metaclient/meta_client_test.go
+++ b/lib/metaclient/meta_client_test.go
@@ -866,3 +866,52 @@ func TestDBPTCtx_String(t *testing.T) {
 	ctx.DBPTStat = nil
 	require.Equal(t, "", ctx.String())
 }
+
+func TestClient_ShowContinuousQueries(t *testing.T) {
+	c := &Client{
+		cacheData: &meta2.Data{
+			Databases: map[string]*meta2.DatabaseInfo{
+				"test1": &meta2.DatabaseInfo{
+					Name: "test1",
+					ContinuousQueries: map[string]*meta2.ContinuousQueryInfo{
+						"cq1_1": {
+							Name:  "cq1_1",
+							Query: `CREATE CONTINUOUS QUERY "cq1_1" ON "test1" RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean("passengers") INTO "average_passengers" FROM "bus_data" GROUP BY time(30m) END`,
+						},
+						"cq1_2": {
+							Name:  "cq1_2",
+							Query: `CREATE CONTINUOUS QUERY "cq1_2" ON "test1" RESAMPLE EVERY 2h FOR 30m BEGIN SELECT max("passengers") INTO "max_passengers" FROM "bus_data" GROUP BY time(10m) END`,
+						},
+					},
+				},
+				"test2": &meta2.DatabaseInfo{
+					Name: "test2",
+					ContinuousQueries: map[string]*meta2.ContinuousQueryInfo{
+						"cq2_1": {
+							Name:  "cq2_1",
+							Query: `CREATE CONTINUOUS QUERY "cq2_1" ON "test2" RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min("passengers") INTO "min_passengers" FROM "bus_data" GROUP BY time(15m) END`,
+						},
+					},
+				},
+			},
+		},
+		metaServers: []string{"127.0.0.1:8092"},
+		logger:      logger.NewLogger(errno.ModuleMetaClient).With(zap.String("service", "metaclient")),
+	}
+	rows, err := c.ShowContinuousQueries()
+	if err != nil {
+		t.Fatal("query continuous queries failed!")
+	}
+
+	require.EqualValues(t, 2, len(rows))
+	for i := 0; i < rows.Len(); i++ {
+		switch rows[i].Name {
+		case "test1":
+			require.EqualValues(t, 2, len(rows[i].Values))
+		case "test2":
+			require.EqualValues(t, 1, len(rows[i].Values))
+		default:
+			t.Fatal("unexcepted query continuous queries result!")
+		}
+	}
+}

--- a/open_src/influx/coordinator/statement_executor.go
+++ b/open_src/influx/coordinator/statement_executor.go
@@ -243,6 +243,8 @@ func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement, ctx *query
 		rows, err = e.retryExecuteStatement(stmt, ctx)
 	case *influxql.ShowRetentionPoliciesStatement:
 		rows, err = e.executeShowRetentionPoliciesStatement(stmt)
+	case *influxql.ShowContinuousQueriesStatement:
+		rows, err = e.executeShowContinuousQueriesStatement(stmt)
 	case *influxql.ShowSeriesCardinalityStatement:
 		rows, err = e.retryExecuteStatement(stmt, ctx)
 	case *influxql.ShowShardsStatement:
@@ -1108,6 +1110,10 @@ func (e *StatementExecutor) executeShowRetentionPoliciesStatement(q *influxql.Sh
 	}
 
 	return e.MetaClient.ShowRetentionPolicies(q.Database)
+}
+
+func (e *StatementExecutor) executeShowContinuousQueriesStatement(q *influxql.ShowContinuousQueriesStatement) (models.Rows, error) {
+	return e.MetaClient.ShowContinuousQueries()
 }
 
 func (e *StatementExecutor) executeShowShardsStatement(stmt *influxql.ShowShardsStatement) (models.Rows, error) {

--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -1415,6 +1415,25 @@ func (data *Data) UpdateRetentionPolicy(database, name string, rpu *RetentionPol
 	return nil
 }
 
+// ShowContinuousQueries shows all continuous queries group by db.
+func (data *Data) ShowContinuousQueries() (models.Rows, error) {
+	rows := []*models.Row{}
+
+	data.WalkDatabases(func(dbi *DatabaseInfo) {
+		row := &models.Row{Name: dbi.Name, Columns: []string{"name", "query"}}
+		dbi.WalkContinuousQuery(func(cq *ContinuousQueryInfo) {
+			row.Values = append(row.Values, []interface{}{cq.Name, cq.Query})
+		})
+
+		sort.Slice(row.Values, func(i, j int) bool {
+			return row.Values[i][0].(string) < row.Values[j][0].(string)
+		})
+		rows = append(rows, row)
+	})
+
+	return rows, nil
+}
+
 // DropShard removes a shard by ID.
 //
 // DropShard won't return an error if the shard can't be found, which

--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -1428,7 +1428,9 @@ func (data *Data) ShowContinuousQueries() (models.Rows, error) {
 		sort.Slice(row.Values, func(i, j int) bool {
 			return row.Values[i][0].(string) < row.Values[j][0].(string)
 		})
-		rows = append(rows, row)
+		if len(row.Values) > 0 {
+			rows = append(rows, row)
+		}
 	})
 
 	return rows, nil

--- a/open_src/influx/meta/database.go
+++ b/open_src/influx/meta/database.go
@@ -271,3 +271,9 @@ func (di *DatabaseInfo) WalkRetentionPolicy(fn func(rp *RetentionPolicyInfo)) {
 		fn(di.RetentionPolicies[rpName])
 	}
 }
+
+func (di *DatabaseInfo) WalkContinuousQuery(fn func(cq *ContinuousQueryInfo)) {
+	for cqName := range di.ContinuousQueries {
+		fn(di.ContinuousQueries[cqName])
+	}
+}

--- a/tests/server_suite.go
+++ b/tests/server_suite.go
@@ -1131,6 +1131,34 @@ func init() {
 		},
 	}
 
+	tests["continuous_query_commands"] = Test{
+		queries: []*Query{
+			&Query{
+				name:    "create continuous query cq0_1 should succeed",
+				command: `CREATE CONTINUOUS QUERY "cq0_1" ON "db0" RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean("passengers") INTO "average_passengers" FROM "bus_data" GROUP BY time(30m) END`,
+				exp:     `{"results":[{"statement_id":0}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create continuous query cq0_1 should failed",
+				command: `CREATE CONTINUOUS QUERY "cq0_1" ON "db0" RESAMPLE EVERY 1h FOR 10m BEGIN SELECT min("passengers") INTO "min_passengers" FROM "bus_data" GROUP BY time(15m) END`,
+				exp:     `{"results":[{"statement_id":0,"error":"continuous query name already exists"}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create continuous query cq1_1 should succeed",
+				command: `CREATE CONTINUOUS QUERY "cq1_1" ON "db1" RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min("passengers") INTO "min_passengers" FROM "bus_data" GROUP BY time(15m) END`,
+				exp:     `{"results":[{"statement_id":0}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "show continuous query should succeed",
+				command: `SHOW CONTINUOUS QUERIES`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["name","query"],"values":[["cq0_1","CREATE CONTINUOUS QUERY cq0_1 ON db0 RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean(passengers) INTO db0.autogen.average_passengers FROM db0.autogen.bus_data GROUP BY time(30m) END"]]},{"name":"db1","columns":["name","query"],"values":[["cq1_1","CREATE CONTINUOUS QUERY cq1_1 ON db1 RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min(passengers) INTO db1.autogen.min_passengers FROM db1.autogen.bus_data GROUP BY time(15m) END"]]}]}]}`,
+			},
+		},
+	}
+
 }
 
 func (tests Tests) load(t *testing.T, key string) Test {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #296 

### What is changed and how it works?
Execute the ShowContinuousQueriesStatement query statement, obtain information from the meta for continuous queries, and present it to the user.

### How Has This Been Tested?

I added the test function `TestClient_ ShowContinuousQueries` to `lib/metaclient/meta_client_test.go` and check the reliability of the code by running corresponding tests in `lib/metaclient/meta_client_test.go`.
In addition, I manually entered SQL statements for integration testing, and the test results are as follows:
```sql
> CREATE CONTINUOUS QUERY "cq1_1" ON "test1" RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean("passengers") INTO "average_passengers" FROM "bus_data" GROUP BY time(30m) END
> CREATE CONTINUOUS QUERY "cq2_1" ON "test2" RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min("passengers") INTO "min_passengers" FROM "bus_data" GROUP BY time(15m) END
> SHOW CONTINUOUS QUERIES
name: test1
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name  | query                                                                                                                                                                                   |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| cq1_1 | CREATE CONTINUOUS QUERY cq1_1 ON test1 RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean(passengers) INTO test1.autogen.average_passengers FROM test1.autogen.bus_data GROUP BY time(30m) END |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 columns, 1 rows in set

name: test2
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name  | query                                                                                                                                                                              |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| cq2_1 | CREATE CONTINUOUS QUERY cq2_1 ON test2 RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min(passengers) INTO test2.autogen.min_passengers FROM test2.autogen.bus_data GROUP BY time(15m) END |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 columns, 1 rows in set
```
Finally, I added the integration test function `TestServer_ContinuousQueryCommand` corresponding to the continuous query in `tests/server_test.go`.

- [x] meta_client_test.go
- [x] full build of project
- [x] integration testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
