### PR TITLE
fix: not print logs to monitor.log for ts-monitor

### DIFF
--- a/app/ts-monitor/main.go
+++ b/app/ts-monitor/main.go
@@ -67,6 +67,17 @@ func doRun(args ...string) error {
 			return err
 		}
 		mainCmd := app.NewCommand()
+		info := app.ServerInfo{
+			App:       config.AppMonitor,
+			Version:   TsVersion,
+			Commit:    TsCommit,
+			Branch:    TsBranch,
+			BuildTime: TsBuildTime,
+		}
+		mainCmd.Info = info
+		mainCmd.Logo = app.MONITORLOGO
+		mainCmd.Version = info.FullVersion()
+		mainCmd.Usage = fmt.Sprintf(app.RunUsage, info.App, info.App)
 		err = mainCmd.InitConfig(config.NewTSMonitor(), options.ConfigPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #407 

### What is changed and how it works?

Set ts-monitor app info because:

```go
	if lc := conf.GetLogging(); lc != nil {
		lc.SetApp(cmd.Info.App)
		logger.InitLogger(*lc)
	}
```


### How Has This Been Tested?

- [x] full build project
- [x] self-tested

<img width="644" alt="image" src="https://github.com/openGemini/openGemini/assets/22270117/39fa49ec-0f3c-4f3b-bebf-714eb9665680">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
