### PR TITLE
fix(log): dropDB cmd for raft playback was executed before the metaclient  was set

### DIFF
--- a/app/ts-meta/meta/store_internal_test.go
+++ b/app/ts-meta/meta/store_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/metaclient"
+	"github.com/openGemini/openGemini/lib/obs"
 	"github.com/openGemini/openGemini/lib/util"
 	"github.com/openGemini/openGemini/lib/util/lifted/hashicorp/serf/serf"
 	meta2 "github.com/openGemini/openGemini/lib/util/lifted/influx/meta"
@@ -811,4 +812,101 @@ func Test_applyInsertFiles(t *testing.T) {
 	require.Nil(t, resErr)
 	resErr = applyInsertFilesCommand(fsm, cmd)
 	require.EqualError(t, resErr.(error), "UNIQUE constraint failed: files.mst_id, files.shard_id, files.sequence, files.level, files.extent, files.merge")
+}
+
+func Test_executeCmdErr(t *testing.T) {
+	s := &Store{Logger: logger.NewLogger(errno.ModuleUnknown).SetZapLogger(zap.NewNop())}
+	fsm := (*storeFSM)(s)
+	typ := proto2.Command_InsertFilesCommand
+	cmd := &proto2.Command{Type: &typ}
+	value := &proto2.InsertFilesCommand{}
+	err := proto.SetExtension(cmd, proto2.E_InsertFilesCommand_Command, value)
+	require.NoError(t, err)
+	var errType proto2.Command_Type = math.MaxInt32
+	cmd.Type = &errType
+	fsm.executeCmd(*cmd)
+}
+
+func Test_DeleteRpForLogkeeper(t *testing.T) {
+	config.SetProductType("logkeeper")
+	dir := t.TempDir()
+	s := &Store{
+		config: &config.Meta{DataDir: dir + "/data", WalDir: dir + "/wal"},
+		cacheData: &meta2.Data{
+			DataNodes: []meta2.DataNode{
+				meta2.DataNode{NodeInfo: meta2.NodeInfo{ID: 0, TCPHost: "127.0.0.1", Status: serf.StatusAlive}, ConnID: 2, AliveConnID: 2},
+				meta2.DataNode{NodeInfo: meta2.NodeInfo{ID: 1, TCPHost: "127.0.0.2", Status: serf.StatusLeaving}, ConnID: 2, AliveConnID: 2},
+			},
+			PtView: map[string]meta2.DBPtInfos{
+				"db0": {
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 0}, Status: meta2.Online, PtId: 0},
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 1}, Status: meta2.Offline, PtId: 1},
+				},
+				"db1": {
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 0}, Status: meta2.Online, PtId: 0},
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 1}, Status: meta2.Offline, PtId: 1},
+				},
+			},
+			Databases: map[string]*meta2.DatabaseInfo{
+				"db0": &meta2.DatabaseInfo{Name: "db0", DefaultRetentionPolicy: "autogen"},
+				"db1": &meta2.DatabaseInfo{Name: "db0", DefaultRetentionPolicy: "autogen", Options: &obs.ObsOptions{}},
+			},
+		},
+		NetStore: NewMockNetStorage(),
+		raft:     &MockRaftForCQ{isLeader: true},
+	}
+	err := s.deleteRetentionPolicy("db0", "rp0")
+	if err != nil {
+		t.Errorf("deleteRetentionPolicy failed, err:%+v", err)
+	}
+	err = s.deleteRetentionPolicy("db1", "rp0")
+	if err == nil {
+		t.Error("expect deleteRetentionPolicy failed")
+	}
+	err = s.deleteRetentionPolicy("db2", "rp0")
+	if err != nil {
+		t.Errorf("deleteRetentionPolicy failed, err:%+v", err)
+	}
+}
+
+func Test_DeleteDbForLogkeeper(t *testing.T) {
+	config.SetProductType("logkeeper")
+	dir := t.TempDir()
+	s := &Store{
+		config: &config.Meta{DataDir: dir + "/data", WalDir: dir + "/wal"},
+		cacheData: &meta2.Data{
+			DataNodes: []meta2.DataNode{
+				meta2.DataNode{NodeInfo: meta2.NodeInfo{ID: 0, TCPHost: "127.0.0.1", Status: serf.StatusAlive}, ConnID: 2, AliveConnID: 2},
+				meta2.DataNode{NodeInfo: meta2.NodeInfo{ID: 1, TCPHost: "127.0.0.2", Status: serf.StatusLeaving}, ConnID: 2, AliveConnID: 2},
+			},
+			PtView: map[string]meta2.DBPtInfos{
+				"db0": {
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 0}, Status: meta2.Online, PtId: 0},
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 1}, Status: meta2.Offline, PtId: 1},
+				},
+				"db1": {
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 0}, Status: meta2.Online, PtId: 0},
+					meta2.PtInfo{Owner: meta2.PtOwner{NodeID: 1}, Status: meta2.Offline, PtId: 1},
+				},
+			},
+			Databases: map[string]*meta2.DatabaseInfo{
+				"db0": &meta2.DatabaseInfo{Name: "db0"},
+				"db1": &meta2.DatabaseInfo{Name: "db0", Options: &obs.ObsOptions{}},
+			},
+		},
+		NetStore: NewMockNetStorage(),
+		raft:     &MockRaftForCQ{isLeader: true},
+	}
+	err := s.deleteDatabase("db0")
+	if err != nil {
+		t.Errorf("deleteDatabase failed, err:%+v", err)
+	}
+	err = s.deleteDatabase("db1")
+	if err == nil {
+		t.Error("expect deleteDatabase failed")
+	}
+	err = s.deleteDatabase("db2")
+	if err != nil {
+		t.Errorf("deleteDatabase failed, err:%+v", err)
+	}
 }

