### PR TITLE
feat: support lazy load shards

### DIFF
--- a/app/ts-store/run/server.go
+++ b/app/ts-store/run/server.go
@@ -174,7 +174,7 @@ func (s *Server) Open() error {
 	}
 
 	s.metaClient = metaclient.DefaultMetaClient
-	s.metaClient.OpenAtStore()
+	s.metaClient.OpenAtStore() // wait for ts-meta to be ready
 
 	log := Logger.GetLogger()
 	s.storage, err = storage.OpenStorage(s.storageDataPath, s.node, s.metaClient.(*metaclient.Client), s.config)

--- a/app/ts-store/run/server_test.go
+++ b/app/ts-store/run/server_test.go
@@ -241,6 +241,11 @@ func TestNewServer(t *testing.T) {
 type MockMetaClient struct {
 }
 
+func (client *MockMetaClient) ThermalShards(db string, start, end time.Duration) map[uint64]struct{} {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (client *MockMetaClient) GetStreamInfosStore() map[string]*meta2.StreamInfo {
 	//TODO implement me
 	panic("implement me")

--- a/app/ts-store/storage/storage.go
+++ b/app/ts-store/storage/storage.go
@@ -176,6 +176,9 @@ func OpenStorage(path string, node *metaclient.Node, cli *metaclient.Client, con
 	opt.WalReplayAsync = conf.Data.WalReplayAsync
 	opt.CompactionMethod = conf.Data.CompactionMethod
 	opt.OpenShardLimit = conf.Data.OpenShardLimit
+	opt.LazyLoadShardEnable = conf.Data.LazyLoadShardEnable
+	opt.ThermalShardStartDuration = time.Duration(conf.Data.ThermalShardStartDuration)
+	opt.ThermalShardEndDuration = time.Duration(conf.Data.ThermalShardEndDuration)
 	opt.DownSampleWriteDrop = conf.Data.DownSampleWriteDrop
 	opt.MaxDownSampleTaskConcurrency = conf.Data.MaxDownSampleTaskConcurrency
 	opt.MaxSeriesPerDatabase = conf.Data.MaxSeriesPerDatabase

--- a/config/openGemini.conf
+++ b/config/openGemini.conf
@@ -121,6 +121,13 @@
   # maximum number of series a node can hold per database. 0: unlimited
   # max-series-per-database = 0
 
+  # Determines whether the lazy shard open is enabled.
+  # lazy-load-shard-enable = false
+
+  # The time range for thermal shards.
+  # thermal-shard-start-duration = "0s"
+  # thermal-shard-end-duration = "0s"
+
 # [data.ops-monitor]
   # store-http-addr = "{{addr}}:8402"
   # auth-enabled = false

--- a/coordinator/shard_mapper_test.go
+++ b/coordinator/shard_mapper_test.go
@@ -51,6 +51,11 @@ type mocShardMapperMetaClient struct {
 	databases map[string]*meta.DatabaseInfo
 }
 
+func (m mocShardMapperMetaClient) ThermalShards(db string, start, end time.Duration) map[uint64]struct{} {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m mocShardMapperMetaClient) GetStreamInfos() map[string]*meta.StreamInfo {
 	return nil
 }

--- a/engine/partition_test.go
+++ b/engine/partition_test.go
@@ -70,16 +70,16 @@ func TestOpenShard(t *testing.T) {
 	durationInfos := make(map[uint64]*meta.ShardDurationInfo)
 	resC := make(chan *res, 1)
 	openShardsLimit <- struct{}{}
-	dbPTInfo.openShard(0, "xxx", "0", durationInfos, resC, 0, nil)
+	dbPTInfo.openShard(0, nil, "xxx", "0", durationInfos, resC, 0, nil)
 	r := <-resC
 	require.NoError(t, r.err)
 	openShardsLimit <- struct{}{}
-	dbPTInfo.openShard(0, "1_1635724800000000000_1636329600000000000_1", "1", durationInfos, resC, 0, nil)
+	dbPTInfo.openShard(0, nil, "1_1635724800000000000_1636329600000000000_1", "1", durationInfos, resC, 0, nil)
 	r = <-resC
 	require.NoError(t, r.err)
 
 	durationInfos[10] = &meta.ShardDurationInfo{DurationInfo: meta.DurationDescriptor{Duration: time.Second}}
-	sh, err := dbPTInfo.loadProcess(0, "10_1635724800000000000_1636329600000000000_100", "1", 100, 10, durationInfos, nil, nil)
+	sh, err := dbPTInfo.loadProcess(0, nil, "10_1635724800000000000_1636329600000000000_100", "1", 100, 10, durationInfos, nil, nil)
 	require.Empty(t, sh)
 	require.NoError(t, err)
 }

--- a/engine/shard_test.go
+++ b/engine/shard_test.go
@@ -3251,14 +3251,13 @@ func TestEngine_GetShard(t *testing.T) {
 		_ = eng.Close()
 	}()
 
-	sh := eng.GetShard("db0", uint32(0), uint64(1))
-	if sh == nil {
-		t.Errorf("get shard failed")
-	}
-	sh2 := eng.GetShard("db0", uint32(0), uint64(10))
-	if sh2 != nil {
-		t.Errorf("get shard failed")
-	}
+	sh, err := eng.GetShard("db0", uint32(0), uint64(1))
+	assert2.NoError(t, err)
+	assert2.NotEmpty(t, sh)
+
+	sh2, err := eng.GetShard("db0", uint32(0), uint64(10))
+	assert2.NoError(t, err)
+	assert2.Nil(t, sh2)
 }
 
 func TestEngine_Statistics_Shard(t *testing.T) {
@@ -4591,6 +4590,11 @@ func NewMockColumnStoreMstInfo() *meta2.MeasurementInfo {
 }
 
 type MockMetaClient struct {
+}
+
+func (client *MockMetaClient) ThermalShards(db string, start, end time.Duration) map[uint64]struct{} {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (client *MockMetaClient) GetStreamInfosStore() map[string]*meta2.StreamInfo {

--- a/lib/config/store.go
+++ b/lib/config/store.go
@@ -226,6 +226,11 @@ type Store struct {
 	MinChunkReaderConcurrency    int           `toml:"min-chunk-reader-concurrency"`
 	MinShardsConcurrency         int           `toml:"min-shards-concurrency"`
 	MaxDownSampleTaskConcurrency int           `toml:"max-downsample-task-concurrency"`
+
+	// config for lazy load shard
+	LazyLoadShardEnable       bool          `toml:"lazy-load-shard-enable"`
+	ThermalShardStartDuration toml.Duration `toml:"thermal-shard-start-duration"`
+	ThermalShardEndDuration   toml.Duration `toml:"thermal-shard-end-duration"`
 }
 
 // NewStore returns the default configuration for tsdb.

--- a/lib/netstorage/engine_option.go
+++ b/lib/netstorage/engine_option.go
@@ -69,7 +69,12 @@ type EngineOptions struct {
 	CacheMetaBlock   bool
 	EnableMmapRead   bool
 	CompactionMethod int // 0:auto, 1:stream, 2: non-stream
-	OpenShardLimit   int
+
+	OpenShardLimit int
+	// lazy load shards
+	LazyLoadShardEnable       bool
+	ThermalShardStartDuration time.Duration
+	ThermalShardEndDuration   time.Duration
 
 	DownSampleWriteDrop          bool
 	MaxDownSampleTaskConcurrency int


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #348 

### What is changed and how it works?

When `GetShard` is needed in the process, it is judged whether the shard has been opened, and if not, the `openAndEnable` function of the shard is called.

### How Has This Been Tested?

1. Change the config items:
```toml
  # Determines whether the lazy shard open is enabled.
  lazy-load-shard-enable = true

  # The time range for thermal shards.
  thermal-shard-start-duration = "0s"
  thermal-shard-end-duration = "0s"
```
2. Prepare test data to write to database.
3. Restart the database process, and confirm that shards are not open through logs and breakpoints.
4. Write a piece of data to one of the shards and trigger `lazyShardOpen` successfully.
5. Execute `select * from h2o_feet` to trigger `lazyShardOpen` successfully.
6. Executing `show tag keys` and `show tag values` will not trigger `lazyShardOpen`.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
