### PR TITLE
ci: support auto release  archives when publish tags

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,34 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ vendor/
 config/openGemini-*
 config/monitor-*
 
+dist/
+
 output/
 go.sum

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,147 @@
+# Make sure to check the documentation at https://goreleaser.com
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: "ts-cli"
+    binary: usr/bin/ts-cli
+    main: ./app/ts-cli
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+  - id: "ts-meta"
+    binary: usr/bin/ts-meta
+    main: ./app/ts-meta
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+  - id: "ts-monitor"
+    binary: usr/bin/ts-monitor
+    main: ./app/ts-monitor
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+  - id: "ts-server"
+    binary: usr/bin/ts-server
+    main: ./app/ts-server
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+  - id: "ts-sql"
+    binary: usr/bin/ts-sql
+    main: ./app/ts-sql
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+  - id: "ts-store"
+    binary: usr/bin/ts-store
+    main: ./app/ts-store
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}-
+      {{- .Version }}-
+      {{- .Os }}-
+      {{- if eq .Arch "amd64" }}amd64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - src: "config/*"
+        dst: etc
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Bug fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^revert:"
+#      - "^chore:"
+      - "^ci:"
+
+release:
+  github:
+  prerelease: auto
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->


### What is changed and how it works?

Support auto release openGemini archives by push tags.


### Release Steps

The tag name MUST be a [SemVer-compatible](https://semver.org/lang/zh-CN/) version. 

- Normal Release
    1. Fetch the latest code for upstream: `git fetch upstream`
    2. Create tag: `git tag v1.5.12` (Create pre-release tag: `git tag v1.5.12-rc0`)
    3. Push tag to upstream: `git push upstream --tags`
    4. Triggering GitHub Actions for releasing

- Release exception, need to re-release
    1. Delete local code tag: `git tag -d v1.5.12`
    2. Delete upstream tag: `git push --delete upstream v1.5.12`
    3. Delete GitHub release drafts (if any)
    4. Fix the issue and re-run the normal releasing process


### How Has This Been Tested?

Tested by my cloned repo.


<img width="909" alt="image" src="https://github.com/openGemini/openGemini/assets/22270117/1115a009-4160-4a56-8232-2bfc673584a7">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
