### PR TITLE
feat: support to switch leader for meta node

### DIFF
--- a/app/ts-meta/meta/handler.go
+++ b/app/ts-meta/meta/handler.go
@@ -390,7 +390,7 @@ func (h *httpHandler) handleResponse(w http.ResponseWriter, err error) {
 // curl -i -XPOST 'http://127.0.0.1:8091/expandGroups'
 func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) {
 	err := h.store.ExpandGroups()
-	if strings.Contains(err.Error(), "node is not the leader") {
+	if err != nil {
 		h.logger.Error("error expand groups", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/app/ts-meta/meta/handler.go
+++ b/app/ts-meta/meta/handler.go
@@ -19,6 +19,7 @@ package meta
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -53,6 +54,8 @@ type IStore interface {
 	markBalancer(enable bool) error
 	movePt(db string, pt uint32, to uint64) error
 	ExpandGroups() error
+	leader() string
+	leadershipTransfer() error
 }
 
 var httpScheme = map[bool]string{
@@ -134,6 +137,8 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.WrapHandler(h.serveMovePt).ServeHTTP(w, r)
 		case "/expandGroups":
 			h.WrapHandler(h.serveExpandGroups).ServeHTTP(w, r)
+		case "/leadershiptransfer":
+			h.WrapHandler(h.leadershipTransfer).ServeHTTP(w, r)
 		}
 		h.logger.Info("serve post")
 	default:
@@ -237,8 +242,8 @@ func (h *httpHandler) httpErr(err error, w http.ResponseWriter, status int) {
 	http.Error(w, err.Error(), status)
 }
 
-//get the status of Data include MetaNodes and DataNodes
-//do this way:curl -i GET 'http://127.0.0.1:8091/getdata?nodeStatus=ok'
+// get the status of Data include MetaNodes and DataNodes
+// do this way:curl -i GET 'http://127.0.0.1:8091/getdata?nodeStatus=ok'
 func (h *httpHandler) serveGetdata(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 
@@ -385,7 +390,7 @@ func (h *httpHandler) handleResponse(w http.ResponseWriter, err error) {
 // curl -i -XPOST 'http://127.0.0.1:8091/expandGroups'
 func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) {
 	err := h.store.ExpandGroups()
-	if err != nil {
+	if strings.Contains(err.Error(), "node is not the leader") {
 		h.logger.Error("error expand groups", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -410,4 +415,48 @@ func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		h.logger.Error("write result failed", zap.Error(err))
 	}
+}
+
+// curl -i -XPOST 'http://127.0.0.1:8091/leadershiptransfer'
+func (h *httpHandler) leadershipTransfer(w http.ResponseWriter, r *http.Request) {
+	err := h.store.leadershipTransfer()
+	if err != nil && strings.Contains(err.Error(), "node is not the leader") {
+		l := h.store.leader()
+		if l == "" {
+			h.httpErr(errors.New("no raft leader"), w, http.StatusServiceUnavailable)
+		}
+		scheme := "http"
+		if h.config.HTTPSEnabled {
+			scheme = "https"
+		}
+
+		url := fmt.Sprintf("%s://%s/leadershiptransfer", scheme, l)
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		return
+	}
+
+	if err != nil {
+		h.logger.Error("store.leadershiptransfer error", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := &proto2.Response{
+		OK:    proto.Bool(true),
+		Index: proto.Uint64(h.store.index()),
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		h.httpErr(err, w, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Add("Content-Type", "application/octet-stream")
+	_, err = w.Write(b)
+	if err != nil {
+		h.logger.Error("write result failed", zap.Error(err))
+	}
+	_, _ = w.Write([]byte("\n"))
 }

--- a/app/ts-meta/meta/handler_test.go
+++ b/app/ts-meta/meta/handler_test.go
@@ -153,6 +153,14 @@ func (w *MockResponseWriter) WriteHeader(statusCode int) {
 type MockIStore struct {
 }
 
+func (s *MockIStore) leader() string {
+	return ""
+}
+
+func (s *MockIStore) leadershipTransfer() error {
+	return nil
+}
+
 func (s *MockIStore) index() uint64 {
 	return 0
 }

--- a/app/ts-meta/meta/raft_wrapper.go
+++ b/app/ts-meta/meta/raft_wrapper.go
@@ -248,3 +248,7 @@ func (l *raftLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net
 func (l *raftLayer) Accept() (net.Conn, error) { return l.ln.Accept() }
 
 func (l *raftLayer) Close() error { return l.ln.Close() }
+
+func (r *raftWrapper) LeadershipTransfer() error {
+	return r.raft.LeadershipTransfer().Error()
+}

--- a/app/ts-meta/meta/store.go
+++ b/app/ts-meta/meta/store.go
@@ -349,6 +349,7 @@ type RaftInterface interface {
 	AddServer(addr string) error
 	ShowDebugInfo(witch string) ([]byte, error)
 	UserSnapshot() error
+	LeadershipTransfer() error
 }
 
 type Store struct {
@@ -1739,4 +1740,11 @@ func (s *Store) registerQueryIDOffset(host meta.SQLHost) (uint64, error) {
 	} else {
 		return offset, nil
 	}
+}
+
+func (s *Store) leadershipTransfer() error {
+	if s.raft == nil {
+		return errors.New("raft state not create")
+	}
+	return s.raft.LeadershipTransfer()
 }

--- a/app/ts-meta/meta/store_internal_test.go
+++ b/app/ts-meta/meta/store_internal_test.go
@@ -143,6 +143,10 @@ func (m MockRaft) UserSnapshot() error {
 	panic("implement me")
 }
 
+func (m MockRaft) LeadershipTransfer() error {
+	panic("implement me")
+}
+
 func Test_GetStreamInfo(t *testing.T) {
 	Streams := map[string]*meta2.StreamInfo{}
 	Streams["test"] = &meta2.StreamInfo{


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
support to switch leader for meta node and it will switch leader by command:

```
curl -i -X POST http://127.0.0.1:8091/leadershiptransfer
```
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: resolve #346 

### What is changed and how it works?
The leader node executes the appropriate commands.

```
curl -i -X POST http://leader_addr:port/leadershiptransfer
```

### How Has This Been Tested?

```
>curl -i -X POST http://127.0.0.3:8091/leadershiptransfer
HTTP/1.1 307 Temporary Redirect
Location: http://127.0.0.1:8088/leadershiptransfer
Date: Tue, 18 Jul 2023 06:14:29 GMT
Content-Length: 0

>curl -s -GET http://127.0.0.2:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.2:8091": {
        "applied_index": "57",
        "commit_index": "57",
        "fsm_pending": "0",
        "last_contact": "13.1074ms",
        "last_log_index": "57",
        "last_log_term": "28",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Follower",
        "term": "28"
    }
}
>curl -s -GET http://127.0.0.1:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.1:8091": {
        "applied_index": "57",
        "commit_index": "57",
        "fsm_pending": "0",
        "last_contact": "0",
        "last_log_index": "57",
        "last_log_term": "28",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Leader",
        "term": "28"
    }
}

>curl -s -GET http://127.0.0.3:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.3:8091": {
        "applied_index": "57",
        "commit_index": "57",
        "fsm_pending": "0",
        "last_contact": "35.8165ms",
        "last_log_index": "57",
        "last_log_term": "28",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Follower",
        "term": "28"
    }
}
```

When a leader executes this command, it returns that it is a leader and also switches leader
```
>curl -i -X POST http://127.0.0.1:8091/leadershiptransfer
HTTP/1.1 200 OK
Date: Tue, 18 Jul 2023 06:15:10 GMT
Content-Length: 23
Content-Type: text/plain; charset=utf-8

{"OK":true,"Index":48}
>curl -s -GET http://127.0.0.3:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.3:8091": {
        "applied_index": "58",
        "commit_index": "58",
        "fsm_pending": "0",
        "last_contact": "0",
        "last_log_index": "58",
        "last_log_term": "29",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Leader",
        "term": "29"
    }
}

>curl -s -GET http://127.0.0.1:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.1:8091": {
        "applied_index": "58",
        "commit_index": "58",
        "fsm_pending": "0",
        "last_contact": "13.7639ms",
        "last_log_index": "58",
        "last_log_term": "29",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Follower",
        "term": "29"
    }
}
>curl -s -GET http://127.0.0.2:8091/debug?witch=raft-stat -H 'all:y' | python -mjson.tool
{
    "127.0.0.2:8091": {
        "applied_index": "58",
        "commit_index": "58",
        "fsm_pending": "0",
        "last_contact": "2.5149ms",
        "last_log_index": "58",
        "last_log_term": "29",
        "last_snapshot_index": "0",
        "last_snapshot_term": "0",
        "latest_configuration": "[{Suffrage:Voter ID:127.0.0.3:8088 Address:127.0.0.3:8088} {Suffrage:Voter ID:127.0.0.1:8088 Address:127.0.0.1:8088} {Suffrage:Voter ID:127.0.0.2:8088 Address:127.0.0.2:8088}]",
        "latest_configuration_index": "0",
        "num_peers": "2",
        "protocol_version": "3",
        "protocol_version_max": "3",
        "protocol_version_min": "0",
        "snapshot_version_max": "1",
        "snapshot_version_min": "0",
        "state": "Follower",
        "term": "29"
    }
}
```




# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
