### PR TITLE
fix: updatesherlock rule

### DIFF
--- a/lib/sherlock/rule.go
+++ b/lib/sherlock/rule.go
@@ -19,15 +19,17 @@ package sherlock
 type RuleType uint8
 
 const (
-	RuleCurLessMin RuleType = iota
+	RuleHistoryLessMin RuleType = iota
 	RuleCurlGreaterMin
 	RuleCurGreaterAbs
 	RuleDiff
 )
 
 func matchRule(history *MetricCircle, curVal, ruleMin, ruleDiff, ruleAbs int) (bool, RuleType) {
-	if curVal < ruleMin {
-		return false, RuleCurLessMin
+	for i := range history.data {
+		if history.data[i] < ruleMin {
+			return false, RuleHistoryLessMin
+		}
 	}
 
 	if curVal > ruleAbs {

--- a/lib/sherlock/rule_test.go
+++ b/lib/sherlock/rule_test.go
@@ -27,17 +27,18 @@ func Test_matchRule(t *testing.T) {
 	for i := 20; i < 50; i += 5 {
 		metrics.push(i)
 	}
-	// < ruleMin
-	match, rule := matchRule(metrics, 2, 20, 25, 80)
-	require.Equal(t, false, match)
-	require.Equal(t, RuleCurLessMin, rule)
 
-	// > ruleAbs
+	// some historical record < ruleMin
+	match, rule := matchRule(metrics, 35, 30, 25, 80)
+	require.Equal(t, false, match)
+	require.Equal(t, RuleHistoryLessMin, rule)
+
+	// curVal > ruleAbs
 	match, rule = matchRule(metrics, 99, 20, 25, 80)
 	require.Equal(t, true, match)
 	require.Equal(t, RuleCurGreaterAbs, rule)
 
-	// > ruleDiff
+	// curVal > ruleDiff
 	match, rule = matchRule(metrics, 60, 20, 25, 80)
 	require.Equal(t, true, match)
 	require.Equal(t, RuleDiff, rule)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #451

### What is changed and how it works?

Updated sherlock exceptions matching rules when detecting cpu, mem and goroutine.
Changed from only comparing current value with rule-min to comparing historical 10 values with rule-min

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules