### PR TITLE
fix: show tag values skip sid not found in index

### DIFF
--- a/engine/immutable/sequence_iterator.go
+++ b/engine/immutable/sequence_iterator.go
@@ -148,14 +148,12 @@ func (itr *sequenceIterator) iterateFile(f TSSPFile) error {
 		offsets = append(offsets, uint32(len(buf)))
 		for k := 0; k < len(offsets)-1; k++ {
 			err = itr.handler.NextChunkMeta(buf[offsets[k]:offsets[k+1]])
-			if err != nil {
-				return err
-			}
-
-			// sid not found in index, skip
-			if errno.Equal(err, errno.ErrSearchSeriesKey) {
+			if err != nil && errno.Equal(err, errno.ErrSearchSeriesKey) {
+				// sid not found in index, skip
 				itr.logger.Warn("sequenceIterator.iterateFile NextChunkMeta search sid failed", zap.Error(err))
 				continue
+			} else if err != nil {
+				return err
 			}
 
 			// reach the limit


### PR DESCRIPTION
show tag values will skip sid which not found in the index

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
