### PR TITLE
feat(json): op http json marshal

### DIFF
--- a/lib/util/lifted/influx/httpd/handler_logstore.go
+++ b/lib/util/lifted/influx/httpd/handler_logstore.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/uuid"
 	"github.com/openGemini/openGemini/lib/bufferpool"
 	"github.com/openGemini/openGemini/lib/config"
@@ -54,7 +53,7 @@ import (
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
 	meta2 "github.com/openGemini/openGemini/lib/util/lifted/influx/meta"
 	proto2 "github.com/openGemini/openGemini/lib/util/lifted/influx/meta/proto"
-	query2 "github.com/openGemini/openGemini/lib/util/lifted/influx/query"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 	"github.com/openGemini/openGemini/lib/util/lifted/logparser"
 	"github.com/openGemini/openGemini/lib/util/lifted/vm/protoparser/influx"
 	"github.com/valyala/fastjson"
@@ -1866,7 +1865,7 @@ func (h *Handler) serveLogQuery(w http.ResponseWriter, r *http.Request, param *Q
 	}
 	// Parse whether this is an async command.
 	async := r.FormValue("async") == "true"
-	opts := *query2.NewExecutionOptions(info.database, r.FormValue("rp"), nodeID, chunkSize, innerChunkSize, false, r.Method == "GET", true,
+	opts := *query.NewExecutionOptions(info.database, r.FormValue("rp"), nodeID, chunkSize, innerChunkSize, false, r.Method == "GET", true,
 		atomic.LoadInt32(&syscontrol.ParallelQueryInBatch) == 1)
 	if param != nil {
 		opts.IncQuery, opts.QueryID, opts.IterID = param.IncQuery, param.QueryID, param.IterID
@@ -2552,7 +2551,7 @@ type Histograms struct {
 	Count int64 `json:"count"`
 }
 
-func GenZeroHistogram(opt query2.ProcessorOptions, start, end int64, ascending bool) []Histograms {
+func GenZeroHistogram(opt query.ProcessorOptions, start, end int64, ascending bool) []Histograms {
 	startTime, _ := opt.Window(start)
 	_, endTime := opt.Window(end)
 	if !ascending {

--- a/lib/util/lifted/influx/httpd/handler_logstore_query_test.go
+++ b/lib/util/lifted/influx/httpd/handler_logstore_query_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/util/lifted/influx/httpd/handler_prom.go
+++ b/lib/util/lifted/influx/httpd/handler_prom.go
@@ -33,7 +33,6 @@ import (
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/prometheus"
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/engine/executor"
 	"github.com/openGemini/openGemini/engine/op"
 	"github.com/openGemini/openGemini/lib/pool"
@@ -41,7 +40,7 @@ import (
 	"github.com/openGemini/openGemini/lib/syscontrol"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
 	meta2 "github.com/openGemini/openGemini/lib/util/lifted/influx/meta"
-	query2 "github.com/openGemini/openGemini/lib/util/lifted/influx/query"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 	"github.com/openGemini/openGemini/lib/util/lifted/promql2influxql"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -226,7 +225,7 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 	// Parse whether this is an async command.
 	async := r.FormValue("async") == "true"
 
-	opts := query2.ExecutionOptions{
+	opts := query.ExecutionOptions{
 		Database:        db,
 		RetentionPolicy: r.FormValue("rp"),
 		ChunkSize:       1,
@@ -237,14 +236,14 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 
 	if h.Config.AuthEnabled {
 		if user != nil && user.AuthorizeUnrestricted() {
-			opts.Authorizer = query2.OpenAuthorizer
+			opts.Authorizer = query.OpenAuthorizer
 		} else {
 			// The current user determines the authorized actions.
 			opts.Authorizer = user
 		}
 	} else {
 		// Auth is disabled, so allow everything.
-		opts.Authorizer = query2.OpenAuthorizer
+		opts.Authorizer = query.OpenAuthorizer
 	}
 
 	// Make sure if the client disconnects we signal the query to abort
@@ -460,7 +459,7 @@ func (h *Handler) servePromBaseQuery(w http.ResponseWriter, r *http.Request, use
 	// Parse whether this is an async command.
 	async := r.FormValue("async") == "true"
 
-	opts := query2.ExecutionOptions{
+	opts := query.ExecutionOptions{
 		Database:        db,
 		RetentionPolicy: r.FormValue("rp"),
 		ChunkSize:       chunkSize,
@@ -540,8 +539,8 @@ func (h *Handler) promExprQuery(promCommand *promql2influxql.PromCommand, statem
 	valuer := influxql.ValuerEval{
 		Valuer: influxql.MultiValuer(
 			op.Valuer{},
-			query2.MathValuer{},
-			query2.StringValuer{},
+			query.MathValuer{},
+			query.StringValuer{},
 			executor.PromTimeValuer{},
 			promTimeValuer,
 		),
@@ -680,7 +679,7 @@ func (h *Handler) servePromBaseMetaQuery(w http.ResponseWriter, r *http.Request,
 	// Parse whether this is an async command.
 	async := r.FormValue("async") == "true"
 
-	opts := query2.ExecutionOptions{
+	opts := query.ExecutionOptions{
 		Database:        db,
 		RetentionPolicy: r.FormValue("rp"),
 		ReadOnly:        r.Method == "GET",

--- a/lib/util/lifted/influx/httpd/handler_prom_util.go
+++ b/lib/util/lifted/influx/httpd/handler_prom_util.go
@@ -29,9 +29,9 @@ import (
 
 	prompb2 "github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
 	"github.com/gorilla/mux"
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 	"github.com/openGemini/openGemini/lib/util/lifted/promql2influxql"
 	"github.com/openGemini/openGemini/lib/util/lifted/vm/protoparser/influx"
 	"github.com/prometheus/common/model"

--- a/lib/util/lifted/influx/httpd/response_writer_test.go
+++ b/lib/util/lifted/influx/httpd/response_writer_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpd
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
+)
+
+type mockWriter struct {
+}
+
+func (w *mockWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func BenchmarkJsonFormatter(b *testing.B) {
+	f := &jsonFormatter{}
+	res := []*query.Result{}
+	for i := 0; i < 100; i++ {
+		res = append(res, &query.Result{Series: []*models.Row{{
+			Name:    "db2",
+			Columns: []string{"name", "query"},
+			Values: [][]interface{}{
+				{"db2_query_name", "db2_query"},
+				{"db2_query2_name", "db2_query2"},
+			},
+		},
+			{
+				Name:    "db4",
+				Columns: []string{"name", "query"},
+				Values: [][]interface{}{
+					{"db4_query_name", "db4_query"},
+					{"db4_query2_name", "db4_query2"},
+					{"db4_query3_name", "db4_query3"},
+				},
+			}}})
+	}
+	resp := Response{Results: res}
+	writer := &mockWriter{}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		f.WriteResponse(writer, resp)
+	}
+}
+
+func BenchmarkSonicJsonFormatter(b *testing.B) {
+	f := &sonicJsonFormatter{}
+	res := []*query.Result{}
+	for i := 0; i < 100; i++ {
+		res = append(res, &query.Result{Series: []*models.Row{{
+			Name:    "db2",
+			Columns: []string{"name", "query"},
+			Values: [][]interface{}{
+				{"db2_query_name", "db2_query"},
+				{"db2_query2_name", "db2_query2"},
+			},
+		},
+			{
+				Name:    "db4",
+				Columns: []string{"name", "query"},
+				Values: [][]interface{}{
+					{"db4_query_name", "db4_query"},
+					{"db4_query2_name", "db4_query2"},
+					{"db4_query3_name", "db4_query3"},
+				},
+			}}})
+	}
+	resp := Response{Results: res}
+	writer := &mockWriter{}
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		f.WriteResponse(writer, resp)
+	}
+}

--- a/lib/util/lifted/influx/query/executor_context.go
+++ b/lib/util/lifted/influx/query/executor_context.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/util/lifted/vm/protoparser/influx"
 )
@@ -28,7 +27,7 @@ type ExecutionContext struct {
 	task []*Task
 
 	// Output channel where results and errors should be sent.
-	Results chan *query.Result
+	Results chan *Result
 
 	// Options used to start this query.
 	ExecutionOptions
@@ -107,7 +106,7 @@ func (ctx *ExecutionContext) Value(key interface{}) interface{} {
 
 // send sends a Result to the Results channel and will exit if the query has
 // been aborted.
-func (ctx *ExecutionContext) send(result *query.Result, seq int) error {
+func (ctx *ExecutionContext) send(result *Result, seq int) error {
 	result.StatementID = seq
 	select {
 	case <-ctx.AbortCh:
@@ -119,7 +118,7 @@ func (ctx *ExecutionContext) send(result *query.Result, seq int) error {
 
 // Send sends a Result to the Results channel and will exit if the query has
 // been interrupted or aborted.
-func (ctx *ExecutionContext) Send(result *query.Result, seq int) error {
+func (ctx *ExecutionContext) Send(result *Result, seq int) error {
 	result.StatementID = seq
 	select {
 	case <-ctx.Done():

--- a/lib/util/lifted/influx/query/executor_test.go
+++ b/lib/util/lifted/influx/query/executor_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	query2 "github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/errno"
 	Logger "github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/coordinator"
@@ -45,7 +44,7 @@ func TestQueryExecutor_Parallel(t *testing.T) {
 	discardOutput(results)
 }
 
-func discardOutput(results <-chan *query2.Result) {
+func discardOutput(results <-chan *query.Result) {
 	for range results {
 		// Read all results and discard.
 	}

--- a/lib/util/lifted/influx/query/result.go
+++ b/lib/util/lifted/influx/query/result.go
@@ -1,0 +1,150 @@
+package query
+
+/*
+Copyright (c) 2018 InfluxData
+This code is originally from: https://github.com/influxdata/influxdb/blob/1.7/query/result.go
+
+2024.04.26 It has been modified to compatible files in influx/query.
+Huawei Cloud Computing Technologies Co., Ltd.
+*/
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxql"
+	json "github.com/json-iterator/go"
+)
+
+const (
+	// WarningLevel is the message level for a warning.
+	WarningLevel = "warning"
+)
+
+// TagSet is a fundamental concept within the query system. It represents a composite series,
+// composed of multiple individual series that share a set of tag attributes.
+type TagSet struct {
+	Tags       map[string]string
+	Filters    []influxql.Expr
+	SeriesKeys []string
+	Key        []byte
+}
+
+// AddFilter adds a series-level filter to the Tagset.
+func (t *TagSet) AddFilter(key string, filter influxql.Expr) {
+	t.SeriesKeys = append(t.SeriesKeys, key)
+	t.Filters = append(t.Filters, filter)
+}
+
+func (t *TagSet) Len() int           { return len(t.SeriesKeys) }
+func (t *TagSet) Less(i, j int) bool { return t.SeriesKeys[i] < t.SeriesKeys[j] }
+func (t *TagSet) Swap(i, j int) {
+	t.SeriesKeys[i], t.SeriesKeys[j] = t.SeriesKeys[j], t.SeriesKeys[i]
+	t.Filters[i], t.Filters[j] = t.Filters[j], t.Filters[i]
+}
+
+// Reverse reverses the order of series keys and filters in the TagSet.
+func (t *TagSet) Reverse() {
+	for i, j := 0, len(t.Filters)-1; i < j; i, j = i+1, j-1 {
+		t.Filters[i], t.Filters[j] = t.Filters[j], t.Filters[i]
+		t.SeriesKeys[i], t.SeriesKeys[j] = t.SeriesKeys[j], t.SeriesKeys[i]
+	}
+}
+
+// LimitTagSets returns a tag set list with SLIMIT and SOFFSET applied.
+func LimitTagSets(a []*TagSet, slimit, soffset int) []*TagSet {
+	// Ignore if no limit or offset is specified.
+	if slimit == 0 && soffset == 0 {
+		return a
+	}
+
+	// If offset is beyond the number of tag sets then return nil.
+	if soffset > len(a) {
+		return nil
+	}
+
+	// Clamp limit to the max number of tag sets.
+	if soffset+slimit > len(a) {
+		slimit = len(a) - soffset
+	}
+	return a[soffset : soffset+slimit]
+}
+
+// Message represents a user-facing message to be included with the result.
+type Message struct {
+	Level string `json:"level"`
+	Text  string `json:"text"`
+}
+
+// ReadOnlyWarning generates a warning message that tells the user the command
+// they are using is being used for writing in a read only context.
+//
+// This is a temporary method while to be used while transitioning to read only
+// operations for issue #6290.
+func ReadOnlyWarning(stmt string) *Message {
+	return &Message{
+		Level: WarningLevel,
+		Text:  fmt.Sprintf("deprecated use of '%s' in a read only context, please use a POST request instead", stmt),
+	}
+}
+
+// Result represents a resultset returned from a single statement.
+// Rows represents a list of rows that can be sorted consistently by name/tag.
+type Result struct {
+	// StatementID is just the statement's position in the query. It's used
+	// to combine statement results if they're being buffered in memory.
+	StatementID int
+	Series      models.Rows
+	Messages    []*Message
+	Partial     bool
+	Err         error
+}
+
+// MarshalJSON encodes the result into JSON.
+func (r *Result) MarshalJSON() ([]byte, error) {
+	// Define a struct that outputs "error" as a string.
+	var o struct {
+		StatementID int           `json:"statement_id"`
+		Series      []*models.Row `json:"series,omitempty"`
+		Messages    []*Message    `json:"messages,omitempty"`
+		Partial     bool          `json:"partial,omitempty"`
+		Err         string        `json:"error,omitempty"`
+	}
+
+	// Copy fields to output struct.
+	o.StatementID = r.StatementID
+	o.Series = r.Series
+	o.Messages = r.Messages
+	o.Partial = r.Partial
+	if r.Err != nil {
+		o.Err = r.Err.Error()
+	}
+
+	return sonic.ConfigStd.Marshal(&o)
+}
+
+// UnmarshalJSON decodes the data into the Result struct
+func (r *Result) UnmarshalJSON(b []byte) error {
+	var o struct {
+		StatementID int           `json:"statement_id"`
+		Series      []*models.Row `json:"series,omitempty"`
+		Messages    []*Message    `json:"messages,omitempty"`
+		Partial     bool          `json:"partial,omitempty"`
+		Err         string        `json:"error,omitempty"`
+	}
+
+	err := json.Unmarshal(b, &o)
+	if err != nil {
+		return err
+	}
+	r.StatementID = o.StatementID
+	r.Series = o.Series
+	r.Messages = o.Messages
+	r.Partial = o.Partial
+	if o.Err != "" {
+		r.Err = errors.New(o.Err)
+	}
+	return nil
+}

--- a/lib/util/lifted/influx/query/task_manager.go
+++ b/lib/util/lifted/influx/query/task_manager.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
@@ -125,19 +124,19 @@ func (t *TaskManager) ExecuteStatement(stmt influxql.Statement, ctx *ExecutionCo
 			return err
 		}
 
-		ctx.Send(&query.Result{
+		ctx.Send(&Result{
 			Series: rows,
 		}, seq)
 	case *influxql.KillQueryStatement:
-		var messages []*query.Message
+		var messages []*Message
 		if ctx.ReadOnly {
-			messages = append(messages, query.ReadOnlyWarning(stmt.String()))
+			messages = append(messages, ReadOnlyWarning(stmt.String()))
 		}
 
 		if err := t.executeKillQueryStatement(stmt); err != nil {
 			return err
 		}
-		ctx.Send(&query.Result{
+		ctx.Send(&Result{
 			Messages: messages,
 		}, seq)
 	default:

--- a/lib/util/lifted/promql2influxql/receiver.go
+++ b/lib/util/lifted/promql2influxql/receiver.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"

--- a/services/continuousquery/service.go
+++ b/services/continuousquery/service.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	query2 "github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
 	"github.com/openGemini/openGemini/lib/syscontrol"
@@ -49,7 +48,7 @@ type MetaClient interface {
 }
 
 type QueryExecutor interface {
-	ExecuteQuery(query *influxql.Query, opt query.ExecutionOptions, closing chan struct{}, qDuration *statistics.SQLSlowQueryStatistics) <-chan *query2.Result
+	ExecuteQuery(query *influxql.Query, opt query.ExecutionOptions, closing chan struct{}, qDuration *statistics.SQLSlowQueryStatistics) <-chan *query.Result
 }
 
 // Service represents a service for managing continuous queries.
@@ -264,7 +263,7 @@ func (s *Service) ExecuteContinuousQuery(cq *ContinuousQuery, now time.Time) (bo
 }
 
 // runContinuousQueryAndWriteResult will run the query and write the results.
-func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) *query2.Result {
+func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) *query.Result {
 	// Wrap the CQ's inner SELECT statement in a Query for the Executor.
 	q := &influxql.Query{
 		Statements: influxql.Statements([]influxql.Statement{cq.source}),

--- a/services/continuousquery/service_test.go
+++ b/services/continuousquery/service_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	query2 "github.com/influxdata/influxdb/query"
 	"github.com/openGemini/openGemini/lib/config"
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/logger"
@@ -39,7 +38,7 @@ import (
 type MockMetaClient struct {
 	DatabasesFn                      func() map[string]*meta.DatabaseInfo
 	GetCqLeaseFn                     func() ([]string, error)
-	QueryExecutorFn                  func() <-chan *query2.Result
+	QueryExecutorFn                  func() <-chan *query.Result
 	GetMaxCQChangeIDFn               func() uint64
 	BatchUpdateContinuousQueryStatFn func() error
 
@@ -75,11 +74,11 @@ func (mc *MockMetaClient) BatchUpdateContinuousQueryStat(cqStats map[string]int6
 
 // mockQueryExecutor is a mock query executor
 type mockQueryExecutor struct {
-	ExecuteQueryFn func(results chan *query2.Result)
+	ExecuteQueryFn func(results chan *query.Result)
 }
 
-func (e *mockQueryExecutor) ExecuteQuery(query *influxql.Query, opt query.ExecutionOptions, closing chan struct{}, qDuration *statistics.SQLSlowQueryStatistics) <-chan *query2.Result {
-	res := make(chan *query2.Result)
+func (e *mockQueryExecutor) ExecuteQuery(q *influxql.Query, opt query.ExecutionOptions, closing chan struct{}, qDuration *statistics.SQLSlowQueryStatistics) <-chan *query.Result {
+	res := make(chan *query.Result)
 	go e.ExecuteQueryFn(res)
 	return res
 }
@@ -143,8 +142,8 @@ func TestService_handle(t *testing.T) {
 		changed: make(chan chan struct{}, 10),
 	}
 	s.QueryExecutor = &mockQueryExecutor{
-		ExecuteQueryFn: func(results chan *query2.Result) {
-			results <- &query2.Result{}
+		ExecuteQueryFn: func(results chan *query.Result) {
+			results <- &query.Result{}
 		},
 	}
 	s.handle()
@@ -244,8 +243,8 @@ func NewContinuousQueryService() (*Service, *ContinuousQuery) {
 func TestService_ExecuteContinuousQuery_Error(t *testing.T) {
 	s, cq := NewContinuousQueryService()
 	s.QueryExecutor = &mockQueryExecutor{
-		ExecuteQueryFn: func(results chan *query2.Result) {
-			results <- &query2.Result{Err: fmt.Errorf("mock error")}
+		ExecuteQueryFn: func(results chan *query.Result) {
+			results <- &query.Result{Err: fmt.Errorf("mock error")}
 		},
 	}
 	now := time.Now()
@@ -266,8 +265,8 @@ func (mockRegister) RetryRegisterQueryIDOffset(host string) (uint64, error) {
 func TestService_ExecuteContinuousQuery_Successfully(t *testing.T) {
 	s, cq := NewContinuousQueryService()
 	s.QueryExecutor = &mockQueryExecutor{
-		ExecuteQueryFn: func(results chan *query2.Result) {
-			results <- &query2.Result{}
+		ExecuteQueryFn: func(results chan *query.Result) {
+			results <- &query.Result{}
 		},
 	}
 
@@ -282,8 +281,8 @@ func TestService_ExecuteContinuousQuery_Cooling(t *testing.T) {
 	// test when the statement is executed successfully
 	s, cq := NewContinuousQueryService()
 	s.QueryExecutor = &mockQueryExecutor{
-		ExecuteQueryFn: func(results chan *query2.Result) {
-			results <- &query2.Result{}
+		ExecuteQueryFn: func(results chan *query.Result) {
+			results <- &query.Result{}
 		},
 	}
 
@@ -296,8 +295,8 @@ func TestService_ExecuteContinuousQuery_Cooling(t *testing.T) {
 func TestService_ExecuteContinuousQuery_WithTimeZone(t *testing.T) {
 	s, _ := NewContinuousQueryService()
 	s.QueryExecutor = &mockQueryExecutor{
-		ExecuteQueryFn: func(results chan *query2.Result) {
-			results <- &query2.Result{}
+		ExecuteQueryFn: func(results chan *query.Result) {
+			results <- &query.Result{}
 		},
 	}
 

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -21,13 +21,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/influxdb/query"
 	_ "github.com/influxdata/influxdb/toml"
 	jsoniter "github.com/json-iterator/go"
 	tssql "github.com/openGemini/openGemini/app/ts-sql/sql"
 	"github.com/openGemini/openGemini/lib/config"
 	_ "github.com/openGemini/openGemini/lib/logger"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/meta"
+	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
 )
 
 var verboseServerLogs bool


### PR DESCRIPTION

openGemini write a response to the client via HTTP, and the HTTP message content is in JSON format. After using sonicJson, Marshal's performance increased by 84%.