### PR TITLE
fix: ts-cli command line argument 'precision' has no effect

### DIFF
--- a/app/ts-cli/geminicli/cli.go
+++ b/app/ts-cli/geminicli/cli.go
@@ -270,10 +270,8 @@ func parsePrecision(precision string) (string, error) {
 	switch epoch {
 	case "":
 		return "ns", nil
-	case "h", "m", "s", "ms", "u", "ns":
+	case "h", "m", "s", "ms", "u", "ns", "rfc3339":
 		return epoch, nil
-	case "rfc3339":
-		return "", nil
 	default:
 		return "", fmt.Errorf("unknown precision %q. precision must be rfc3339, h, m, s, ms, u or ns", precision)
 	}

--- a/app/ts-cli/geminicli/cli_test.go
+++ b/app/ts-cli/geminicli/cli_test.go
@@ -97,7 +97,7 @@ func TestPrecisionParser(t *testing.T) {
 			stmt: &geminiql.PrecisionStatement{
 				Precision: "rfc3339",
 			},
-			expect: "",
+			expect: "rfc3339",
 		},
 		{
 			name: "Precision ns",
@@ -147,7 +147,7 @@ func TestParsePrecision(t *testing.T) {
 		{input: "ms", expected: "ms", wantError: false},
 		{input: "u", expected: "u", wantError: false},
 		{input: "ns", expected: "ns", wantError: false},
-		{input: "rfc3339", expected: "", wantError: false},
+		{input: "rfc3339", expected: "rfc3339", wantError: false},
 		{input: "unknown", expected: "", wantError: true},
 	}
 

--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -1035,7 +1035,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta2.
 		}
 
 		// if requested, convert result timestamps to epoch
-		if epoch != "" {
+		if epoch != "rfc3339" {
 			convertToEpoch(r, epoch)
 		}
 

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -491,6 +491,9 @@ func (s *client) QueryWithParams(query string, values url.Values) (results strin
 	} else {
 		v, _ = url.ParseQuery(values.Encode())
 	}
+	if !v.Has("epoch") {
+		v.Add("epoch", "rfc3339")
+	}
 	if v.Get("chunked") == "true" {
 		v.Set("chunked", "true")
 	} else {


### PR DESCRIPTION
### What problem does this PR solve?

 `ts-cli` command line argument `precision` has no effect.

Issue Number: fix #513 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
