### PR TITLE
feat: support to drop subscription

### DIFF
--- a/open_src/influx/coordinator/statement_executor.go
+++ b/open_src/influx/coordinator/statement_executor.go
@@ -183,7 +183,6 @@ func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement, ctx *query
 		}
 		err = e.executeDropShardStatement(stmt, ctx)
 	case *influxql.DropSubscriptionStatement:
-		return meta2.ErrUnsupportCommand
 		if ctx.ReadOnly {
 			messages = append(messages, query.ReadOnlyWarning(stmt.String()))
 		}

--- a/open_src/influx/influxql/sql.y
+++ b/open_src/influx/influxql/sql.y
@@ -2620,7 +2620,7 @@ CREATE_SUBSCRIPTION_STATEMENT:
     }
     |CREATE SUBSCRIPTION STRING_TYPE ON STRING_TYPE DESTINATIONS SUBSCRIPTION_TYPE ALL_DESTINATION
     {
-        $$ = &CreateSubscriptionStatement{Name : $3, Database : $5, RetentionPolicy : "autogen", Destinations : $8, Mode : $7}
+        $$ = &CreateSubscriptionStatement{Name : $3, Database : $5, RetentionPolicy : "", Destinations : $8, Mode : $7}
     }
 
 SHOW_SUBSCRIPTION_STATEMENT:
@@ -2644,6 +2644,6 @@ DROP_SUBSCRIPTION_STATEMENT:
     }
     |DROP SUBSCRIPTION STRING_TYPE ON STRING_TYPE
     {
-        $$ = &DropSubscriptionStatement{Name : $3, Database : $5, RetentionPolicy : "autogen"}
+        $$ = &DropSubscriptionStatement{Name : $3, Database : $5, RetentionPolicy : ""}
     }
 %%

--- a/open_src/influx/influxql/y.go
+++ b/open_src/influx/influxql/y.go
@@ -4049,7 +4049,7 @@ yydefault:
 		yyDollar = yyS[yypt-8 : yypt+1]
 //line sql.y:2622
 		{
-			yyVAL.stmt = &CreateSubscriptionStatement{Name: yyDollar[3].str, Database: yyDollar[5].str, RetentionPolicy: "autogen", Destinations: yyDollar[8].strSlice, Mode: yyDollar[7].str}
+			yyVAL.stmt = &CreateSubscriptionStatement{Name: yyDollar[3].str, Database: yyDollar[5].str, RetentionPolicy: "", Destinations: yyDollar[8].strSlice, Mode: yyDollar[7].str}
 		}
 	case 326:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -4079,7 +4079,7 @@ yydefault:
 		yyDollar = yyS[yypt-5 : yypt+1]
 //line sql.y:2646
 		{
-			yyVAL.stmt = &DropSubscriptionStatement{Name: yyDollar[3].str, Database: yyDollar[5].str, RetentionPolicy: "autogen"}
+			yyVAL.stmt = &DropSubscriptionStatement{Name: yyDollar[3].str, Database: yyDollar[5].str, RetentionPolicy: ""}
 		}
 	}
 	goto yystack /* stack new state and value */

--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -31,7 +31,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -1760,33 +1759,8 @@ func (data *Data) pruneShardGroups(id uint64) error {
 	return nil
 }
 
