### PR TITLE
fix: typo in 'show streams'

### DIFF
--- a/app/ts-meta/meta/balance_store_test.go
+++ b/app/ts-meta/meta/balance_store_test.go
@@ -35,9 +35,9 @@ func TestSelectDbPtsToMove(t *testing.T) {
 			TakeOverEnabled: true,
 		},
 	}
-	_, n1 := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
-	_, n2 := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
-	_, n3 := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
+	n1, _ := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
+	n2, _ := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
+	n3, _ := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
 	_ = store.data.UpdateNodeStatus(n1, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n2, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n3, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
@@ -118,9 +118,9 @@ func TestBalanceDBPts1(t *testing.T) {
 			TakeOverEnabled: true,
 		},
 	}
-	_, n1 := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
-	_, n2 := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
-	_, n3 := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
+	n1, _ := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
+	n2, _ := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
+	n3, _ := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
 	_ = store.data.UpdateNodeStatus(n1, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n2, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n3, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
@@ -155,9 +155,9 @@ func TestBalanceDBPts2(t *testing.T) {
 			TakeOverEnabled: true,
 		},
 	}
-	_, n1 := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
-	_, n2 := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
-	_, n3 := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
+	n1, _ := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
+	n2, _ := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
+	n3, _ := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
 	_ = store.data.UpdateNodeStatus(n1, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n2, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n3, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
@@ -193,9 +193,9 @@ func TestBalanceDBPts3(t *testing.T) {
 			TakeOverEnabled: true,
 		},
 	}
-	_, n1 := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
-	_, n2 := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
-	_, n3 := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
+	n1, _ := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
+	n2, _ := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
+	n3, _ := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
 	_ = store.data.UpdateNodeStatus(n1, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n2, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n3, int32(serf.StatusAlive), 1, "127.0.0.1:8011")

--- a/app/ts-meta/meta/cluster_manager_test.go
+++ b/app/ts-meta/meta/cluster_manager_test.go
@@ -468,9 +468,9 @@ func TestClusterManager_PassiveTakeOver_WhenDropDB(t *testing.T) {
 			BalancerEnabled: true,
 		},
 	}
-	_, n1 := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
-	_, n2 := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
-	_, n3 := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
+	n1, _ := store.data.CreateDataNode("127.0.0.1:8401", "127.0.0.1:8402", "")
+	n2, _ := store.data.CreateDataNode("127.0.0.2:8401", "127.0.0.2:8402", "")
+	n3, _ := store.data.CreateDataNode("127.0.0.3:8401", "127.0.0.3:8402", "")
 	_ = store.data.UpdateNodeStatus(n1, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n2, int32(serf.StatusAlive), 1, "127.0.0.1:8011")
 	_ = store.data.UpdateNodeStatus(n3, int32(serf.StatusAlive), 1, "127.0.0.1:8011")

--- a/app/ts-meta/meta/handler_test.go
+++ b/app/ts-meta/meta/handler_test.go
@@ -92,11 +92,11 @@ func TestHttpHandler_ServeHTTP(t *testing.T) {
 	}
 	defer mms.Close()
 
-	err, node1 := mms.GetStore().data.CreateDataNode("127.0.0.1:8400", "127.0.0.1:8401", "")
+	node1, err := mms.GetStore().data.CreateDataNode("127.0.0.1:8400", "127.0.0.1:8401", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err, node2 := mms.GetStore().data.CreateDataNode("127.0.0.2:8400", "127.0.0.2:8401", "")
+	node2, err := mms.GetStore().data.CreateDataNode("127.0.0.2:8400", "127.0.0.2:8401", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/app/ts-meta/meta/meta_util_test.go
+++ b/app/ts-meta/meta/meta_util_test.go
@@ -19,7 +19,7 @@ package meta
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"reflect"
@@ -240,7 +240,7 @@ func (h *MockHandler) servePeers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *MockHandler) serveJoin(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.httpError(err, w, http.StatusInternalServerError)
 		return

--- a/app/ts-meta/meta/store_fsm.go
+++ b/app/ts-meta/meta/store_fsm.go
@@ -785,7 +785,7 @@ func (fsm *storeFSM) applyCreateDataNodeCommand(cmd *proto2.Command) interface{}
 	}
 
 	fsm.data.ExpandShardsEnable = fsm.config.ExpandShardsEnable
-	err, _ := fsm.data.CreateDataNode(v.GetHTTPAddr(), v.GetTCPAddr(), v.GetRole())
+	_, err := fsm.data.CreateDataNode(v.GetHTTPAddr(), v.GetTCPAddr(), v.GetRole())
 	return err
 }
 

--- a/app/ts-meta/meta/store_test.go
+++ b/app/ts-meta/meta/store_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -268,7 +269,7 @@ func generateData(ms *meta.MetaService, db, rp, mst string, shardKeyN int, value
 				}
 				tagValue := "host_" + strconv.Itoa(idx)
 				shardKeyAndValue := shardKey.ShardKey[0] + "=" + tagValue
-				if shardKeyAndValue < splitPoint {
+				if strings.Compare(shardKeyAndValue, splitPoint) < 0 {
 					continue
 				}
 				sh := sg.DestShard(shardKeyAndValue)

--- a/lib/util/lifted/influx/meta/data_test.go
+++ b/lib/util/lifted/influx/meta/data_test.go
@@ -573,7 +573,7 @@ func TestShardGroupOutOfOrder(t *testing.T) {
 	data := Data{}
 	data.PtNumPerNode = 1
 	DataLogger = logger.New(os.Stderr)
-	err, _ := data.CreateDataNode("127.0.0.1:8400", "127.0.0.1:8401", "")
+	_, err := data.CreateDataNode("127.0.0.1:8400", "127.0.0.1:8401", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -673,7 +673,7 @@ func TestData_CreateShardGroup(t *testing.T) {
 	assert(igs[0].StartTime.Equal(mustParseTime(time.RFC3339Nano, "2022-06-08T08:00:00Z")), "index group startTime error")
 	assert(igs[0].EndTime.Equal(mustParseTime(time.RFC3339Nano, "2022-06-08T10:00:00Z")), "index group endTime error")
 	data.ExpandShardsEnable = true
-	err, _ = data.CreateDataNode("127.0.0.3:8400", "127.0.0.3:8401", "")
+	_, err = data.CreateDataNode("127.0.0.3:8400", "127.0.0.3:8401", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -794,7 +794,7 @@ func initDataWithDataNode() *Data {
 
 	for i := 1; i <= 40; i++ {
 		nodeIp := prefix + fmt.Sprint(i)
-		err, _ := data.CreateDataNode(nodeIp+fmt.Sprint(selectPort), nodeIp+fmt.Sprint(writePort), "")
+		_, err := data.CreateDataNode(nodeIp+fmt.Sprint(selectPort), nodeIp+fmt.Sprint(writePort), "")
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### What problem does this PR solve?

the 'source measurement' should be `database`.`retention policy`.`measurement`, but was `measurement`.`retention policy`.`measurement`.

also fix several lint issues.

fix #524 PR check err 

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->


<!--



There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->



### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
