### PR TITLE
fix(log): delete the remote obs dir when drop db/rp/measurements

### DIFF
--- a/app/ts-meta/meta/store.go
+++ b/app/ts-meta/meta/store.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openGemini/openGemini/lib/logger"
 	mclient "github.com/openGemini/openGemini/lib/metaclient"
 	"github.com/openGemini/openGemini/lib/netstorage"
+	"github.com/openGemini/openGemini/lib/obs"
 	"github.com/openGemini/openGemini/lib/rand"
 	stat "github.com/openGemini/openGemini/lib/statisticsPusher/statistics"
 	"github.com/openGemini/openGemini/lib/util/lifted/hashicorp/serf/serf"
@@ -815,10 +816,35 @@ func (s *Store) deleteMeasurement(db string, rp *meta.RetentionPolicyInfo, mst s
 }
 
 // deletePtDir deletes data/db/pt dir and wal/db/pt dir
-func (s *Store) deletePtDir(db string, pt uint32) error {
+func (s *Store) deletePtDir(db string, pt uint32, obsOpt *obs.ObsOptions) error {
 	ptId := strconv.Itoa(int(pt))
 	dataPtPath := path.Join(s.config.DataDir, config.DataDirectory, db, ptId)
 	lock := fileops.FileLockOption("")
+	if obsOpt != nil {
+		if err := fileops.DeleteObsPath(path.Join(config.DataDirectory, db, ptId), obsOpt); err != nil {
+			return err
+		}
+	}
+	if err := fileops.RemoveAll(dataPtPath, lock); err != nil {
+		return err
+	}
+	walPtPath := path.Join(s.config.WalDir, config.WalDirectory, db, ptId)
+	if err := fileops.RemoveAll(walPtPath, lock); err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteRpDir deletes data/db/pt/rp dir and wal/db/pt/rp dir
+func (s *Store) deleteRpDir(db, rp string, pt uint32, obsOpt *obs.ObsOptions) error {
+	ptId := strconv.Itoa(int(pt))
+	dataPtPath := path.Join(s.config.DataDir, config.DataDirectory, db, ptId, rp)
+	lock := fileops.FileLockOption("")
+	if obsOpt != nil {
+		if err := fileops.DeleteObsPath(path.Join(config.DataDirectory, db, ptId, rp), obsOpt); err != nil {
+			return err
+		}
+	}
 	if err := fileops.RemoveAll(dataPtPath, lock); err != nil {
 		return err
 	}
@@ -832,6 +858,11 @@ func (s *Store) deletePtDir(db string, pt uint32) error {
 func (s *Store) deleteRetentionPolicy(db string, rp string) error {
 	s.cacheMu.RLock()
 	ptInfos := s.cacheData.PtView[db]
+	dbInfo, ok := s.cacheData.Databases[db]
+	if !ok {
+		s.cacheMu.RUnlock()
+		return nil
+	}
 
 	errChan := make(chan error)
 	n := 0
@@ -840,6 +871,15 @@ func (s *Store) deleteRetentionPolicy(db string, rp string) error {
 		if node == nil {
 			continue
 		}
+		// in shared-storage case and the node is not alive status, remove pt dir directly
+		if config.IsLogKeeper() && node.Status != serf.StatusAlive {
+			if err := s.deleteRpDir(db, rp, ptInfos[i].PtId, dbInfo.Options); err != nil {
+				s.cacheMu.RUnlock()
+				return err
+			}
+			continue
+		}
+
 		n++
 		go func(node *meta.DataNode, db string, rp string, pt uint32) {
 			errChan <- s.NetStore.DeleteRetentionPolicy(node, db, rp, pt)
@@ -935,6 +975,11 @@ func (s *Store) checkDelete(deleteType int) {
 func (s *Store) deleteDatabase(dbName string) error {
 	s.cacheMu.RLock()
 	ptInfos := s.cacheData.PtView[dbName]
+	dbInfo, ok := s.cacheData.Databases[dbName]
+	if !ok {
+		s.cacheMu.RUnlock()
+		return nil
+	}
 
 	errChan := make(chan error)
 	n := 0
@@ -946,8 +991,9 @@ func (s *Store) deleteDatabase(dbName string) error {
 
 		// in shared-storage case and the node is not alive status, remove pt dir directly
 		// case: 1.drop database 2.store1 failed 3.database only dropped until store1 startup
-		if config.GetHaPolicy() == config.SharedStorage && node.Status != serf.StatusAlive {
-			if err := s.deletePtDir(dbName, ptInfos[i].PtId); err != nil {
+		if (config.GetHaPolicy() == config.SharedStorage || config.IsLogKeeper()) && node.Status != serf.StatusAlive {
+			if err := s.deletePtDir(dbName, ptInfos[i].PtId, dbInfo.Options); err != nil {
+				s.cacheMu.RUnlock()
 				return err
 			}
 			continue

--- a/app/ts-store/storage/storage.go
+++ b/app/ts-store/storage/storage.go
@@ -273,6 +273,9 @@ func OpenStorage(path string, node *metaclient.Node, cli *metaclient.Client, con
 		slaveStorage: netstorage.NewNetStorage(cli),
 	}
 
+	if cli != nil {
+		eng.SetMetaClient(cli)
+	}
 	s.MetaClient = cli
 	s.log = logger.NewLogger(errno.ModuleStorageEngine)
 	// Append services.

--- a/engine/engine_ha.go
+++ b/engine/engine_ha.go
@@ -141,7 +141,7 @@ func (e *Engine) Assign(opId uint64, nodeId uint64, db string, ptId uint32, ver 
 		return errno.NewError(errno.PtIsAlreadyMigrating)
 	}
 	defer e.clearDbPtMigrating(db, ptId)
-	e.setMetaClient(client)
+	e.SetMetaClient(client)
 	if e.metaClient.IsSQLiteEnabled() && e.fileInfos == nil {
 		e.fileInfos = make(chan []immutable.FileInfoExtend, MaxFileInfoSize)
 		go func() {

--- a/engine/engine_ha_test.go
+++ b/engine/engine_ha_test.go
@@ -76,7 +76,7 @@ func TestPreOffLoadPts001(t *testing.T) {
 	go func() {
 		err := eng.DeleteDatabase(defaultDb, defaultPtId)
 		if err != nil {
-			t.Error("expect delete database success")
+			t.Error("expect delete database success", zap.Error(err))
 		}
 		wg.Done()
 	}()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -57,6 +57,14 @@ import (
 	"go.uber.org/zap"
 )
 
+type mockMetaClient4Drop struct {
+	metaclient.MetaClient
+}
+
+func (m *mockMetaClient4Drop) DatabaseOption(database string) (*obs.ObsOptions, error) {
+	return nil, nil
+}
+
 type shardMock struct {
 	rp      string
 	id      uint64
@@ -204,6 +212,7 @@ func initEngine(dir string) (*Engine, error) {
 	if err != nil {
 		panic(err)
 	}
+	eng.metaClient = &mockMetaClient4Drop{}
 
 	return eng, nil
 }

--- a/lib/metaclient/meta_client.go
+++ b/lib/metaclient/meta_client.go
@@ -165,6 +165,7 @@ type MetaClient interface {
 	CreateUser(name, password string, admin, rwuser bool) (meta2.User, error)
 	Databases() map[string]*meta2.DatabaseInfo
 	Database(name string) (*meta2.DatabaseInfo, error)
+	DatabaseOption(name string) (*obs.ObsOptions, error)
 	DataNode(id uint64) (*meta2.DataNode, error)
 	DataNodes() ([]meta2.DataNode, error)
 	AliveReadNodes() ([]meta2.DataNode, error)
@@ -955,6 +956,17 @@ func (c *Client) Database(name string) (*meta2.DatabaseInfo, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.cacheData.GetDatabase(name)
+}
+
+// returns obs options info for the requested database.
+func (c *Client) DatabaseOption(name string) (*obs.ObsOptions, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	dbi := c.cacheData.Database(name)
+	if dbi == nil {
+		return nil, errno.NewError(errno.DatabaseNotFound, name)
+	}
+	return dbi.Options, nil
 }
 
 // Databases returns a list of all database infos.

--- a/lib/metaclient/meta_client_test.go
+++ b/lib/metaclient/meta_client_test.go
@@ -3182,3 +3182,23 @@ func TestClient_InsertFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_DatabaseOption(t *testing.T) {
+	c := &Client{
+		cacheData: &meta2.Data{
+			Databases: map[string]*meta2.DatabaseInfo{
+				"db0": {
+					Name: "db0",
+				},
+			},
+		},
+	}
+	_, err := c.DatabaseOption("db0")
+	if err != nil {
+		t.Fatalf("get database option failed, %+v", err)
+	}
+	_, err = c.DatabaseOption("db1")
+	if err == nil {
+		t.Fatalf("databases does not exist, but no error returned")
+	}
+}

--- a/lib/netstorage/engine.go
+++ b/lib/netstorage/engine.go
@@ -136,6 +136,7 @@ type Engine interface {
 
 	RaftMessage
 	CreateShowTagValuesPlan(db string, ptIDs []uint32, tr *influxql.TimeRange) ShowTagValuesPlan
+	SetMetaClient(m metaclient.MetaClient)
 }
 
 type RaftMessage interface {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #578 

### What is changed and how it works?

When drop db/rp/measurements, also delete the data stored on the OBS object.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