-// validateURL returns an error if the URL does not have a port or uses a scheme other than HTTP.
-func validateURL(input string) error {
-	u, err := url.Parse(input)
-	if err != nil {
-		return ErrInvalidSubscriptionURL(input)
-	}
-
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return ErrInvalidSubscriptionURL(input)
-	}
-
-	_, port, err := net.SplitHostPort(u.Host)
-	if err != nil || port == "" {
-		return ErrInvalidSubscriptionURL(input)
-	}
-
-	return nil
-}
-
 // CreateSubscription adds a named subscription to a database and retention policy.
 func (data *Data) CreateSubscription(database, rp, name, mode string, destinations []string) error {
-	for _, d := range destinations {
-		if err := validateURL(d); err != nil {
-			return err
-		}
-	}
-
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err
@@ -1811,6 +1785,44 @@ func (data *Data) CreateSubscription(database, rp, name, mode string, destinatio
 
 // DropSubscription removes a subscription.
 func (data *Data) DropSubscription(database, rp, name string) error {
+	// Drop all subscriptions
+	if database == "" {
+		for _, db := range data.Databases {
+			for _, rp := range db.RetentionPolicies {
+				rp.Subscriptions = rp.Subscriptions[:0]
+			}
+		}
+		return nil
+	}
+
+	// Drop all subscriptions on the Specified db
+	if name == "" {
+		db, ok := data.Databases[database]
+		if !ok {
+			return ErrDatabaseNotExists
+		}
+		for _, rp := range db.RetentionPolicies {
+			rp.Subscriptions = rp.Subscriptions[:0]
+		}
+		return nil
+	}
+
+	// if rp is not specified, traverse the rps
+	if rp == "" {
+		db, ok := data.Databases[database]
+		if !ok {
+			return ErrDatabaseNotExists
+		}
+		for _, rpi := range db.RetentionPolicies {
+			for i := range rpi.Subscriptions {
+				if rpi.Subscriptions[i].Name == name {
+					rpi.Subscriptions = append(rpi.Subscriptions[:i], rpi.Subscriptions[i+1:]...)
+					return nil
+				}
+			}
+		}
+	}
+
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err

--- a/open_src/influx/meta/data_test.go
+++ b/open_src/influx/meta/data_test.go
@@ -1225,17 +1225,80 @@ func TestData_Create_Subscription(t *testing.T) {
 	}
 	destinations := []string{"http://192.168.35.1:8080", "http://10.123.65.4:9172"}
 	err := data.CreateSubscription("db0", "rp0", "subs1", "ALL", destinations)
-	assert2.Equal(t, err == nil, true)
+	assert2.NoError(t, err)
 	err = data.CreateSubscription("db0", "rp0", "subs1", "ALL", destinations)
 	assert2.Equal(t, err == ErrSubscriptionExists, true)
 	err = data.CreateSubscription("db2", "rp0", "subs1", "ALL", destinations)
 	assert2.Equal(t, err != nil, true)
 	rpi, err := data.RetentionPolicy("db0", "rp0")
-	assert2.Equal(t, err == nil, true)
+	assert2.NoError(t, err)
 	assert2.Equal(t, len(rpi.Subscriptions), 1)
 	assert2.Equal(t, rpi.Subscriptions[0].Name, "subs1")
 	assert2.Equal(t, rpi.Subscriptions[0].Mode, "ALL")
 	for i := range destinations {
 		assert2.Equal(t, rpi.Subscriptions[0].Destinations[i], destinations[i])
 	}
+}
+
+func TestData_Drop_Subscription(t *testing.T) {
+	Databases := make(map[string]*DatabaseInfo)
+	for i := 0; i < 5; i++ {
+		db := fmt.Sprintf(`db%v`, i)
+		rp := fmt.Sprintf(`rp%v`, i)
+		Databases[db] = &DatabaseInfo{
+			Name: db,
+			RetentionPolicies: map[string]*RetentionPolicyInfo{
+				rp: {},
+			},
+		}
+	}
+	data := &Data{Databases: Databases}
+	for i := 0; i < 5; i++ {
+		db := fmt.Sprintf(`db%v`, i)
+		rp := fmt.Sprintf(`rp%v`, i)
+		for j := 0; j < 3; j++ {
+			subs := fmt.Sprintf(`subs%v`, j)
+			err := data.CreateSubscription(db, rp, subs, "All", []string{"http://192.168.35.1:8080"})
+			assert2.NoError(t, err)
+		}
+	}
+
+	// drop all subscriptions on db0
+	err := data.DropSubscription("db0", "", "")
+	assert2.NoError(t, err)
+	rpi, err := data.RetentionPolicy("db0", "rp0")
+	assert2.NoError(t, err)
+	assert2.Equal(t, len(rpi.Subscriptions), 0)
+
+	// drop subs2 on db2.rp2, but do not specify rp
+	err = data.DropSubscription("db2", "", "subs2")
+	assert2.NoError(t, err)
+
+	// drop subs1 on db3.rp3
+	err = data.DropSubscription("db3", "rp3", "subs1")
+	assert2.NoError(t, err)
+	rpi, err = data.RetentionPolicy("db3", "rp3")
+	assert2.NoError(t, err)
+	assert2.Equal(t, len(rpi.Subscriptions), 2)
+	for i := 0; i < 2; i++ {
+		assert2.NotEqual(t, rpi.Subscriptions[i].Name, "subs1")
+	}
+
+	// try to drop non-exist subscription
+	err = data.DropSubscription("db2", "rp2", "subs10")
+	assert2.Equal(t, err != nil, true)
+
+	// drop all subscriptions
+	rows := data.ShowSubscriptions()
+	assert2.Equal(t, rows.Len(), 4)
+	err = data.DropSubscription("", "", "")
+	assert2.NoError(t, err)
+	rows = data.ShowSubscriptions()
+	assert2.Equal(t, rows.Len(), 0)
+
+	// try drop subscription when there is no subscription
+	err = data.DropSubscription("db0", "rp0", "")
+	assert2.NoError(t, err)
+	err = data.DropSubscription("", "", "")
+	assert2.NoError(t, err)
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -11247,6 +11247,41 @@ func TestServer_SubscriptionCommands(t *testing.T) {
 				command: "SHOW SUBSCRIPTIONS",
 				exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["rp0","subs0","ALL",["%s","%s"]]]}]}]}`, server1.URL, server2.URL),
 			},
+			&Query{
+				name:    `DROP SUBSCRIPTION subs0`,
+				command: "drop subscription subs0 on db0.rp0",
+				exp:     `{"results":[{"statement_id":0}]}`,
+			},
+			&Query{
+				name:    `SHOW SUBSCRIPTIONS AFTER DROP`,
+				command: "SHOW SUBSCRIPTIONS",
+				exp:     `{"results":[{"statement_id":0}]}`,
+			},
+			&Query{
+				name:    `RECREATE SUBSCRIPTION AFTER DROP`,
+				command: fmt.Sprintf("create subscription subs0 on db0.rp0 destinations all \"%s\", \"%s\"", server1.URL, server2.URL),
+				exp:     `{"results":[{"statement_id":0}]}`,
+			},
+			&Query{
+				name:    `SHOW SUBSCRIPTIONS`,
+				command: "SHOW SUBSCRIPTIONS",
+				exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["rp0","subs0","ALL",["%s","%s"]]]}]}]}`, server1.URL, server2.URL),
+			},
+			&Query{
+				name:    `DROP ALL SUBSCRIPTIONS ON db0`,
+				command: "DROP ALL SUBSCRIPTIONS ON db0",
+				exp:     `{"results":[{"statement_id":0}]}`,
+			},
+			&Query{
+				name:    `SHOW SUBSCRIPTIONS AFTER DROP`,
+				command: "SHOW SUBSCRIPTIONS",
+				exp:     `{"results":[{"statement_id":0}]}`,
+			},
+			&Query{
+				name:    `CREATE SUBSCRIPTION WITH INVALID URL`,
+				command: "create subscription subs0 on db0.rp0 destinations all \"127.0.0.3:8086\"",
+				exp:     `{"results":[{"statement_id":0,"error":"invalid url 127.0.0.3:8086"}]}`,
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close #327 #332

### What is changed and how it works?
Enable drop subscription statement in `statementExecutor`, and add support for newly defined syntactic sugar, for example:
```sql
DROP ALL SUBSCRIPTIONS ON db0
DROP ALL SUBSCRIPTIONS
```

### How Has This Been Tested?
I add unit test, integretion test:
![image](https://github.com/openGemini/openGemini/assets/72912470/d8ad5447-977f-49ed-a825-825769ebe78e)

![image](https://github.com/openGemini/openGemini/assets/72912470/474fe4df-72ff-4f62-bdab-f39748d3a02b)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
