### PR TITLE
feat: support show log level config by DDL 

### DIFF
--- a/app/ts-sql/sql/server.go
+++ b/app/ts-sql/sql/server.go
@@ -224,6 +224,7 @@ func (s *Server) initQueryExecutor(c *config.TSSql) {
 		QueryTimeCompareEnabled: c.Coordinator.QueryTimeCompareEnabled,
 		RetentionPolicyLimit:    c.Coordinator.RetentionPolicyLimit,
 		StmtExecLogger:          Logger.NewLogger(errno.ModuleQueryEngine).With(zap.String("query", "StatementExecutor")),
+		Hostname:                config.CombineDomain(s.config.HTTP.Domain, s.config.HTTP.BindAddress),
 	}
 	s.QueryExecutor.TaskManager.QueryTimeout = time.Duration(c.Coordinator.QueryTimeout)
 	s.QueryExecutor.TaskManager.LogQueriesAfter = time.Duration(c.Coordinator.LogQueriesAfter)

--- a/lib/logger/log_test.go
+++ b/lib/logger/log_test.go
@@ -156,6 +156,53 @@ func TestLoggerLevel(t *testing.T) {
 		messages[1:])
 }
 
+func TestSetLevel(t *testing.T) {
+	tests := []struct {
+		name     string
+		lev      string
+		expected zapcore.Level
+		wantErr  bool
+	}{
+		{
+			name:     "Valid level",
+			lev:      "info",
+			expected: zapcore.InfoLevel,
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid level",
+			lev:      "invalid",
+			expected: zapcore.InfoLevel, // Default level
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := logger.SetLevel(tt.lev)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetLevel() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				// If an error is expected, the level should remain unchanged.
+				currentLevel := logger.Alevel.Level()
+				if currentLevel != zapcore.InfoLevel {
+					t.Errorf("SetLevel() level = %v, want %v", currentLevel, zapcore.InfoLevel)
+				}
+			} else {
+				// If no error is expected, the level should be set correctly.
+				currentLevel := logger.Alevel.Level()
+				if currentLevel != tt.expected {
+					t.Errorf("SetLevel() level = %v, want %v", currentLevel, tt.expected)
+				}
+			}
+		})
+	}
+}
+
 func TestZapLogger(t *testing.T) {
 	lg := logger.NewLogger(errno.ModuleUnknown)
 

--- a/open_src/influx/coordinator/statement_executor.go
+++ b/open_src/influx/coordinator/statement_executor.go
@@ -95,6 +95,9 @@ type StatementExecutor struct {
 	MaxQueryParallel        int
 
 	StmtExecLogger *logger.Logger
+
+	// hostname for show configs statement
+	Hostname string
 }
 
 type combinedRunState uint8
@@ -419,7 +422,7 @@ func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement, ctx *query
 	case *influxql.DropStreamsStatement:
 		err = e.executeDropStream(stmt)
 	case *influxql.ShowConfigsStatement:
-		err = e.executeShowConfigs(stmt)
+		rows, err = e.executeShowConfigs(stmt)
 	case *influxql.SetConfigStatement:
 		err = e.executeSetConfig(stmt)
 	default:
@@ -2221,8 +2224,10 @@ func (e *StatementExecutor) executeDropStream(stmt *influxql.DropStreamsStatemen
 	return e.MetaClient.DropStream(stmt.Name)
 }
 
-func (e *StatementExecutor) executeShowConfigs(stmt *influxql.ShowConfigsStatement) error {
-	return fmt.Errorf("impl me")
+func (e *StatementExecutor) executeShowConfigs(stmt *influxql.ShowConfigsStatement) (models.Rows, error) {
+	row := &models.Row{Columns: []string{"component", "instance", "name", "value"}}
+	row.Values = append(row.Values, []interface{}{sqlConfig, e.Hostname, loggingLevel, logger.Alevel})
+	return []*models.Row{row}, nil
 }
 
 func (e *StatementExecutor) executeSetConfig(stmt *influxql.SetConfigStatement) error {

--- a/tests/server_suite.go
+++ b/tests/server_suite.go
@@ -1138,7 +1138,7 @@ func init() {
 			&Query{
 				name:    "show configs",
 				command: `SHOW CONFIGS`,
-				exp:     `{"results":[{"statement_id":0,"error":"impl me"}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["component","instance","name","value"],"values":[["sql","127.0.0.1:8086","logging.level","info"]]}]}]}`,
 			},
 			&Query{
 				name:    "set config",
@@ -1148,7 +1148,7 @@ func init() {
 			&Query{
 				name:    "show configs",
 				command: `SHOW CONFIGS`,
-				exp:     `{"results":[{"statement_id":0,"error":"impl me"}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["component","instance","name","value"],"values":[["sql","127.0.0.1:8086","logging.level","debug"]]}]}]}`,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!-- #354 

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: ref #354 
### What is changed and how it works?
Support `SHOW CONFIGS` command.
```
➜  openGemini git:(show-log) ts-cli
2023/10/08 17:45:22 proto: duplicate proto type registered: influxql.Measurements
2023/10/08 17:45:22 proto: duplicate proto type registered: influxql.Measurement
openGemini CLI 0.1.0 (rev-revision)
Please use `quit`, `exit` or `Ctrl-D` to exit this program.
> show configs
+-----------+----------+---------------+-------+
| component | instance | name          | value |
+-----------+----------+---------------+-------+
| sql       | :8086    | logging.level | info  |
+-----------+----------+---------------+-------+
4 columns, 1 rows in set

> 
```


### How Has This Been Tested?
Add unit test case in lib/config/config_test.go
Add integration test case in tests/server_test.go

First, you should start openGemini cluster. Then you can run as follows:
```shell
 URL=http://127.0.0.1:8086 go test -mod=mod -test.parallel 1 -timeout 10m ./tests -run  TestServer_ConfigCommand -v GOCACHE=off
```

```
➜  openGemini git:(show-log) ✗ URL=http://:8086 go test -mod=mod -test.parallel 1 -timeout 10m ./tests -run  TestServer_ConfigCommand -v GOCACHE=off
# github.com/openGemini/openGemini/tests.test
ld: warning: '/private/var/folders/w_/4l7k3gwn3g581ztmz26mzdc00000gn/T/go-link-3733628193/go.o' has malformed LC_DYSYMTAB, expected 137 undefined symbols to start at index 52935, found 157 undefined symbols starting at index 134
2023/10/08 17:46:46 proto: duplicate proto type registered: influxql.Measurements
2023/10/08 17:46:46 proto: duplicate proto type registered: influxql.Measurement
============= Running all tests for "tsi" index =============
=== RUN   TestServer_ConfigCommand
=== PAUSE TestServer_ConfigCommand
=== CONT  TestServer_ConfigCommand
=== RUN   TestServer_ConfigCommand/show_configs
=== RUN   TestServer_ConfigCommand/set_config
=== RUN   TestServer_ConfigCommand/show_configs#01
--- PASS: TestServer_ConfigCommand (0.53s)
    --- PASS: TestServer_ConfigCommand/show_configs (0.00s)
    --- PASS: TestServer_ConfigCommand/set_config (0.00s)
    --- PASS: TestServer_ConfigCommand/show_configs#01 (0.00s)
PASS

ok      github.com/openGemini/openGemini/tests  1.690s
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
