### PR TITLE
feat(storage): set full text bf block size to 8m

### DIFF
--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -60,7 +60,7 @@ const (
 	NonStreamingCompact               = 2
 	StreamingCompact                  = 1
 	AutoCompact                       = 0
-	DefaultExpectedSegmentSize uint32 = 1024 * 1024
+	DefaultExpectedSegmentSize uint32 = 8 * 1024 * 1024
 	DefaultFileSizeLimit              = 8 * 1024 * 1024 * 1024
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

set DefaultExpectedSegmentSize = 8 * 1024*1024

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
