### PR TITLE
chore: change maxLineSize from 256*1024 to 1024*1024

### DIFF
--- a/lib/util/lifted/vm/protoparser/influx/streamparser.go
+++ b/lib/util/lifted/vm/protoparser/influx/streamparser.go
@@ -23,7 +23,7 @@ import (
 )
 
 // The maximum size of a single line returned by ReadLinesBlock.
-const maxLineSize = 256 * 1024
+const maxLineSize = 1024 * 1024
 
 // Default size in bytes of a single block returned by ReadLinesBlock.
 const defaultBlockSize = 64 * 1024


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->
Issue Number: fix #435 

### What is changed and how it works?
Solve the following problems:
openGemini currently supports a maximum of 256KB for a single row of data. When there are many columns, a single row of data may exceed 256KB.

change the maxLineSize from 256\*1024 to 1024\*1024
