### PR TITLE
fix(index): index type needs to support upper letters in DDL statements

### DIFF
--- a/engine/index/tsi/index_am.go
+++ b/engine/index/tsi/index_am.go
@@ -18,6 +18,7 @@ package tsi
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openGemini/openGemini/lib/tracing"
 	"github.com/openGemini/openGemini/open_src/influx/influxql"
@@ -47,7 +48,7 @@ var (
 )
 
 func GetIndexIdByName(name string) (uint32, error) {
-	id, ok := IndexNameToID[name]
+	id, ok := IndexNameToID[strings.ToLower(name)]
 	if !ok {
 		return 0, fmt.Errorf("invalid index type %s", name)
 	}

--- a/engine/index/tsi/index_test.go
+++ b/engine/index/tsi/index_test.go
@@ -955,3 +955,14 @@ func TestSortTagsets(t *testing.T) {
 	schema := executor.NewQuerySchema(nil, nil, &opt, nil)
 	tagset.Sort(schema)
 }
+
+func TestGetIndexOidByName(t *testing.T) {
+	_, err := GetIndexIdByName("field")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = GetIndexIdByName("FIELD")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
index type needs to support upper letters in DDL statements

Issue Number: fix #339 

### What is changed and how it works?
When the index type is upper letters, translate it to lower letter automatically . Such as, "TEXT" or "FIELD" translate to "text" or "field".

### How Has This Been Tested?

Use the upper keyword `INDEXTYPE TEXT INDEXLIST`:

```sql
CREATE MEASUREMENT mst_name WITH INDEXTYPE TEXT INDEXLIST field_name1,field_name2
```

- [X] Test cases to be added
- [X] Full build the project

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
