### PR TITLE
chore(version): change default version v1.1.0 to v1.1.0rc0

### DIFF
--- a/app/ts-cli/main.go
+++ b/app/ts-cli/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	TsVersion = "v1.0.1"
+	TsVersion = "v1.1.0rc0"
 	TsCommit  string
 	TsBranch  string
 )

--- a/app/ts-meta/main.go
+++ b/app/ts-meta/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	TsVersion   = "v1.0.1"
+	TsVersion   = "v1.1.0rc0"
 	TsCommit    string
 	TsBranch    string
 	TsBuildTime string

--- a/app/ts-monitor/main.go
+++ b/app/ts-monitor/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	TsVersion   = "v1.0.1"
+	TsVersion   = "v1.1.0rc0"
 	TsCommit    string
 	TsBranch    string
 	TsBuildTime string

--- a/app/ts-server/main.go
+++ b/app/ts-server/main.go
@@ -35,7 +35,7 @@ import (
 )
 
 var (
-	TsVersion   = "v1.0.1"
+	TsVersion   = "v1.1.0rc0"
 	TsCommit    string
 	TsBranch    string
 	TsBuildTime string

--- a/app/ts-sql/main.go
+++ b/app/ts-sql/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	TsVersion   = "v1.0.1"
+	TsVersion   = "v1.1.0rc0"
 	TsCommit    string
 	TsBranch    string
 	TsBuildTime string

--- a/app/ts-store/main.go
+++ b/app/ts-store/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	TsVersion   = "v1.0.1"
+	TsVersion   = "v1.1.0rc0"
 	TsCommit    string
 	TsBranch    string
 	TsBuildTime string


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
set default version v1.1.0rc0

### What is changed and how it works?
change default version v1.1.0 to v1.1.0rc0

- **complie code**
```
python3 build.py
```
- **check version**
```
> cd build
> ./ts-sql version
> ./ts-cli version
> ./ts-meta version
> ./ts-store version
> ./ts-server version
> ./ts-monitor version
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
