### PR TITLE
chore: modify return port

### DIFF
--- a/app/ts-meta/meta/handler.go
+++ b/app/ts-meta/meta/handler.go
@@ -390,7 +390,7 @@ func (h *httpHandler) handleResponse(w http.ResponseWriter, err error) {
 // curl -i -XPOST 'http://127.0.0.1:8091/expandGroups'
 func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) {
 	err := h.store.ExpandGroups()
-	if err != nil {
+	if strings.Contains(err.Error(), "node is not the leader") {
 		h.logger.Error("error expand groups", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/app/ts-meta/meta/handler.go
+++ b/app/ts-meta/meta/handler.go
@@ -54,7 +54,7 @@ type IStore interface {
 	markBalancer(enable bool) error
 	movePt(db string, pt uint32, to uint64) error
 	ExpandGroups() error
-	leader() string
+	leaderHTTP() string
 	leadershipTransfer() error
 }
 
@@ -390,7 +390,7 @@ func (h *httpHandler) handleResponse(w http.ResponseWriter, err error) {
 // curl -i -XPOST 'http://127.0.0.1:8091/expandGroups'
 func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) {
 	err := h.store.ExpandGroups()
-	if strings.Contains(err.Error(), "node is not the leader") {
+	if err != nil {
 		h.logger.Error("error expand groups", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -421,7 +421,7 @@ func (h *httpHandler) serveExpandGroups(w http.ResponseWriter, r *http.Request) 
 func (h *httpHandler) leadershipTransfer(w http.ResponseWriter, r *http.Request) {
 	err := h.store.leadershipTransfer()
 	if err != nil && strings.Contains(err.Error(), "node is not the leader") {
-		l := h.store.leader()
+		l := h.store.leaderHTTP()
 		if l == "" {
 			h.httpErr(errors.New("no raft leader"), w, http.StatusServiceUnavailable)
 		}

--- a/app/ts-meta/meta/handler_test.go
+++ b/app/ts-meta/meta/handler_test.go
@@ -153,7 +153,7 @@ func (w *MockResponseWriter) WriteHeader(statusCode int) {
 type MockIStore struct {
 }
 
-func (s *MockIStore) leader() string {
+func (s *MockIStore) leaderHTTP() string {
 	return ""
 }
 

--- a/app/ts-meta/meta/raft_wrapper.go
+++ b/app/ts-meta/meta/raft_wrapper.go
@@ -250,5 +250,8 @@ func (l *raftLayer) Accept() (net.Conn, error) { return l.ln.Accept() }
 func (l *raftLayer) Close() error { return l.ln.Close() }
 
 func (r *raftWrapper) LeadershipTransfer() error {
+	if r == nil || r.raft == nil {
+		return nil
+	}
 	return r.raft.LeadershipTransfer().Error()
 }

--- a/app/ts-meta/meta/store.go
+++ b/app/ts-meta/meta/store.go
@@ -1035,6 +1035,30 @@ func (s *Store) leader() string {
 	return s.raft.Leader()
 }
 
+// leaderHTTP returns the http address what the Store thinks is the current leader. An empty
+// string indicates no leader exists.
+func (s *Store) leaderHTTP() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.raft == nil {
+		return ""
+	}
+
+	leader := s.raft.Leader()
+	if leader == "" {
+		return leader
+	}
+
+	var addr string
+	for _, node := range s.data.MetaNodes {
+		if leader == node.TCPHost {
+			addr = node.Host
+			break
+		}
+	}
+	return addr
+}
+
 // otherMetaServersHTTP will return the HTTP bind addresses of the other
 // meta servers in the cluster
 func (s *Store) otherMetaServersHTTP() []string {
@@ -1741,13 +1765,6 @@ func (s *Store) registerQueryIDOffset(host meta.SQLHost) (uint64, error) {
 		return 0, fmt.Errorf("register query id failed, host: %s", host)
 	}
 	return offset, nil
-}
-
-func (s *Store) leadershipTransfer() error {
-	if s.raft == nil {
-		return errors.New("raft state not create")
-	}
-	return s.raft.LeadershipTransfer()
 }
 
 func (s *Store) leadershipTransfer() error {

--- a/app/ts-meta/meta/store.go
+++ b/app/ts-meta/meta/store.go
@@ -1749,3 +1749,10 @@ func (s *Store) leadershipTransfer() error {
 	}
 	return s.raft.LeadershipTransfer()
 }
+
+func (s *Store) leadershipTransfer() error {
+	if s.raft == nil {
+		return errors.New("raft state not create")
+	}
+	return s.raft.LeadershipTransfer()
+}


### PR DESCRIPTION
```
> curl -i -X POST http://127.0.0.3:8091/leadershiptransfer
HTTP/1.1 307 Temporary Redirect
Location: http://127.0.0.1:8091/leadershiptransfer
Date: Tue, 18 Jul 2023 06:14:29 GMT
Content-Length: 0
```

The Location port should be 8091

ref: #351 