### PR TITLE
fix: create the same name for continuous query

### DIFF
--- a/open_src/influx/meta/continuous_query.go
+++ b/open_src/influx/meta/continuous_query.go
@@ -44,6 +44,13 @@ func (data *Data) CreateContinuousQuery(dbName, cqName, cqQuery string) error {
 		return ErrSameContinuousQueryName
 	}
 
+	// Make sure continuous query name is unique.
+	for _, db := range data.Databases {
+		if _, ok := db.ContinuousQueries[cqName]; ok {
+			return ErrSameContinuousQueryName
+		}
+	}
+
 	dbi.ContinuousQueries[cqName] = &ContinuousQueryInfo{
 		Name:  cqName,
 		Query: cqQuery,

--- a/tests/server_continuous_query_test.go
+++ b/tests/server_continuous_query_test.go
@@ -41,6 +41,11 @@ func init() {
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
 			&Query{
+				name:    "create continuous query cq2_1 should return conflict name error",
+				command: `CREATE CONTINUOUS QUERY "cq2_1" ON "db0" RESAMPLE EVERY 1h FOR 90m BEGIN SELECT min("passengers") INTO "min_passengers" FROM "bus_data" GROUP BY time(15m) END`,
+				exp:     `{"results":[{"statement_id":0,"error":"continuous query name already exists"}]}`,
+			},
+			&Query{
 				name:    "drop continuous query cq2_1 should succeed",
 				command: `DROP CONTINUOUS QUERY "cq2_1" ON "db2"`,
 				exp:     `{"results":[{"statement_id":0}]}`,


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #399 

### What is changed and how it works?

Check all continuous query names before save to metadata.

### How Has This Been Tested?

Add IT at tests/server_continuous_query_test.go

- [x] IT


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
