### PR TITLE
fix: data race in EachDBNodes

### DIFF
--- a/coordinator/meta_executor_test.go
+++ b/coordinator/meta_executor_test.go
@@ -33,13 +33,13 @@ func TestMetaExecutor(t *testing.T) {
 	defer me.Close()
 
 	me.SetTimeOut(time.Second)
-	err := me.EachDBNodes("db_not_exists", func(nodeID uint64, pts []uint32, hasErr *bool) error { return nil })
+	err := me.EachDBNodes("db_not_exists", func(nodeID uint64, pts []uint32) error { return nil })
 	assert.True(t, errno.Equal(err, errno.DatabaseNotFound))
 
-	err = me.EachDBNodes("dbpt_not_exists", func(nodeID uint64, pts []uint32, hasErr *bool) error { return nil })
+	err = me.EachDBNodes("dbpt_not_exists", func(nodeID uint64, pts []uint32) error { return nil })
 	assert.True(t, errno.Equal(err, errno.DatabaseNotFound))
 
-	err = me.EachDBNodes("db0", func(nodeID uint64, pts []uint32, hasErr *bool) error { return nil })
+	err = me.EachDBNodes("db0", func(nodeID uint64, pts []uint32) error { return nil })
 	assert.NoError(t, err)
 
 }

--- a/coordinator/show_tag_keys_executor.go
+++ b/coordinator/show_tag_keys_executor.go
@@ -57,10 +57,7 @@ func (e *ShowTagKeysExecutor) Execute(stmt *influxql.ShowTagKeysStatement) (nets
 	lock := new(sync.Mutex)
 
 	mapMstMap := make(map[string]map[string]struct{})
-	err = e.me.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err = e.me.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32) error {
 		/*
 			ShowTagKeys return
 				{"mst,tag1,tag2,tag3","mst,tag2,tag3"}

--- a/coordinator/show_tag_values_executor.go
+++ b/coordinator/show_tag_values_executor.go
@@ -192,18 +192,12 @@ func (e *ShowTagValuesExecutor) queryTagValues(q *influxql.ShowTagValuesStatemen
 	var tagValuesSlice TagValuesSlice
 
 	lock := new(sync.Mutex)
-	err = e.me.EachDBNodes(q.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err = e.me.EachDBNodes(q.Database, func(nodeID uint64, pts []uint32) error {
 		s, err := e.store.TagValues(nodeID, q.Database, pts, tagKeys, q.Condition)
 		lock.Lock()
 		defer lock.Unlock()
 		if err != nil {
-			*hasErr = true
 			tagValuesSlice = tagValuesSlice[:0]
-		}
-		if *hasErr {
 			return err
 		}
 		tagValuesSlice = append(tagValuesSlice, s...)

--- a/coordinator/show_tag_values_executor_test.go
+++ b/coordinator/show_tag_values_executor_test.go
@@ -263,17 +263,16 @@ type mockME struct {
 	MetaExecutor
 }
 
-func (m *mockME) EachDBNodes(database string, fn func(nodeID uint64, pts []uint32, hasErr *bool) error) error {
+func (m *mockME) EachDBNodes(database string, fn func(nodeID uint64, pts []uint32) error) error {
 	n := 4
 	wg := sync.WaitGroup{}
 	wg.Add(n)
-	hasErr := false
 	var mu sync.RWMutex
 	errs := make([]error, n)
 	for i := 0; i < n; i++ {
 		go func(nodeID int) {
 			mu.Lock()
-			errs[nodeID] = fn(uint64(nodeID), nil, &hasErr)
+			errs[nodeID] = fn(uint64(nodeID), nil)
 			mu.Unlock()
 			wg.Done()
 		}(i)

--- a/lib/util/lifted/influx/coordinator/statement_executor.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor.go
@@ -1673,18 +1673,13 @@ func (e *StatementExecutor) executeShowSeries(q *influxql.ShowSeriesStatement, c
 	var series []string
 	lock := new(sync.Mutex)
 
-	err = e.MetaExecutor.EachDBNodes(q.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err = e.MetaExecutor.EachDBNodes(q.Database, func(nodeID uint64, pts []uint32) error {
 		arr, err := e.NetStorage.ShowSeries(nodeID, q.Database, pts, names, q.Condition)
 		lock.Lock()
 		defer lock.Unlock()
 		if err != nil {
-			*hasErr = true
 			series = series[:0] // if execute command failed reset res
-		}
-		if !*hasErr {
+		} else {
 			series = append(series, arr...)
 		}
 		return err
@@ -1741,18 +1736,12 @@ func (e *StatementExecutor) showSeriesCardinality(stmt *influxql.ShowSeriesCardi
 	stime := time.Now()
 	var ret meta2.CardinalityInfos
 	lock := new(sync.Mutex)
-	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32) error {
 		mstCardinality, err := e.NetStorage.SeriesCardinality(nodeID, stmt.Database, pts, names, stmt.Condition)
 		lock.Lock()
 		defer lock.Unlock()
 		if err != nil {
-			*hasErr = true
 			ret = ret[:0]
-		}
-		if *hasErr {
 			return err
 		}
 		for i := range mstCardinality {
@@ -1788,18 +1777,12 @@ func (e *StatementExecutor) showSeriesCardinalityWithCondition(stmt *influxql.Sh
 	stime := time.Now()
 	ret := make(map[string]meta2.CardinalityInfos)
 	lock := new(sync.Mutex)
-	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32) error {
 		mstCardinality, err := e.NetStorage.SeriesCardinality(nodeID, stmt.Database, pts, names, stmt.Condition)
 		lock.Lock()
 		defer lock.Unlock()
 		if err != nil {
-			*hasErr = true
 			ret = make(map[string]meta2.CardinalityInfos)
-		}
-		if *hasErr {
 			return err
 		}
 		for i := range mstCardinality {
@@ -1841,18 +1824,12 @@ func (e *StatementExecutor) showSeriesExactCardinality(stmt *influxql.ShowSeries
 	stime := time.Now()
 	ret := make(map[string]uint64)
 	lock := new(sync.Mutex)
-	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32, hasErr *bool) error {
-		if *hasErr {
-			return nil
-		}
+	err := e.MetaExecutor.EachDBNodes(stmt.Database, func(nodeID uint64, pts []uint32) error {
 		tmp, err := e.NetStorage.SeriesExactCardinality(nodeID, stmt.Database, pts, names, stmt.Condition)
 		lock.Lock()
 		defer lock.Unlock()
 		if err != nil {
-			*hasErr = true
 			ret = make(map[string]uint64)
-		}
-		if *hasErr {
 			return err
 		}
 		for name, n := range tmp {


### PR DESCRIPTION
There are two data races in `EachDBNodes`:
- the write of `err` is a data race and could cause a crash when reading the error.
- the read/write of `hasErr` is a data race, though I don't think it will cause severe issues, its usage does not make much sense in a concurrent program.

other minor improvements:
- don't log "retry execute command" before timeout
- refactor to `EachDBNodes` and `IsRetryErrorForPtView`

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
