### PR TITLE
feat: ts-monitor supports https and auth

### DIFF
--- a/app/ts-monitor/collector/collect_test.go
+++ b/app/ts-monitor/collector/collect_test.go
@@ -42,8 +42,9 @@ func Test_Collect_MetricFiles(t *testing.T) {
 		expect func(err error) error
 	}
 
-	var testCases = []TestCase{
-		{"report metric file ok",
+	testCases := []TestCase{
+		{
+			"report metric file ok",
 			func(r *http.Request) (*http.Response, error) {
 				resp := &http.Response{
 					StatusCode: http.StatusNoContent,
@@ -76,21 +77,12 @@ func Test_Collect_MetricFiles(t *testing.T) {
 	}
 
 	logger := logger.NewLogger(errno.ModuleUnknown)
-
 	for _, tt := range testCases {
 		coll := NewCollector(dir, "", "history.json", logger)
-		coll.Reporter = NewReportJob(config.DefaultMonitorAddress,
-			config.DefaultMonitorDatabase,
-			config.DefaultMonitorRP,
-			"",
-			"",
+		coll.Reporter = NewReportJob(logger,
+			config.NewTSMonitor(),
 			false,
-			config.DefaultMonitorRPDuration,
-			false,
-			false,
-			logger,
-			config.DefaultHistoryFile,
-		)
+			config.DefaultHistoryFile)
 
 		go func() {
 			time.AfterFunc(2*time.Second, func() {
@@ -134,8 +126,9 @@ func Test_Collect_ErrLogFiles(t *testing.T) {
 		expect func(err error) error
 	}
 
-	var testCases = []TestCase{
-		{"report error logs ok",
+	testCases := []TestCase{
+		{
+			"report error logs ok",
 			func(r *http.Request) (*http.Response, error) {
 				resp := &http.Response{
 					StatusCode: http.StatusNoContent,
@@ -174,18 +167,10 @@ func Test_Collect_ErrLogFiles(t *testing.T) {
 	logger := logger.NewLogger(errno.ModuleUnknown)
 	for _, tt := range testCases {
 		coll := NewCollector("", dir, "history.json", logger)
-		coll.Reporter = NewReportJob(config.DefaultMonitorAddress,
-			config.DefaultMonitorDatabase,
-			config.DefaultMonitorRP,
-			"",
-			"",
+		coll.Reporter = NewReportJob(logger,
+			config.NewTSMonitor(),
 			false,
-			config.DefaultMonitorRPDuration,
-			false,
-			false,
-			logger,
-			filepath.Join(dir, config.DefaultHistoryFile),
-		)
+			filepath.Join(dir, config.DefaultHistoryFile))
 
 		go func() {
 			ticker := time.NewTicker(2 * time.Second)
@@ -230,5 +215,4 @@ func Test_Collect_ErrLogFiles(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/app/ts-monitor/collector/node_monitor.go
+++ b/app/ts-monitor/collector/node_monitor.go
@@ -156,7 +156,6 @@ func (nc *NodeCollector) collect() {
 			continue
 		}
 	}
-
 }
 
 func (nc *NodeCollector) collectBasic(ctx context.Context) error {

--- a/app/ts-monitor/collector/query_test.go
+++ b/app/ts-monitor/collector/query_test.go
@@ -50,7 +50,18 @@ func TestQueryMetric(t *testing.T) {
 		QueryInterval: toml.Duration(10 * time.Second), // 10s
 	}
 	q := NewQueryMetric(log, &conf)
-	rj := NewReportJob("127.0.0.1/write", "db0", "rp0", "", "", false, time.Hour, false, false, log, "errLogHistory")
+
+	rjConfig := config.NewTSMonitor()
+	rjConfig.ReportConfig.Address = "127.0.0.1/write"
+	rjConfig.ReportConfig.Database = "db0"
+	rjConfig.ReportConfig.Rp = "rp0"
+	rjConfig.ReportConfig.RpDuration = toml.Duration(time.Hour)
+	rj := NewReportJob(log,
+		rjConfig,
+		false,
+		"errLogHistory",
+	)
+
 	q.Reporter = rj
 
 	showFn := func(r *http.Request) (*http.Response, error) {
@@ -113,7 +124,18 @@ func TestQueryMetric_Manual(t *testing.T) {
 	}
 	nc := NewQueryMetric(logger, &conf)
 	defer nc.Close()
-	rj := NewReportJob("127.0.0.1/write", "db0", "rp0", "", "", false, time.Hour, false, false, logger, "errLogHistory")
+
+	rjConfig := config.NewTSMonitor()
+	rjConfig.ReportConfig.Address = "127.0.0.1/write"
+	rjConfig.ReportConfig.Database = "db0"
+	rjConfig.ReportConfig.Rp = "rp0"
+	rjConfig.ReportConfig.RpDuration = toml.Duration(time.Hour)
+	rj := NewReportJob(logger,
+		rjConfig,
+		false,
+		"errLogHistory",
+	)
+
 	nc.Reporter = rj
 
 	type TestCase struct {
@@ -121,7 +143,7 @@ func TestQueryMetric_Manual(t *testing.T) {
 		DoFunc func(req *http.Request) (*http.Response, error)
 	}
 
-	var testCases = []TestCase{
+	testCases := []TestCase{
 		{
 			Name: "manual collect and report ok",
 			DoFunc: func(r *http.Request) (*http.Response, error) {

--- a/app/ts-monitor/collector/report.go
+++ b/app/ts-monitor/collector/report.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -37,6 +38,8 @@ import (
 	"time"
 
 	"github.com/hpcloud/tail"
+	"github.com/openGemini/openGemini/lib/config"
+	"github.com/openGemini/openGemini/lib/crypto"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/fileops"
 	"github.com/openGemini/openGemini/lib/logger"
@@ -86,7 +89,9 @@ type ReportJob struct {
 	storeRP       string
 	storeDuration time.Duration
 	writeUrl      string
+	writeHeader   http.Header
 	queryUrl      string
+	queryHeader   http.Header
 	gzipped       bool
 
 	Client HTTPClient
@@ -102,19 +107,37 @@ type ReportJob struct {
 	reportStat *ReportStat
 }
 
-func NewReportJob(addr, database, storeRP, username, password string, useHttps bool, rpDuration time.Duration, gzipped, compress bool, logger *logger.Logger, errLogHistory string) *ReportJob {
-	protocol := "http"
-	if useHttps {
-		protocol = "https"
+func NewReportJob(logger *logger.Logger, c *config.TSMonitor, gzipped bool, errLogHistory string) *ReportJob {
+	r := &c.ReportConfig
+	m := &c.MonitorConfig
+	q := &c.QueryConfig
+	writeProtocol := "http"
+	if c.ReportConfig.HTTPSEnabled {
+		writeProtocol = "https"
 	}
 
+	queryProtocol := "http"
+	if c.QueryConfig.HTTPSEnabled {
+		queryProtocol = "https"
+	}
+
+	writeUrl := fmt.Sprintf("%s://%s/write?db=%s&rp=%s", writeProtocol, r.Address, r.Database, r.Rp)
+	writeHeader := http.Header{}
+	writeHeader.Set("Authorization", "Basic "+basicAuth(r.Username, crypto.Decrypt(r.Password)))
+
+	queryUrl := fmt.Sprintf("%s://%s/query", queryProtocol, r.Address)
+	queryHeader := http.Header{}
+	queryHeader.Set("Authorization", "Basic "+basicAuth(q.Username, crypto.Decrypt(q.Password)))
+
 	mr := &ReportJob{
-		storeDatabase: database,
-		storeRP:       storeRP,
-		storeDuration: rpDuration,
-		writeUrl:      fmt.Sprintf("%s://%s/write?db=%s&rp=%s&u=%s&p=%s", protocol, addr, database, storeRP, username, password),
-		queryUrl:      fmt.Sprintf("http://%s/query", addr),
-		compress:      compress,
+		storeDatabase: r.Database,
+		storeRP:       r.Rp,
+		storeDuration: time.Duration(r.RpDuration),
+		writeUrl:      writeUrl,
+		writeHeader:   writeHeader,
+		queryUrl:      queryUrl,
+		queryHeader:   queryHeader,
+		compress:      m.Compress,
 		gzipped:       gzipped,
 		done:          make(chan struct{}),
 		logger:        logger,
@@ -131,7 +154,7 @@ func (rb *ReportJob) CreateDatabase() error {
 	cmd := fmt.Sprintf("CREATE DATABASE %s with duration %s replication 1 name %s", rb.storeDatabase, rb.storeDuration, rb.storeRP)
 	data.Set("q", cmd)
 	buf := data.Encode()
-	headers := http.Header{}
+	headers := rb.queryHeader
 	headers.Add("Content-Type", "application/x-www-form-urlencoded")
 	if err := rb.retryEver(rb.queryUrl, headers, buf, HttpTimeout); err != nil {
 		return err
@@ -139,8 +162,13 @@ func (rb *ReportJob) CreateDatabase() error {
 	return nil
 }
 
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
 func (rb *ReportJob) WriteData(buf string) error {
-	return rb.retryEver(rb.writeUrl, nil, buf, 0)
+	return rb.retryEver(rb.writeUrl, rb.writeHeader, buf, 0)
 }
 
 func checkConnectionError(err error) bool {
@@ -272,7 +300,7 @@ func (rb *ReportJob) postData(buf *bytes.Buffer, batch *int, minSize int) error 
 	if err := rb.CreateDatabase(); err != nil {
 		return err
 	}
-	if err := rb.retryEver(rb.writeUrl, nil, buf.String(), 0); err != nil {
+	if err := rb.WriteData(buf.String()); err != nil {
 		return err
 	}
 
@@ -376,7 +404,7 @@ func (rb *ReportJob) reportHistoryErrLog(filename string) error {
 	}
 
 	if len(errnoMap) > 0 {
-		if err = rb.retryEver(rb.writeUrl, nil, buf.String(), 0); err != nil {
+		if err = rb.WriteData(buf.String()); err != nil {
 			return err
 		}
 		buf.Reset()
@@ -436,7 +464,7 @@ func (rb *ReportJob) reportCurrentErrLog(filename, errLogPath string) error {
 					buf.WriteString(data)
 					buf.WriteByte('\n')
 				}
-				if err = rb.retryEver(rb.writeUrl, nil, buf.String(), 0); err != nil {
+				if err = rb.WriteData(buf.String()); err != nil {
 					return err
 				}
 				buf.Reset()

--- a/app/ts-monitor/collector/report_test.go
+++ b/app/ts-monitor/collector/report_test.go
@@ -35,8 +35,9 @@ func Test_Reporter_CreateDatabase(t *testing.T) {
 		expect func(err error) error
 	}
 
-	var testCases = []TestCase{
-		{"create database ok",
+	testCases := []TestCase{
+		{
+			"create database ok",
 			func(r *http.Request) (*http.Response, error) {
 				resp := &http.Response{
 					StatusCode: http.StatusOK,
@@ -60,18 +61,10 @@ func Test_Reporter_CreateDatabase(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		mr := NewReportJob(config.DefaultMonitorAddress,
-			config.DefaultMonitorDatabase,
-			config.DefaultMonitorRP,
-			"",
-			"",
+		mr := NewReportJob(logger.NewLogger(errno.ModuleUnknown),
+			config.NewTSMonitor(),
 			false,
-			config.DefaultMonitorRPDuration,
-			false,
-			false,
-			logger.NewLogger(errno.ModuleUnknown),
-			config.DefaultHistoryFile,
-		)
+			config.DefaultHistoryFile)
 
 		t.Run(tt.Name, func(t *testing.T) {
 			mr.Client = &mocks.MockClient{DoFunc: tt.DoFunc}

--- a/app/ts-monitor/main.go
+++ b/app/ts-monitor/main.go
@@ -42,8 +42,10 @@ var (
 
 const TsMonitor = "ts-monitor"
 
-var monitorUsage = fmt.Sprintf(app.MainUsage, TsMonitor, TsMonitor)
-var runUsage = fmt.Sprintf(app.RunUsage, TsMonitor, TsMonitor)
+var (
+	monitorUsage = fmt.Sprintf(app.MainUsage, TsMonitor, TsMonitor)
+	runUsage     = fmt.Sprintf(app.RunUsage, TsMonitor, TsMonitor)
+)
 
 func main() {
 	app.InitParse()

--- a/app/ts-monitor/run/server.go
+++ b/app/ts-monitor/run/server.go
@@ -55,9 +55,7 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *logger.Logger) (a
 	}
 
 	errLogHistory := filepath.Join(c.MonitorConfig.ErrLogPath, c.MonitorConfig.History)
-	reporterJob := collector.NewReportJob(c.ReportConfig.Address, c.ReportConfig.Database, c.ReportConfig.Rp,
-		c.ReportConfig.Username, c.ReportConfig.Password, c.ReportConfig.HTTPSEnabled, time.Duration(c.ReportConfig.RpDuration),
-		false, c.MonitorConfig.Compress, logger, errLogHistory)
+	reporterJob := collector.NewReportJob(logger, c, false, errLogHistory)
 
 	s.collector.Reporter = reporterJob
 	s.nodeMonitor.Reporter = reporterJob
@@ -90,7 +88,7 @@ func (s *Server) Open() error {
 		zap.String("branch", s.cmd.ValidArgs[0]),
 		zap.String("commit", s.cmd.ValidArgs[1]),
 		zap.String("buildTime", s.cmd.ValidArgs[2]))
-	//Mark start-up in extra log
+	// Mark start-up in extra log
 	_, _ = fmt.Fprintf(os.Stdout, "%v ts-monitor starting\n", time.Now())
 
 	go s.collect()

--- a/config/monitor.conf
+++ b/config/monitor.conf
@@ -27,6 +27,9 @@
   query-enable = false
   http-endpoint = "{{query_addr}}:8086"
   query-interval = "5m"
+  # username = ""
+  # password = ""
+  # https-enable = false
 
 [report]
   # Address for metric data to be reported.

--- a/lib/config/monitor.go
+++ b/lib/config/monitor.go
@@ -121,6 +121,9 @@ type MonitorQuery struct {
 	QueryEnable   bool          `toml:"query-enable"`
 	HttpEndpoint  string        `toml:"http-endpoint"`
 	QueryInterval toml.Duration `toml:"query-interval"`
+	Username      string        `toml:"username"`
+	Password      string        `toml:"password"`
+	HTTPSEnabled  bool          `toml:"https-enable"`
 }
 
 func newMonitorQuery() MonitorQuery {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #289 

### What is changed ?
1. Make query requests for ts-monitor support HTTPS and authentication.
2. Change the URL parameters used for authentication in the request to `Base Auth` in the request header.
3. Changed the parameter passing method for `collect.NewReport` in `ts-monitor`, and modified the relevant parts of its invocation.
4. Made some code formatting changes using `gofumpt` in `ts-monitor`.

### How it works?
Add username and password fields to the report configuration of ts-monitor -query.
```
[query]
  username = "user"
  password = "pass"
  https-enable = true
```
When ts-monitor enables the config of querying the database, MST and series cardinality, it can support authentication and HTTPS protocol.

### How Has This Been Tested?
- config in openGemini.conf 
```
http:
  auth-enabled = true
```
- create user in openGemini
- configure usename and password in the monitor.conf
- start the cluster and monitor
```
bash script/install_cluster.sh
bash script/install_monitor.sh
cat /tmp/openGemini/logs/monitor.log
```
There should be no authentication-related errors in the ts-monitor log file.

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
