### PR TITLE
chore: replace 'strings.Compare' and 'ioutil'

### DIFF
--- a/app/ts-meta/meta/handler.go
+++ b/app/ts-meta/meta/handler.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -218,7 +218,7 @@ func (h *httpHandler) getOtherStat(errorMap map[string]string, status map[string
 				continue
 			}
 
-			b, err := ioutil.ReadAll(resp.Body)
+			b, err := io.ReadAll(resp.Body)
 			defer util.MustClose(resp.Body)
 			if err != nil {
 				errorMap["Error"] = fmt.Sprintf("%s", err)

--- a/app/ts-meta/meta/meta_util_test.go
+++ b/app/ts-meta/meta/meta_util_test.go
@@ -19,7 +19,7 @@ package meta
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
@@ -240,7 +240,7 @@ func (h *MockHandler) servePeers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *MockHandler) serveJoin(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		h.httpError(err, w, http.StatusInternalServerError)
 		return

--- a/app/ts-meta/meta/store_fsm.go
+++ b/app/ts-meta/meta/store_fsm.go
@@ -19,7 +19,6 @@ package meta
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"time"
 
@@ -875,7 +874,7 @@ func (fsm *storeFSM) applyUpdatePtVersionCommand(cmd *proto2.Command) interface{
 }
 
 func (fsm *storeFSM) Restore(r io.ReadCloser) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/app/ts-meta/meta/store_test.go
+++ b/app/ts-meta/meta/store_test.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -269,7 +268,7 @@ func generateData(ms *meta.MetaService, db, rp, mst string, shardKeyN int, value
 				}
 				tagValue := "host_" + strconv.Itoa(idx)
 				shardKeyAndValue := shardKey.ShardKey[0] + "=" + tagValue
-				if strings.Compare(shardKeyAndValue, splitPoint) < 0 {
+				if shardKeyAndValue < splitPoint {
 					continue
 				}
 				sh := sg.DestShard(shardKeyAndValue)

--- a/app/ts-monitor/collector/query.go
+++ b/app/ts-monitor/collector/query.go
@@ -19,7 +19,7 @@ package collector
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -135,11 +135,11 @@ func (q *QueryMetric) queryExecute(db, cmd string) ([]byte, error) {
 		resp, err := q.Client.Do(req)
 		if err == nil {
 			if resp.StatusCode == http.StatusOK {
-				bytesBody, _ = ioutil.ReadAll(resp.Body)
+				bytesBody, _ = io.ReadAll(resp.Body)
 				_ = resp.Body.Close()
 				break
 			}
-			bytesBody, _ = ioutil.ReadAll(resp.Body)
+			bytesBody, _ = io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
 		}
 		tries++

--- a/app/ts-monitor/collector/report.go
+++ b/app/ts-monitor/collector/report.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -210,7 +209,7 @@ func (rb *ReportJob) retryEver(url string, headers http.Header, buf string, http
 				_ = resp.Body.Close()
 				break
 			} else {
-				bytesBody, _ = ioutil.ReadAll(resp.Body)
+				bytesBody, _ = io.ReadAll(resp.Body)
 				_ = resp.Body.Close()
 			}
 		} else if checkConnectionError(err) {

--- a/coordinator/subscriber.go
+++ b/coordinator/subscriber.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -63,7 +63,7 @@ func (c *HTTPClient) Send(db, rp string, lineProtocol []byte) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/coordinator/subscriber_test.go
+++ b/coordinator/subscriber_test.go
@@ -19,7 +19,7 @@ package coordinator
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -307,7 +307,7 @@ func TestSendWriteRequest(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/write", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wr := Request{db: r.URL.Query().Get("db"), rp: r.URL.Query().Get("rp")}
-		wr.lineProtocol, _ = ioutil.ReadAll(r.Body)
+		wr.lineProtocol, _ = io.ReadAll(r.Body)
 		ch <- wr
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/engine/executor/spdy/multiplexed_connection.go
+++ b/engine/executor/spdy/multiplexed_connection.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -307,7 +306,7 @@ func (c *MultiplexedConnection) discardData(hdr []byte) error {
 		if err := c.setReadDeadline(); err != nil {
 			return err
 		}
-		if _, err := io.CopyN(ioutil.Discard, c.input, int64(length)); err != nil {
+		if _, err := io.CopyN(io.Discard, c.input, int64(length)); err != nil {
 			return err
 		}
 	}

--- a/engine/mutable/table.go
+++ b/engine/mutable/table.go
@@ -18,8 +18,8 @@ package mutable
 
 import (
 	"errors"
-	"io/ioutil"
 	"math"
+	"os"
 	"sort"
 	"strconv"
 	"sync"
@@ -266,12 +266,12 @@ type MTable interface {
 func StoreMstRowCount(countFile string, rowCount int) error {
 	str := strconv.Itoa(rowCount)
 
-	return ioutil.WriteFile(countFile, []byte(str), 0640)
+	return os.WriteFile(countFile, []byte(str), 0640)
 }
 
 // LoadMstRowCount is used to load the rowcount value for mst-level pre-aggregation.
 func LoadMstRowCount(countFile string) (int, error) {
-	data, err := ioutil.ReadFile(countFile)
+	data, err := os.ReadFile(countFile)
 	if err != nil {
 		return 0, err
 	}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -19,8 +19,8 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"strings"
 
@@ -92,7 +92,7 @@ func Parse(conf Config, path string) error {
 }
 
 func fromTomlFile(c Config, p string) error {
-	content, err := ioutil.ReadFile(path.Clean(p))
+	content, err := os.ReadFile(path.Clean(p))
 	if err != nil {
 		return err
 	}

--- a/lib/fileops/file_ops.go
+++ b/lib/fileops/file_ops.go
@@ -19,6 +19,7 @@ package fileops
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -112,7 +113,7 @@ type VFS interface {
 	MkdirAll(path string, perm os.FileMode, opt ...FSOption) error
 	// ReadDir reads the directory named by dirname and returns
 	// a list of fs.FileInfo for the directory's contents, sorted by filename.
-	ReadDir(dirname string) ([]os.FileInfo, error)
+	ReadDir(dirname string) ([]fs.FileInfo, error)
 	// Glob returns the names of all files matching pattern or nil if there is no matching file.
 	Glob(pattern string) ([]string, error)
 	// RenameFile renames (moves) oldPath to newPath.
@@ -204,7 +205,7 @@ func MkdirAll(path string, perm os.FileMode, opt ...FSOption) error {
 
 // ReadDir reads the directory named by dirname and returns
 // a list of fs.FileInfo for the directory's contents, sorted by filename.
-func ReadDir(dirname string) ([]os.FileInfo, error) {
+func ReadDir(dirname string) ([]fs.FileInfo, error) {
 	t := GetFsType(dirname)
 	return GetFs(t).ReadDir(dirname)
 }

--- a/lib/fileops/os_fs.go
+++ b/lib/fileops/os_fs.go
@@ -201,11 +201,11 @@ func (vfs) Stat(name string) (os.FileInfo, error) {
 }
 
 func (vfs) WriteFile(filename string, data []byte, perm os.FileMode, _ ...FSOption) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func (vfs) ReadFile(filename string, _ ...FSOption) ([]byte, error) {
-	return ioutil.ReadFile(path.Clean(filename))
+	return os.ReadFile(path.Clean(filename))
 }
 
 func (vfs) CreateTime(name string) (*time.Time, error) {

--- a/lib/fileops/os_fs.go
+++ b/lib/fileops/os_fs.go
@@ -22,7 +22,7 @@ package fileops
 
 import (
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -184,8 +184,20 @@ func (vfs) MkdirAll(path string, perm os.FileMode, _ ...FSOption) error {
 	return os.MkdirAll(path, perm)
 }
 
-func (vfs) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+func (vfs) ReadDir(dirname string) ([]fs.FileInfo, error) {
+	entries, err := os.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]fs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
 }
 
 func (vfs) Glob(pattern string) ([]string, error) {

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -18,11 +18,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -1680,7 +1680,7 @@ func (c *Client) isSimilarToUserName(s, user string) bool {
 
 func (c *Client) isInWeakPwdDict(s string) (bool, error) {
 	filename := c.weakPwdPath
-	content, err := ioutil.ReadFile(path.Clean(filename))
+	content, err := os.ReadFile(path.Clean(filename))
 	if err != nil {
 		return false, err
 	}

--- a/lib/metaclient/node.go
+++ b/lib/metaclient/node.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metaclient
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,7 +60,7 @@ func (n *Node) LoadLogicalClock() error {
 	defer util.MustClose(file)
 
 	var content []byte
-	content, err = ioutil.ReadAll(file)
+	content, err = io.ReadAll(file)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (n *Node) LoadLogicalClock() error {
 	}
 
 	LogicClock = uint64(clock)
-	if err = ioutil.WriteFile(clockPath, []byte(strconv.Itoa(clock+1)), 0600); err != nil {
+	if err = os.WriteFile(clockPath, []byte(strconv.Itoa(clock+1)), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/lib/proxy/proxy.go
+++ b/lib/proxy/proxy.go
@@ -19,7 +19,7 @@ package proxy
 import (
 	"bytes"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -65,11 +65,11 @@ func (u *Pool) Get(ul *url.URL, targetHost string) (*httputil.ReverseProxy, erro
 		proxy.Transport = defaultTransport
 		proxy.ModifyResponse = func(response *http.Response) error {
 			if response.StatusCode == 200 {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				if err != nil {
 					return err
 				}
-				response.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+				response.Body = io.NopCloser(bytes.NewBuffer(body))
 				response.Header.Set("Content-Length", strconv.Itoa(len(body)))
 			}
 			return nil

--- a/lib/usage_client/client.go
+++ b/lib/usage_client/client.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -69,7 +69,7 @@ func (c *Client) Send(usage UsageValues) (*http.Response, error) {
 		c.logger.Error("send usage failed", zap.Error(err))
 		return resp, err
 	}
-	bytesBody, err := ioutil.ReadAll(resp.Body)
+	bytesBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return resp, err
 	}

--- a/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/agent_test.go
+++ b/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/agent_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -125,7 +124,7 @@ func TestAgentTagsFile(t *testing.T) {
 		"datacenter": "us-east",
 	}
 
-	td, err := ioutil.TempDir("", "serf")
+	td, err := os.MkdirTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -245,7 +244,7 @@ func TestAgentKeyringFile(t *testing.T) {
 		"5K9OtfP7efFrNKe5WCQvXvnaXJ5cWP0SvXiwe0kkjM4=",
 	}
 
-	td, err := ioutil.TempDir("", "serf")
+	td, err := os.MkdirTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -262,7 +261,7 @@ func TestAgentKeyringFile(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := ioutil.WriteFile(keyringFile, encodedKeys, 0600); err != nil {
+	if err := os.WriteFile(keyringFile, encodedKeys, 0600); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -296,14 +295,14 @@ func TestAgentKeyringFile_BadOptions(t *testing.T) {
 }
 
 func TestAgentKeyringFile_NoKeys(t *testing.T) {
-	dir, err := ioutil.TempDir("", "serf")
+	dir, err := os.MkdirTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	defer os.RemoveAll(dir)
 
 	keysFile := filepath.Join(dir, "keyring")
-	if err := ioutil.WriteFile(keysFile, []byte("[]"), 0600); err != nil {
+	if err := os.WriteFile(keysFile, []byte("[]"), 0600); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/config_test.go
+++ b/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/config_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -532,7 +531,7 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 }
 
 func TestReadConfigPaths_file(t *testing.T) {
-	tf, err := ioutil.TempFile("", "serf")
+	tf, err := os.CreateTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -551,26 +550,26 @@ func TestReadConfigPaths_file(t *testing.T) {
 }
 
 func TestReadConfigPaths_dir(t *testing.T) {
-	td, err := ioutil.TempDir("", "serf")
+	td, err := os.MkdirTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "a.json"),
+	err = os.WriteFile(filepath.Join(td, "a.json"),
 		[]byte(`{"node_name": "bar"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(td, "b.json"),
+	err = os.WriteFile(filepath.Join(td, "b.json"),
 		[]byte(`{"node_name": "baz"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// A non-json file, shouldn't be read
-	err = ioutil.WriteFile(filepath.Join(td, "c"),
+	err = os.WriteFile(filepath.Join(td, "c"),
 		[]byte(`{"node_name": "bad"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/event_handler_test.go
+++ b/lib/util/lifted/hashicorp/serf/cmd/serf/command/agent/event_handler_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -48,7 +47,7 @@ done
 // agent. It returns the path to the event script itself and a path to
 // the file that will contain the events that that script receives.
 func testEventScript(t *testing.T, script string) (string, string) {
-	scriptFile, err := ioutil.TempFile("", "serf")
+	scriptFile, err := os.CreateTemp("", "serf")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -58,7 +57,7 @@ func testEventScript(t *testing.T, script string) (string, string) {
 		t.Fatalf("err: %v", err)
 	}
 
-	resultFile, err := ioutil.TempFile("", "serf-result")
+	resultFile, err := os.CreateTemp("", "serf-result")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -108,7 +107,7 @@ func TestScriptEventHandler(t *testing.T) {
 
 	h.HandleEvent(event)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +148,7 @@ func TestScriptUserEventHandler(t *testing.T) {
 
 	h.HandleEvent(userEvent)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -188,7 +187,7 @@ func TestScriptQueryEventHandler(t *testing.T) {
 
 	h.HandleEvent(query)
 
-	result, err := ioutil.ReadFile(results)
+	result, err := os.ReadFile(results)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/lib/util/lifted/hashicorp/serf/cmd/serf/main.go
+++ b/lib/util/lifted/hashicorp/serf/cmd/serf/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	// Get the command line args. We shortcut "--version" and "-v" to
 	// just show the version.

--- a/lib/util/lifted/hashicorp/serf/serf/serf.go
+++ b/lib/util/lifted/hashicorp/serf/serf/serf.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -1878,7 +1877,7 @@ func (s *Serf) writeKeyringFile() error {
 	}
 
 	// Use 0600 for permissions because key data is sensitive
-	if err = ioutil.WriteFile(s.config.KeyringFile, encodedKeys, 0600); err != nil {
+	if err = os.WriteFile(s.config.KeyringFile, encodedKeys, 0600); err != nil {
 		return fmt.Errorf("Failed to write keyring file: %s", err)
 	}
 

--- a/lib/util/lifted/influx/coordinator/statement_executor.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor.go
@@ -1200,7 +1200,7 @@ func (e *StatementExecutor) executeShowDatabasesStatement(q *influxql.ShowDataba
 		}
 	}
 	sort.Slice(row.Values, func(i, j int) bool {
-		return strings.Compare(row.Values[i][0].(string), row.Values[j][0].(string)) < 0
+		return row.Values[i][0].(string) < row.Values[j][0].(string)
 	})
 	return []*models.Row{row}, nil
 }

--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"mime/multipart"
 	"net/http"
@@ -1584,7 +1583,7 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 	//h.httpError(w, "not implementation", http.StatusBadRequest)
 	startTime := time.Now()
 	h.requestTracker.Add(r, user)
-	compressed, err := ioutil.ReadAll(r.Body)
+	compressed, err := io.ReadAll(r.Body)
 	if err != nil {
 		h.httpError(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/lib/util/lifted/influx/meta/shardinfo.go
+++ b/lib/util/lifted/influx/meta/shardinfo.go
@@ -133,15 +133,15 @@ func (sgi ShardGroupInfo) TargetShards(mst *MeasurementInfo, ski *ShardKeyInfo, 
 		sort.Sort(tagsGroup[tagGroupIdx])
 		i, j := 0, 0
 		for i < len(ski.ShardKey) && j < len(*tagsGroup[tagGroupIdx]) {
-			cmp := strings.Compare(ski.ShardKey[i], (*tagsGroup[tagGroupIdx])[j].Key)
-			if cmp < 0 {
+			sk, tag := ski.ShardKey[i], &(*tagsGroup[tagGroupIdx])[j]
+			if sk < tag.Key {
 				break
 			}
-			if cmp == 0 {
+			if sk == tag.Key {
 				shardKeyAndValue = append(shardKeyAndValue, ","...)
-				shardKeyAndValue = append(shardKeyAndValue, (*tagsGroup[tagGroupIdx])[j].Key...)
+				shardKeyAndValue = append(shardKeyAndValue, tag.Key...)
 				shardKeyAndValue = append(shardKeyAndValue, "="...)
-				shardKeyAndValue = append(shardKeyAndValue, (*tagsGroup[tagGroupIdx])[j].Value...)
+				shardKeyAndValue = append(shardKeyAndValue, tag.Value...)
 				i++
 			}
 			j++
@@ -425,9 +425,9 @@ type ShardInfo struct {
 }
 
 func (si ShardInfo) Contain(shardKey string) bool {
-	gtMin := strings.Compare(si.Min, shardKey) <= 0
+	gtMin := si.Min <= shardKey
 	ltMax := si.Max == ""
-	ltMax = ltMax || strings.Compare(shardKey, si.Max) < 0
+	ltMax = ltMax || shardKey < si.Max
 	return gtMin && ltMax
 }
 
@@ -435,12 +435,12 @@ func (si ShardInfo) ContainPrefix(prefix string) bool {
 	prefixLen := len(prefix)
 	gtMin := si.Min == ""
 	if len(si.Min) > prefixLen {
-		gtMin = strings.Compare(si.Min[:prefixLen], prefix) <= 0
+		gtMin = si.Min[:prefixLen] <= prefix
 	} else {
-		gtMin = gtMin || strings.Compare(si.Min, prefix) <= 0
+		gtMin = gtMin || si.Min <= prefix
 	}
 
-	ltMax := si.Max == "" || strings.Compare(prefix, si.Max) < 0
+	ltMax := si.Max == "" || prefix < si.Max
 	return gtMin && ltMax
 }
 

--- a/lib/util/lifted/vm/fs/reader_at_test.go
+++ b/lib/util/lifted/vm/fs/reader_at_test.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -19,7 +19,7 @@ func testReaderAt(t *testing.T, bufSize int) {
 	lockPath := ""
 	const fileSize = 8 * 1024 * 1024
 	data := make([]byte, fileSize)
-	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		t.Fatalf("cannot create %q: %s", path, err)
 	}
 	defer MustRemoveAll(path, &lockPath)

--- a/lib/util/lifted/vm/fs/reader_at_timing_test.go
+++ b/lib/util/lifted/vm/fs/reader_at_timing_test.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -26,7 +26,7 @@ func benchmarkReaderAtMustReadAt(b *testing.B, isMmap bool) {
 	lockPath := ""
 	const fileSize = 8 * 1024 * 1024
 	data := make([]byte, fileSize)
-	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		b.Fatalf("cannot create %q: %s", path, err)
 	}
 	defer MustRemoveAll(path, &lockPath)

--- a/lib/util/lifted/vm/mergeset/metaindex_row.go
+++ b/lib/util/lifted/vm/mergeset/metaindex_row.go
@@ -3,7 +3,6 @@ package mergeset
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
@@ -83,7 +82,7 @@ func (mr *metaindexRow) Unmarshal(src []byte) ([]byte, error) {
 func unmarshalMetaindexRows(dst []metaindexRow, r io.Reader) ([]metaindexRow, error) {
 	// It is ok to read all the metaindex in memory,
 	// since it is quite small.
-	compressedData, err := ioutil.ReadAll(r)
+	compressedData, err := io.ReadAll(r)
 	if err != nil {
 		return dst, fmt.Errorf("cannot read metaindex data: %w", err)
 	}

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -676,7 +675,7 @@ var LosAngeles = mustParseLocation("America/Los_Angeles")
 
 // MustReadAll reads r. Panic on error.
 func MustReadAll(r io.Reader) []byte {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}
@@ -942,6 +941,6 @@ func writeTestData(s Server, t *Test) error {
 func configureLogging(s Server) {
 	// Set the logger to discard unless verbose is on
 	if !verboseServerLogs {
-		s.SetLogOutput(ioutil.Discard)
+		s.SetLogOutput(io.Discard)
 	}
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -11904,7 +11903,7 @@ func TestServer_SubscriptionForward(t *testing.T) {
 	}))
 	mux.HandleFunc("/write", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		wr := Request{db: r.URL.Query().Get("db"), rp: r.URL.Query().Get("rp")}
-		wr.lineProtocol, _ = ioutil.ReadAll(r.Body)
+		wr.lineProtocol, _ = io.ReadAll(r.Body)
 		ch <- wr
 		w.WriteHeader(http.StatusNoContent)
 	}))


### PR DESCRIPTION
### What is changed and how it works?

- Per the comment of `strings.Compare`, it is slower and should not be used.
- `ioutil` is deprecated.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
