### PR TITLE
fix: time disorder of order files after merge unordered data

### DIFF
--- a/engine/immutable/merge_out_of_order.go
+++ b/engine/immutable/merge_out_of_order.go
@@ -234,7 +234,7 @@ func (m *MmsTables) matchOrderFiles(ctx *MergeContext) {
 			continue
 		}
 
-		if ctx.tr.Overlaps(min, max) || min > ctx.tr.Max {
+		if ctx.order.Len() > 0 || ctx.tr.Overlaps(min, max) || min > ctx.tr.Max {
 			ctx.order.add(f)
 		}
 	}


### PR DESCRIPTION
time disorder of order files after merge unordered data