### PR TITLE
fix: goroutine leak and race condition in sherlock

### DIFF
--- a/lib/sherlock/sherlock_test.go
+++ b/lib/sherlock/sherlock_test.go
@@ -18,7 +18,6 @@ package sherlock
 
 import (
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -46,8 +45,6 @@ func Test_Sherlock_start_stop(t *testing.T) {
 	sh.DisableGrtDump()
 	sh.EnableGrtDump()
 	sh.Start()
-	sh.Start() // test start again
-	defer sh.Stop()
 	defer sh.Stop()
 	time.Sleep(15 * time.Second)
 	fmt.Println("on running")
@@ -81,7 +78,6 @@ func Test_Sherlock_startDumpLoop_return(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	sh.Stop()
 	time.Sleep(10 * time.Millisecond)
-	require.Equal(t, int64(1), atomic.LoadInt64(&sh.closed))
 
 	// case 2. cpu is too high, disable to dump
 	var collector2 = func(cpuCore int, memoryLimit uint64) (int, int, int, error) {


### PR DESCRIPTION
The current implementation of Sherlock has checks for repetitive Start & Stop, but it does not work all the time, for example:

```go
s.Start() // s.closed = 0 and start a goroutine
s.Stop() // s.closed = 1 but the goroutine may not be closed
s.Start() // s.closed = 0 and start a new goroutine
```

result in two goroutines for the dump loop, and there may be data races between the two goroutines.

However, the checks to `s.closed` makes developers feel the code is safe, and can handle repetitive Start & Stop correctly, which introduces potential bugs to their code.

To be precise, this PR hasn't fix the issues directly, because it is very very hard to make things always correct here. This PR takes another approach, it removes the checks and leave all the issues to the callers, where is a better place to handle them correctly. For example, the sherlock service already leverage `sync.Once` to avoid repetitive Start & Stop.

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?

possible goroutine leaks and data races.

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
