### PR TITLE
feat(scan): quick cancel query with proactive manager

### DIFF
--- a/app/operation.go
+++ b/app/operation.go
@@ -117,7 +117,7 @@ func (pm *ProactiveManager) KillQuery(id uint64) {
 		}
 		isExist = true
 		manager.Kill(id)
-		manager.Abort(id)
+		manager.Crash(id)
 		abortSuccess = true
 	}
 	query.VisitManagers(killQueryByIDFn)

--- a/app/ts-store/transport/handler/handler_test.go
+++ b/app/ts-store/transport/handler/handler_test.go
@@ -145,6 +145,8 @@ type mockQuery struct {
 
 func (m *mockQuery) Abort() {}
 
+func (m *mockQuery) Crash() {}
+
 func (m *mockQuery) GetQueryExeInfo() *netstorage.QueryExeInfo {
 	return m.info
 }

--- a/app/ts-store/transport/handler/select_test.go
+++ b/app/ts-store/transport/handler/select_test.go
@@ -238,6 +238,12 @@ func TestCreateSerfInstance(t *testing.T) {
 	require.NoError(t, h.Process())
 
 	h = NewSelect(store, resp, req)
+	h.SetCrashHook(func() {})
+	h.Crash()
+	h.SetCrashHook(func() {})
+	require.NoError(t, h.Process())
+
+	h = NewSelect(store, resp, req)
 	require.NotEmpty(t, h.execute(context.Background(), nil))
 	h.Abort()
 	require.NoError(t, h.execute(context.Background(), &executor.PipelineExecutor{}))

--- a/app/ts-store/transport/query/manager.go
+++ b/app/ts-store/transport/query/manager.go
@@ -29,6 +29,7 @@ const (
 
 type IQuery interface {
 	Abort()
+	Crash()
 	GetQueryExeInfo() *netstorage.QueryExeInfo
 }
 
@@ -138,6 +139,17 @@ func (qm *Manager) Abort(qid uint64) {
 	h := qm.Get(qid)
 	if h != nil {
 		h.Abort()
+	}
+}
+
+func (qm *Manager) Crash(qid uint64) {
+	qm.abortedMu.Lock()
+	qm.aborted[qid] = time.Now()
+	qm.abortedMu.Unlock()
+
+	h := qm.Get(qid)
+	if h != nil {
+		h.Crash()
 	}
 }
 

--- a/app/ts-store/transport/query/manager_test.go
+++ b/app/ts-store/transport/query/manager_test.go
@@ -75,6 +75,8 @@ func (m *mockQuery) Abort() {
 
 }
 
+func (m *mockQuery) Crash() {}
+
 func (m *mockQuery) GetQueryExeInfo() *netstorage.QueryExeInfo {
 	return m.info
 }

--- a/engine/column_store_reader_test.go
+++ b/engine/column_store_reader_test.go
@@ -344,7 +344,7 @@ func TestColumnStoreReaderFunctions(t *testing.T) {
 	assert2.Equal(t, reader.GetOutputNumber(nil), 0)
 	assert2.Equal(t, reader.GetInputNumber(nil), 0)
 	reader.sendChunk(nil)
-	assert2.Equal(t, reader.closedCount, int64(1))
+	assert2.Equal(t, *(reader.closedSignal), int32(1))
 }
 
 type MockStoreEngine struct {

--- a/engine/executor/rpc_message_test.go
+++ b/engine/executor/rpc_message_test.go
@@ -188,6 +188,10 @@ func (c *RPCServer) Abort() {
 	fmt.Println("aborted")
 }
 
+func (c *RPCServer) Crash() {
+	fmt.Println("crashed")
+}
+
 type RPCAbort struct {
 }
 

--- a/engine/immutable/location.go
+++ b/engine/immutable/location.go
@@ -271,6 +271,9 @@ func (l *Location) readData(filterOpts *FilterOptions, dst, filterRec *record.Re
 	}
 
 	for rec == nil && l.hasNext() {
+		if l.ctx.isAborted() {
+			return nil, oriRowCount, nil
+		}
 		if (!l.ctx.tr.Overlaps(l.getCurSegMinMax())) ||
 			(!l.overlapsForRowFilter(filterOpts.rowFilters)) {
 			l.nextSegment(false)


### PR DESCRIPTION
### What is changed and how it works?
When the memory exceeds a certain threshold, the crash method is used to quickly interrupt the query and push each executor to exit quickly.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
