### PR TITLE
fix: ts-store panic on LoadIdTimes #477

### DIFF
--- a/engine/immutable/tssp_file.go
+++ b/engine/immutable/tssp_file.go
@@ -926,6 +926,10 @@ func (r *tsspFileReader) LoadComponents() error {
 }
 
 func (r *tsspFileReader) LoadIdTimes(isOrder bool, p *IdTimePairs) error {
+	if r.r == nil {
+		return nil
+	}
+
 	var buf []byte
 	var err error
 

--- a/engine/immutable/tssp_reader.go
+++ b/engine/immutable/tssp_reader.go
@@ -604,7 +604,9 @@ func (f *tsspFile) Close() error {
 
 	f.Unref()
 	f.wg.Wait()
+	f.mu.Lock()
 	_ = f.reader.Close()
+	f.mu.Unlock()
 
 	if memSize > 0 && !tmp {
 		if order {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #477 

### What is changed and how it works?

The LoadIdTimes method is not mutually exclusive with the Close method. When the file is closed and the LoadIdtimes method is called, a null pointer panic will occur.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
