### PR TITLE
fix: ts-store panic on LoadIdTimes #477

### DIFF
--- a/engine/immutable/tssp_file.go
+++ b/engine/immutable/tssp_file.go
@@ -926,6 +926,10 @@ func (r *tsspFileReader) LoadComponents() error {
 }
 
 func (r *tsspFileReader) LoadIdTimes(isOrder bool, p *IdTimePairs) error {
+	if r.r == nil {
+		return nil
+	}
+
 	var buf []byte
 	var err error
 

--- a/engine/immutable/tssp_reader.go
+++ b/engine/immutable/tssp_reader.go
@@ -604,7 +604,10 @@ func (f *tsspFile) Close() error {
 
 	f.Unref()
 	f.wg.Wait()
+
+	f.mu.Lock()
 	_ = f.reader.Close()
+	f.mu.Unlock()
 
 	if memSize > 0 && !tmp {
 		if order {

--- a/engine/immutable/tssp_reader_test.go
+++ b/engine/immutable/tssp_reader_test.go
@@ -2253,3 +2253,29 @@ func TestQueryFileCache1(t *testing.T) {
 	fileCache.Get()
 	fileCache.GetCap()
 }
+
+func TestLoadIdTimesFromClosedFile(t *testing.T) {
+	dir := t.TempDir()
+	conf := NewTsStoreConfig()
+	tier := uint64(util.Hot)
+	lockPath := ""
+	store := NewTableStore(dir, &lockPath, &tier, false, conf)
+	store.SetImmTableType(config.TSSTORE)
+
+	fileSeq := uint64(1)
+	var idMinMax, tmMinMax MinMax
+	ids, data := genMemTableData(1, 10, 100, &idMinMax, &tmMinMax)
+	fileName := NewTSSPFileName(fileSeq, 0, 0, 0, true, &lockPath)
+	msb := NewMsBuilder(dir, "mst", &lockPath, conf, 10, fileName, 0, store.Sequencer(), 2, config.TSSTORE)
+	for _, id := range ids {
+		require.NoError(t, msb.WriteData(id, data[id]))
+	}
+	store.AddTable(msb, true, false)
+
+	fs := store.tableFiles("mst", true)
+	require.NotEmpty(t, fs)
+
+	f := fs.Files()[0]
+	require.NoError(t, f.Close())
+	require.NoError(t, f.LoadIdTimes(&IdTimePairs{}))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number:  fix #477 

### What is changed and how it works?

The LoadIdTimes method is not mutually exclusive with the Close method. When the file is closed and the LoadIdtimes method is called, a null pointer panic will occur.

