### PR TITLE
fix: return the error if no field selected

### DIFF
--- a/lib/util/lifted/influx/httpd/handler_logstore.go
+++ b/lib/util/lifted/influx/httpd/handler_logstore.go
@@ -1638,6 +1638,8 @@ func (h *Handler) serveLogQuery(w http.ResponseWriter, r *http.Request, param *Q
 	if err != nil {
 		return nil, nil, status, err
 	}
+	// If an error occurs during the query, an error must be returned to avoid error shielding.
+	q.SetReturnErr(true)
 	epoch := strings.TrimSpace(r.FormValue("epoch"))
 	db := r.FormValue("db")
 	var qDuration *statistics.SQLSlowQueryStatistics


### PR DESCRIPTION

### What is changed and how it works?
When querying fields that are not found in lookkeeper, an error will be reported, and the missing fields will be prompted in the error.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
