### PR TITLE
perf: allocate Record as required

### DIFF
--- a/engine/mutable/table.go
+++ b/engine/mutable/table.go
@@ -69,11 +69,9 @@ type WriteChunk struct {
 	UnOrderWriteRec WriteRec
 }
 
-func (chunk *WriteChunk) Init(sid uint64, schema []record.Field) {
+func (chunk *WriteChunk) Init(sid uint64) {
 	chunk.Sid = sid
 	chunk.LastFlushTime = math.MinInt64
-	chunk.OrderWriteRec.init(schema)
-	chunk.UnOrderWriteRec.init(schema)
 }
 
 func (chunk *WriteChunk) SortRecordNoLock(hlp *record.ColumnSortHelper) {
@@ -195,7 +193,7 @@ func (msi *MsInfo) CreateChunk(sid uint64) (*WriteChunk, bool) {
 	chunk, ok := msi.sidMap[sid]
 	if !ok {
 		chunk = msi.allocChunk()
-		chunk.Init(sid, msi.Schema)
+		chunk.Init(sid)
 		msi.sidMap[sid] = chunk
 	}
 	msi.mu.Unlock()

--- a/engine/mutable/ts_table.go
+++ b/engine/mutable/ts_table.go
@@ -196,6 +196,10 @@ func (t *tsMemTableImpl) appendFields(table *MemTable, msInfo *MsInfo, chunk *Wr
 		writeRec = &chunk.UnOrderWriteRec
 	}
 
+	if writeRec.rec == nil {
+		writeRec.init(msInfo.Schema)
+	}
+
 	sameSchema := checkSchemaIsSame(writeRec.rec.Schema, fields)
 	if !sameSchema && !writeRec.schemaCopyed {
 		copySchema := record.Schemas{}


### PR DESCRIPTION
Optimized for memory:
1. allocate the Record when required

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
