### PR TITLE
fix: continuous query print logs too often

### DIFF
--- a/services/continuousquery/service.go
+++ b/services/continuousquery/service.go
@@ -137,7 +137,7 @@ func (s *Service) getCQLease() map[string]struct{} {
 		s.logger.Error("cq service get cq lease failed", zap.Error(err))
 		return nil
 	}
-	s.logger.Info("get continuous query lease info", zap.Strings("cq names", cqNames))
+	s.logger.Debug("get continuous query lease info", zap.Strings("cq names", cqNames))
 
 	var cqLease = make(map[string]struct{}, len(cqNames))
 	for _, cqName := range cqNames {
@@ -175,7 +175,7 @@ func (s *Service) getContinuousQueries() []*ContinuousQuery {
 			s.reportInterval = continuousQueries[i].reportInterval
 		}
 	}
-	s.logger.Info("get newly continuous query lease", zap.Int("CQ numbers", len(continuousQueries)))
+	s.logger.Debug("get newly continuous query lease", zap.Int("CQ numbers", len(continuousQueries)))
 	return continuousQueries
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->


### What is changed and how it works?

Continuous query print logs too often. Change the logging level to debug.

### How Has This Been Tested?

- [x] Test A
- [x] Test B
- [x] Test cases to be added
- [x] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
