### PR TITLE
fix: support measurement name containing colons

### DIFF
--- a/open_src/influx/meta/data.go
+++ b/open_src/influx/meta/data.go
@@ -2971,8 +2971,7 @@ func ValidMeasurementName(name string) bool {
 	if name == "." || name == ".." {
 		return false
 	}
-
-	return validName(name, `,:;/\`)
+	return validName(name, `,;/\`)
 }
 
 func validName(name string, charactersNotSupport string) bool {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #377

Resolved the bug that the automatic creation of measurement names cannot contain `:` when writing using line protocol.

### What is changed and how it works?

When automatically creating a measurement, special character filtering is performed for hard code. This fix only delete the `:` in the hard code.

### How Has This Been Tested?
![image](https://github.com/openGemini/openGemini/assets/37504557/803f633c-9a65-4bb9-8fad-8dc5e1333bc2)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules