### PR TITLE
fix: not rotate profile files when enable sherlock

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -31,7 +31,7 @@ PACKAGES_OPEN_GEMINI_TESTS ?= $$($(PACKAGE_LIST_OPEN_GEMINI_TESTS))
 
 COPYRIGHT_EXCEPT  := "open_src|tests|lib/netstorage/data/data.pb.go|lib/statisticsPusher/statistics/handler_statistics.go|app/ts-meta/meta/snapshot.go|engine/index/tsi/tag_filters.go|engine/index/tsi/tag_filter_test.go|engine/index/mergeindex/item.go|lib/config/openGemini_dir.go"
 COPYRIGHT_GOFILE  := $$(find . -name '*.go' | grep -vE $(COPYRIGHT_EXCEPT))
-COPYRIGHT_HEADER  := "Copyright 2022|2023 Huawei Cloud Computing Technologies Co., Ltd."
+COPYRIGHT_HEADER  := "Copyright 2022|2023|2024 Huawei Cloud Computing Technologies Co., Ltd."
 
 STYLE_CHECK_EXCEPT :=  "open_src/github.com/hashicorp"
 STYLE_CHECK_GOFILE  := $$(find . -name '*.go' | grep -vE $(STYLE_CHECK_EXCEPT))

--- a/config/openGemini.conf
+++ b/config/openGemini.conf
@@ -245,6 +245,8 @@
   # collect-interval = "10s"
   # cpu-max-limit = 95
   # dump-path = "/tmp"
+  # max-num = 32
+  # max-age = 7
 # [sherlock.cpu]
   # enable = false
   # min = 30

--- a/lib/config/sherlock.go
+++ b/lib/config/sherlock.go
@@ -19,13 +19,16 @@ package config
 import (
 	"fmt"
 	"math"
+	"path/filepath"
 	"time"
 
 	"github.com/influxdata/influxdb/toml"
 )
 
 const (
-	DefaultCollectInterval = time.Minute
+	DefaultCollectInterval = 10 * time.Second
+	DefaultSherlockMaxNum  = 32
+	DefaultSherlockMaxAge  = 7 // 7 days
 
 	defaultCPUTriggerMin  = 10 // 10%
 	defaultCPUTriggerDiff = 25 // 25% diff
@@ -46,6 +49,8 @@ type SherlockConfig struct {
 	CollectInterval toml.Duration `toml:"collect-interval"`
 	CPUMaxPercent   toml.Size     `toml:"cpu-max-percent"`
 	DumpPath        string        `toml:"dump-path"`
+	MaxNum          int           `toml:"max-num"`
+	MaxAge          int           `toml:"max-age"`
 
 	CPUConfig       typeConfig `toml:"cpu"`
 	MemoryConfig    typeConfig `toml:"memory"`
@@ -66,7 +71,9 @@ func NewSherlockConfig() *SherlockConfig {
 		SherlockEnable:  false,
 		CollectInterval: toml.Duration(DefaultCollectInterval),
 		CPUMaxPercent:   0,
-		DumpPath:        openGeminiDir(),
+		DumpPath:        filepath.Join(openGeminiDir(), "sherlock"),
+		MaxNum:          DefaultSherlockMaxNum,
+		MaxAge:          DefaultSherlockMaxAge,
 		CPUConfig: typeConfig{
 			Enable:   false,
 			Min:      defaultCPUTriggerMin,

--- a/lib/sherlock/options.go
+++ b/lib/sherlock/options.go
@@ -30,16 +30,22 @@ const (
 	Goroutine
 )
 
+func (t configureType) string() string {
+	switch t {
+	case CPU:
+		return "cpu"
+	case Memory:
+		return "mem"
+	case Goroutine:
+		return "goroutine"
+	default:
+		return "unknown"
+	}
+}
+
 // check type to profile name, just align to pprof
 var type2name = map[configureType]string{
 	Memory:    "heap",
-	CPU:       "cpu",
-	Goroutine: "goroutine",
-}
-
-// check type to check name
-var check2name = map[configureType]string{
-	Memory:    "mem",
 	CPU:       "cpu",
 	Goroutine: "goroutine",
 }
@@ -62,6 +68,8 @@ type options struct {
 const (
 	defaultInterval = 10 * time.Second
 	defaultDumpPath = "/tmp"
+	defaultMaxNum   = 32
+	defaultMaxAge   = 7
 )
 
 func newOptions() *options {
@@ -73,6 +81,8 @@ func newOptions() *options {
 		MonitorInterval: defaultInterval,
 		dumpOptions: &dumpOptions{
 			dumpPath: defaultDumpPath,
+			maxNum:   defaultMaxNum,
+			maxAge:   defaultMaxAge,
 		},
 	}
 	return opts
@@ -101,6 +111,21 @@ func WithSavePath(dumpPath string) Option {
 	}
 }
 
+// WithMaxNum set the maximum number of old profile files to retain
+func WithMaxNum(num int) Option {
+	return func(opts *options) {
+		opts.maxNum = num
+	}
+}
+
+// WithMaxAge set the maximum number of days to retain old profile files based on the
+// timestamp encoded in their filename
+func WithMaxAge(age int) Option {
+	return func(opts *options) {
+		opts.maxAge = age
+	}
+}
+
 func WithLogger(log *logger.Logger) Option {
 	return func(opts *options) {
 		opts.logger = log
@@ -110,6 +135,8 @@ func WithLogger(log *logger.Logger) Option {
 // dumpOptions contains configuration about dump file.
 type dumpOptions struct {
 	dumpPath string
+	maxNum   int
+	maxAge   int
 }
 
 type commonOption struct {

--- a/lib/sherlock/profiles.go
+++ b/lib/sherlock/profiles.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sherlock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// rotateProfilesFiles rotates profile files, ensure that the number of files does not exceed the threshold, and delete expired files
+func rotateProfilesFiles(directory string, dumpType configureType, maxNum int, maxAge time.Duration) error {
+	files, err := listProfileFiles(directory, dumpType)
+	if err != nil {
+		return err
+	}
+	// processing expired files
+	err = deleteOldProfileFiles(files, directory, maxAge)
+	if err != nil {
+		return err
+	}
+
+	// processing redundant files
+	err = deleteRedundantProfileFiles(files, directory, maxNum)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// listProfileFiles gets a list of profile files in the directory
+func listProfileFiles(directory string, dumpType configureType) ([]os.FileInfo, error) {
+	var filename string
+	switch dumpType {
+	case CPU:
+		filename = filepath.Join(directory, allCpuProfiles)
+	case Memory:
+		filename = filepath.Join(directory, allMemProfiles)
+	case Goroutine:
+		filename = filepath.Join(directory, allGrtProfiles)
+	default:
+		return nil, fmt.Errorf("do not support type: %s", dumpType.string())
+	}
+
+	files, err := filepath.Glob(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list profile files: %v", err)
+	}
+
+	var fileInfos []os.FileInfo
+	for _, file := range files {
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			continue
+		}
+		fileInfos = append(fileInfos, fileInfo)
+	}
+
+	return fileInfos, nil
+}
+
+// deleteOldProfileFiles deletes Profile files that are older than the specified time
+func deleteOldProfileFiles(files []os.FileInfo, directory string, maxAge time.Duration) error {
+	currentTime := time.Now()
+	for _, file := range files {
+		if currentTime.Sub(file.ModTime()) > maxAge {
+			// file expired, delete it
+			filePath := filepath.Join(directory, file.Name())
+			_ = os.Remove(filePath) //nolint
+		}
+	}
+	return nil
+}
+
+// deleteRedundantProfileFiles deletes too many files
+func deleteRedundantProfileFiles(files []os.FileInfo, directory string, maxNum int) error {
+	// if the number of files exceeds the threshold, delete the oldest file
+	if len(files) > maxNum {
+		sort.Sort(byModTime(files))
+		filesToDelete := files[:len(files)-maxNum]
+
+		for _, file := range filesToDelete {
+			filePath := filepath.Join(directory, file.Name())
+			_ = os.Remove(filePath) //nolint
+		}
+	}
+	return nil
+}
+
+// byModTime Used to sort files by modification time
+type byModTime []os.FileInfo
+
+func (s byModTime) Len() int {
+	return len(s)
+}
+
+func (s byModTime) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byModTime) Less(i, j int) bool {
+	return s[i].ModTime().Before(s[j].ModTime())
+}

--- a/lib/sherlock/profiles_test.go
+++ b/lib/sherlock/profiles_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sherlock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRotateProfilesFiles(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create some test profile files
+	createTestProfileFile(tempDir, "ts-store.cpu.1.pb.gz", time.Now().Add(-48*time.Hour)) // Expired
+	createTestProfileFile(tempDir, "ts-store.cpu.2.pb.gz", time.Now().Add(-24*time.Hour)) // Expired
+	createTestProfileFile(tempDir, "ts-store.cpu.3.pb.gz", time.Now())                    // Not expired
+	createTestProfileFile(tempDir, "ts-store.cpu.4.pb.gz", time.Now())                    // Not expired
+	createTestProfileFile(tempDir, "ts-store.cpu.5.pb.gz", time.Now())                    // Not expired
+
+	// Test rotateProfilesFiles
+	err := rotateProfilesFiles(tempDir, CPU, 3, 36*time.Hour)
+	assert.NoError(t, err, "Error rotating profile files")
+
+	// Validate the result
+	files, err := listProfileFiles(tempDir, CPU)
+	assert.NoError(t, err, "Error listing profile files")
+	// Expecting 3 files to remain after rotation
+	assert.Equal(t, 3, len(files), "Expected 3 profile files after rotation")
+}
+
+// createTestProfileFile creates a test profile file with the specified modification time
+func createTestProfileFile(directory, filename string, modTime time.Time) {
+	filePath := filepath.Join(directory, filename)
+	file, err := os.Create(filePath)
+	if err != nil {
+		panic(err)
+	}
+	file.Close()
+
+	// Set the file's modification time
+	err = os.Chtimes(filePath, modTime, modTime)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/lib/sherlock/report_test.go
+++ b/lib/sherlock/report_test.go
@@ -18,24 +18,72 @@ package sherlock
 
 import (
 	"bytes"
-	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_createAndGetFileInfo(t *testing.T) {
+func Test_createAndGetFileInfo_CPU(t *testing.T) {
 	tmpDir := t.TempDir()
-	_ = os.RemoveAll(tmpDir)
-	fi, filename, err := createAndGetFileInfo(tmpDir, CPU)
-	require.NoError(t, err)
+	dumpOpt := &dumpOptions{
+		dumpPath: tmpDir,
+		maxNum:   1,
+		maxAge:   1,
+	}
+	fi, filename, err := createAndGetFileInfo(dumpOpt, CPU)
+	assert.NoError(t, err)
 	defer fi.Close()
-	require.Equal(t, true, strings.Contains(filename, tmpDir))
+	assert.Equal(t, true, strings.Contains(filename, tmpDir))
 	file := path.Base(filename)
-	require.Equal(t, true, strings.Contains(file, "cpu"))
-	require.Equal(t, true, strings.HasSuffix(file, "pb.gz"))
+	assert.Contains(t, file, "cpu")
+	assert.Contains(t, file, "pb.gz")
+
+	fi2, filename, err := createAndGetFileInfo(dumpOpt, CPU)
+	assert.NoError(t, err)
+	defer fi2.Close()
+	assert.Equal(t, true, strings.Contains(filename, tmpDir))
+	file = path.Base(filename)
+	assert.Contains(t, file, "cpu")
+	assert.Contains(t, file, "pb.gz")
+
+	files, err := filepath.Glob(filepath.Join(tmpDir, allCpuProfiles))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(files))
+}
+
+func Test_createAndGetFileInfo_Mem(t *testing.T) {
+	tmpDir := t.TempDir()
+	dumpOpt := &dumpOptions{
+		dumpPath: tmpDir,
+		maxNum:   1,
+		maxAge:   0,
+	}
+	fi, filename, err := createAndGetFileInfo(dumpOpt, Memory)
+	assert.NoError(t, err)
+	defer fi.Close()
+	assert.Equal(t, true, strings.Contains(filename, tmpDir))
+	file := path.Base(filename)
+	assert.Contains(t, file, "mem")
+	assert.Contains(t, file, "pb.gz")
+}
+
+func Test_createAndGetFileInfo_Goroutine(t *testing.T) {
+	tmpDir := t.TempDir()
+	dumpOpt := &dumpOptions{
+		dumpPath: tmpDir,
+		maxNum:   1,
+		maxAge:   0,
+	}
+	fi, filename, err := createAndGetFileInfo(dumpOpt, Goroutine)
+	assert.NoError(t, err)
+	defer fi.Close()
+	assert.Equal(t, true, strings.Contains(filename, tmpDir))
+	file := path.Base(filename)
+	assert.Contains(t, file, "goroutine")
+	assert.Contains(t, file, "pb.gz")
 }
 
 func Test_writeFile(t *testing.T) {
@@ -46,8 +94,8 @@ func Test_writeFile(t *testing.T) {
 	filename, err := writeFile(buf, Memory, &dumpOptions{
 		dumpPath: tmpDir,
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	file := path.Base(filename)
-	require.Equal(t, true, strings.Contains(file, "mem"))
-	require.Equal(t, true, strings.HasSuffix(file, "pb.gz"))
+	assert.Contains(t, file, "mem")
+	assert.Contains(t, file, "pb.gz")
 }

--- a/lib/sherlock/sherlock.go
+++ b/lib/sherlock/sherlock.go
@@ -250,7 +250,7 @@ func (s *Sherlock) cpuProfile(curCPUUsage int, c commonOption) bool {
 	match, _ := matchRule(s.cpuStats, curCPUUsage, c.TriggerMin, c.TriggerDiff, c.TriggerAbs)
 	if !match {
 		// let user know why this should not dump
-		s.opts.logger.Info("[Sherlock] not match cpu dump rule",
+		s.opts.logger.Debug("[Sherlock] not match cpu dump rule",
 			zap.Int("config_min", c.TriggerMin), zap.Int("config_diff", c.TriggerDiff), zap.Int("config_abs", c.TriggerAbs),
 			zap.Int("current", curCPUUsage), zap.Ints("previous", s.cpuStats.sequentialData()))
 		return false
@@ -260,7 +260,7 @@ func (s *Sherlock) cpuProfile(curCPUUsage int, c commonOption) bool {
 		zap.Int("config_min", c.TriggerMin), zap.Int("config_diff", c.TriggerDiff), zap.Int("config_abs", c.TriggerAbs),
 		zap.Int("current", curCPUUsage), zap.Ints("previous", s.cpuStats.sequentialData()))
 
-	bf, filename, err := createAndGetFileInfo(s.opts.dumpPath, CPU)
+	bf, filename, err := createAndGetFileInfo(s.opts.dumpOptions, CPU)
 	if err != nil {
 		s.opts.logger.Error("[Sherlock] failed to create cpu profile file", zap.Error(err))
 		return false
@@ -335,7 +335,7 @@ func (s *Sherlock) writeProfileDataToFile(data bytes.Buffer, dumpType configureT
 		s.opts.logger.Error("[Sherlock] failed to write profile to file", zap.String("filename", filename), zap.Error(err))
 		return
 	}
-	s.opts.logger.Info("[Sherlock] profile write to file successfully", zap.String("type", check2name[dumpType]), zap.String("filename", filename))
+	s.opts.logger.Info("[Sherlock] profile write to file successfully", zap.String("type", dumpType.string()), zap.String("filename", filename))
 }
 
 func (s *Sherlock) getMemoryLimit() (uint64, error) {

--- a/services/sherlock/service.go
+++ b/services/sherlock/service.go
@@ -53,6 +53,8 @@ func newService(c *config.SherlockConfig) *Service {
 		sl.WithMonitorInterval(time.Duration(c.CollectInterval)),
 		sl.WithCPUMax(int(c.CPUMaxPercent)),
 		sl.WithSavePath(c.DumpPath),
+		sl.WithMaxNum(c.MaxNum),
+		sl.WithMaxAge(c.MaxAge),
 		sl.WithCPURule(int(c.CPUConfig.Min), int(c.CPUConfig.Diff), int(c.CPUConfig.Abs), time.Duration(c.CPUConfig.CoolDown)),
 		sl.WithMemRule(int(c.MemoryConfig.Min), int(c.MemoryConfig.Diff), int(c.MemoryConfig.Abs), time.Duration(c.MemoryConfig.CoolDown)),
 		sl.WithGrtRule(int(c.GoroutineConfig.Min), int(c.GoroutineConfig.Diff), int(c.GoroutineConfig.Abs), int(c.GoroutineConfig.Max), time.Duration(c.GoroutineConfig.CoolDown)),


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #449

### What is changed and how it works?

There are two config items:

```
max-num: kept the max number of the profile files
max-age: kept the max days of the profile files
```

Determine whether to age old files when creating new files.

### How Has This Been Tested?

- [x] unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