--- a/app/ts-store/storage/storage.go
+++ b/app/ts-store/storage/storage.go
@@ -273,6 +273,9 @@ func OpenStorage(path string, node *metaclient.Node, cli *metaclient.Client, con
 		slaveStorage: netstorage.NewNetStorage(cli),
 	}
 
+	if cli != nil {
+		eng.SetMetaClient(cli)
+	}
 	s.MetaClient = cli
 	s.log = logger.NewLogger(errno.ModuleStorageEngine)
 	// Append services.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -187,7 +187,7 @@ func (e *Engine) Open(durationInfos map[uint64]*meta2.ShardDurationInfo, dbBrief
 		return err
 	}
 
-	e.setMetaClient(m)
+	e.SetMetaClient(m)
 	err := e.loadShards(durationInfos, dbBriefInfos, immutable.LOAD, m)
 	if err != nil {
 		atomic.AddInt64(&stat.EngineStat.OpenErrors, 1)
@@ -197,7 +197,7 @@ func (e *Engine) Open(durationInfos map[uint64]*meta2.ShardDurationInfo, dbBrief
 	return nil
 }
 
-func (e *Engine) setMetaClient(m meta.MetaClient) {
+func (e *Engine) SetMetaClient(m meta.MetaClient) {
 	e.mu.Lock()
 	e.metaClient = m
 	e.mu.Unlock()

--- a/engine/engine_ddl.go
+++ b/engine/engine_ddl.go
@@ -70,7 +70,7 @@ func (e *Engine) DeleteDatabase(db string, ptId uint32) (err error) {
 	dataPath := path.Join(e.dataPath, config.DataDirectory, db, strconv.Itoa(int(ptId)))
 	walPath := path.Join(e.walPath, config.WalDirectory, db, strconv.Itoa(int(ptId)))
 	lockPath := ""
-
+	obsOpt, _ := e.metaClient.DatabaseOption(db)
 	e.mu.RLock()
 	dbInfo, ok := e.DBPartitions[db]
 	if !ok {
@@ -140,6 +140,7 @@ func (e *Engine) DropRetentionPolicy(db string, rp string, ptId uint32) error {
 			zap.String("db", db), zap.String("rp", rp), zap.Duration("duration", d), zap.Uint32("pt", ptId))
 	}(start)
 
+	obsOpt, _ := e.metaClient.DatabaseOption(db)
 	deleteDirFunc := func() error {
 		dataPath := path.Join(e.dataPath, config.DataDirectory, db, strconv.Itoa(int(ptId)), rp)
 		walPath := path.Join(e.walPath, config.WalDirectory, db, strconv.Itoa(int(ptId)), rp)

--- a/engine/engine_ha.go
+++ b/engine/engine_ha.go
@@ -141,7 +141,7 @@ func (e *Engine) Assign(opId uint64, nodeId uint64, db string, ptId uint32, ver 
 		return errno.NewError(errno.PtIsAlreadyMigrating)
 	}
 	defer e.clearDbPtMigrating(db, ptId)
-	e.setMetaClient(client)
+	e.SetMetaClient(client)
 	if e.metaClient.IsSQLiteEnabled() && e.fileInfos == nil {
 		e.fileInfos = make(chan []immutable.FileInfoExtend, MaxFileInfoSize)
 		go func() {

--- a/engine/engine_ha_test.go
+++ b/engine/engine_ha_test.go
@@ -76,7 +76,7 @@ func TestPreOffLoadPts001(t *testing.T) {
 	go func() {
 		err := eng.DeleteDatabase(defaultDb, defaultPtId)
 		if err != nil {
-			t.Error("expect delete database success")
+			t.Error("expect delete database success", zap.Error(err))
 		}
 		wg.Done()
 	}()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -57,6 +57,14 @@ import (
 	"go.uber.org/zap"
 )
 
+type mockMetaClient4Drop struct {
+	metaclient.MetaClient
+}
+
+func (m *mockMetaClient4Drop) DatabaseOption(database string) (*obs.ObsOptions, error) {
+	return nil, nil
+}
+
 type shardMock struct {
 	rp      string
 	id      uint64

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -165,6 +165,7 @@ type MetaClient interface {
 	CreateUser(name, password string, admin, rwuser bool) (meta2.User, error)
 	Databases() map[string]*meta2.DatabaseInfo
 	Database(name string) (*meta2.DatabaseInfo, error)
+	DatabaseOption(name string) (*obs.ObsOptions, error)
 	DataNode(id uint64) (*meta2.DataNode, error)
 	DataNodes() ([]meta2.DataNode, error)
 	AliveReadNodes() ([]meta2.DataNode, error)
@@ -955,6 +956,17 @@ func (c *Client) Database(name string) (*meta2.DatabaseInfo, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.cacheData.GetDatabase(name)
+}
+
+// returns obs options info for the requested database.
+func (c *Client) DatabaseOption(name string) (*obs.ObsOptions, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	dbi := c.cacheData.Database(name)
+	if dbi == nil {
+		return nil, errno.NewError(errno.DatabaseNotFound, name)
+	}
+	return dbi.Options, nil
 }
 
 // Databases returns a list of all database infos.

--- a/lib/metaclient/meta_client_test.go
+++ b/lib/metaclient/meta_client_test.go
@@ -3182,3 +3182,23 @@ func TestClient_InsertFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_DatabaseOption(t *testing.T) {
+	c := &Client{
+		cacheData: &meta2.Data{
+			Databases: map[string]*meta2.DatabaseInfo{
+				"db0": {
+					Name: "db0",
+				},
+			},
+		},
+	}
+	_, err := c.DatabaseOption("db0")
+	if err != nil {
+		t.Fatalf("get database option failed, %+v", err)
+	}
+	_, err = c.DatabaseOption("db1")
+	if err == nil {
+		t.Fatalf("databases does not exist, but no error returned")
+	}
+}

--- a/lib/netstorage/engine.go
+++ b/lib/netstorage/engine.go
@@ -136,6 +136,7 @@ type Engine interface {
 
 	RaftMessage
 	CreateShowTagValuesPlan(db string, ptIDs []uint32, tr *influxql.TimeRange) ShowTagValuesPlan
+	SetMetaClient(m metaclient.MetaClient)
 }
 
 type RaftMessage interface {


### PR DESCRIPTION
fix(log): dropDB cmd for raft playback was executed before the metaclient  was set

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close/fix/resolve/ref #575 

### What is changed and how it works?
Please describe how it works
Complete the setting of the metaclient during engine initialization


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
