### PR TITLE
fix: make the order of the results returned by show cq fixed

### DIFF
--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -1428,9 +1428,11 @@ func (data *Data) ShowContinuousQueries() (models.Rows, error) {
 		sort.Slice(row.Values, func(i, j int) bool {
 			return row.Values[i][0].(string) < row.Values[j][0].(string)
 		})
-		if len(row.Values) > 0 {
-			rows = append(rows, row)
-		}
+		rows = append(rows, row)
+	})
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Name < rows[j].Name
 	})
 
 	return rows, nil

--- a/tests/server_suite.go
+++ b/tests/server_suite.go
@@ -1154,7 +1154,7 @@ func init() {
 			&Query{
 				name:    "show continuous query should succeed",
 				command: `SHOW CONTINUOUS QUERIES`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["name","query"],"values":[["cq0_1","CREATE CONTINUOUS QUERY cq0_1 ON db0 RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean(passengers) INTO db0.autogen.average_passengers FROM db0.autogen.bus_data GROUP BY time(30m) END"]]},{"name":"db1","columns":["name","query"],"values":[["cq1_1","CREATE CONTINUOUS QUERY cq1_1 ON db1 RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min(passengers) INTO db1.autogen.min_passengers FROM db1.autogen.bus_data GROUP BY time(15m) END"]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["name","query"],"values":[["cq0_1","CREATE CONTINUOUS QUERY cq0_1 ON db0 RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean(passengers) INTO db0.autogen.average_passengers FROM db0.autogen.bus_data GROUP BY time(30m) END"]]},{"name":"db1","columns":["name","query"],"values":[["cq1_1","CREATE CONTINUOUS QUERY cq1_1 ON db1 RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min(passengers) INTO db1.autogen.min_passengers FROM db1.autogen.bus_data GROUP BY time(15m) END"]]},{"name":"db2","columns":["name","query"]}]}]}`,
 			},
 		},
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -402,6 +402,10 @@ func TestServer_ContinuousQueryCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if _, err := s.CreateDatabase("db2"); err != nil {
+		t.Fatal(err)
+	}
+
 	for i, query := range test.queries {
 		t.Run(query.name, func(t *testing.T) {
 			if i == 0 {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: ref #296

### What is changed and how it works?
I have sorted the results returned by the show continuous query statement so that the order of the returned results is fixed.
In addition, for databases without cq, the corresponding empty information is displayed in the returned result.

### How Has This Been Tested?

```sql
> show continuous queries;
name: db0
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name  | query                                                                                                                                                                             |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| cq0_1 | CREATE CONTINUOUS QUERY cq0_1 ON db0 RESAMPLE EVERY 1h FOR 90m BEGIN SELECT mean(passengers) INTO db0.autogen.average_passengers FROM db0.autogen.bus_data GROUP BY time(30m) END |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 columns, 1 rows in set

name: db1
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name  | query                                                                                                                                                                        |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| cq1_1 | CREATE CONTINUOUS QUERY cq1_1 ON db1 RESAMPLE EVERY 1h FOR 30m BEGIN SELECT min(passengers) INTO db1.autogen.min_passengers FROM db1.autogen.bus_data GROUP BY time(15m) END |
+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
2 columns, 1 rows in set

name: db2
+------+-------+
| name | query |
+------+-------+
2 columns, 0 rows in set
```

- [x] update `TestServer_ContinuousQueryCommand`
- [x] full build of project

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

