### PR TITLE
feat(replication): add file implement for raft entry logs

### DIFF
--- a/lib/raftlog/file.go
+++ b/lib/raftlog/file.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package raftlog
+
+import (
+	"bufio"
+	"io"
+
+	"github.com/cockroachdb/errors"
+	"github.com/openGemini/openGemini/lib/fileops"
+)
+
+var NewFile = errors.New("Create a new file")
+
+type FileWrapper interface {
+	Name() string
+	Size() int
+	Write(dat []byte) (int, error)
+	WriteAt(offset int64, dat []byte) (int, error)
+	TrySync() error
+	Close() error
+}
+
+// FileWrap represents a file and includes both the buffer to the data
+// and the file descriptor.
+type FileWrap struct {
+	fd   fileops.File
+	data []byte
+}
+
+// OpenFile opens an existing file or creates a new file. If the file is
+// created, it would truncate the file to maxSz. In case the file is created, z.NewFile is
+// returned.
+func OpenFile(fpath string, flag int, maxSz int) (FileWrapper, error) {
+	fd, err := fileops.OpenFile(fpath, flag, 0640, fileops.FilePriorityOption(fileops.IO_PRIORITY_NORMAL))
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to open: %s", fpath)
+	}
+
+	filename := fd.Name()
+	fi, err := fd.Stat()
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot stat file: %s", filename)
+	}
+
+	fw := &FileWrap{
+		fd: fd,
+	}
+
+	var rerr error
+	fileSize := fi.Size()
+	if maxSz > 0 && fileSize == 0 {
+		// If file is empty, truncate it to sz.
+		var buff = make([]byte, maxSz)
+		if _, err = fw.Write(buff); err != nil {
+			return nil, errors.Wrapf(err, "error while truncation")
+		}
+		if err = fw.TrySync(); err != nil {
+			return nil, errors.Wrapf(err, "error while trySync")
+		}
+		rerr = NewFile
+	} else {
+		reader := bufio.NewReader(fd)
+		content, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error while reading file:%s", fw.Name())
+		}
+		fw.data = content
+	}
+	return fw, rerr
+}
+
+func (fw *FileWrap) Name() string {
+	if fw.fd == nil {
+		return ""
+	}
+	return fw.fd.Name()
+}
+
+func (fw *FileWrap) Size() int {
+	return len(fw.data)
+}
+
+func (fw *FileWrap) Write(dat []byte) (int, error) {
+	n, err := fw.fd.Write(dat)
+	if err != nil {
+		return 0, errors.Wrapf(err, "write failed:%s", fw.Name())
+	}
+	fw.data = append(fw.data, dat...)
+	return n, err
+}
+
+func (fw *FileWrap) WriteAt(offset int64, dat []byte) (int, error) {
+	_, err := fw.fd.Seek(offset, 0)
+	if err != nil {
+		return 0, errors.Wrapf(err, "seek unreachable file:%s", fw.fd.Name())
+	}
+	n, err := fw.fd.Write(dat)
+	if err != nil {
+		return 0, errors.Wrapf(err, "write failed for file:%s", fw.fd.Name())
+	}
+	copy(fw.data[offset:], dat)
+	_, err = fw.fd.Seek(0, io.SeekEnd)
+	return n, errors.Wrapf(err, "seek unreachable file:%s", fw.fd.Name())
+}
+
+func (fw *FileWrap) Close() error {
+	if err := fw.TrySync(); err != nil {
+		return errors.Wrapf(err, "sync error:%s", fw.Name())
+	}
+	return fw.fd.Close()
+}
+
+func (fw *FileWrap) TrySync() error {
+	if fw.fd == nil {
+		return nil
+	}
+	return fw.fd.Sync()
+}

--- a/lib/raftlog/file_test.go
+++ b/lib/raftlog/file_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package raftlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openGemini/openGemini/lib/fileops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type badSeeker struct {
+	fileops.File
+}
+
+func (badSeeker) Name() string {
+	return "test file"
+}
+
+func (badSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, fmt.Errorf("mock seek error")
+}
+
+type badWriter struct {
+	badSeeker
+}
+
+func (badWriter) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+func (badWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("mock write error")
+}
+
+func TestFileWrap_OpenFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Run("OpenFile", func(t *testing.T) {
+		fw, err := OpenFile(filepath.Join(tmpDir, "test"), os.O_CREATE|os.O_RDWR, 1000)
+		require.EqualError(t, err, NewFile.Error())
+		defer fw.Close()
+
+		assert.Contains(t, fw.Name(), "test")
+		assert.Equal(t, 1000, fw.Size())
+	})
+
+	t.Run("OpenFile_twice", func(t *testing.T) {
+		fw, err := OpenFile(filepath.Join(tmpDir, "test2"), os.O_CREATE|os.O_RDWR, 1000)
+		require.EqualError(t, err, NewFile.Error())
+		defer fw.Close()
+
+		assert.Contains(t, fw.Name(), "test")
+
+		fw2, err := OpenFile(filepath.Join(tmpDir, "test2"), os.O_CREATE|os.O_RDWR, 1000)
+		require.NoError(t, err)
+		defer fw2.Close()
+
+		assert.Contains(t, fw2.Name(), "test")
+		assert.Equal(t, 1000, fw2.Size())
+
+		fw3 := &FileWrap{}
+		require.Equal(t, "", fw3.Name())
+	})
+}
+
+func TestFileWrap_Write_WriteAt(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Run("WriteAt_Success", func(t *testing.T) {
+		file, err := fileops.OpenFile(filepath.Join(tmpDir, "test"), os.O_CREATE|os.O_RDWR, 0640)
+		require.NoError(t, err)
+		file.Write([]byte("writeahead"))
+
+		fw := &FileWrap{fd: file}
+		defer fw.Close()
+		fw.data = []byte("writeahead")
+
+		n, err := fw.WriteAt(0, []byte("hello"))
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, []byte("hello"), fw.data[:5])
+		var buff = make([]byte, 10)
+		n, err = file.ReadAt(buff, 0)
+		require.NoError(t, err)
+		require.Equal(t, []byte("helloahead"), buff)
+		require.Equal(t, []byte("helloahead"), fw.data)
+
+		n, err = fw.Write([]byte("world"))
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		buff = make([]byte, 15)
+		n, err = file.ReadAt(buff, 0)
+		require.NoError(t, err)
+		require.Equal(t, []byte("helloaheadworld"), buff)
+		require.Equal(t, []byte("helloaheadworld"), fw.data)
+
+		n, err = fw.WriteAt(5, []byte("faker"))
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		buff = make([]byte, 15)
+		n, err = file.ReadAt(buff, 0)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hellofakerworld"), buff)
+		require.Equal(t, []byte("hellofakerworld"), fw.data)
+	})
+
+	t.Run("WriteAt_SeekError", func(t *testing.T) {
+		fw := &FileWrap{fd: &badSeeker{}, data: make([]byte, 10)}
+
+		_, err := fw.WriteAt(0, []byte("hello"))
+		require.EqualError(t, err, "seek unreachable file:test file: mock seek error")
+	})
+
+	t.Run("Write_badWriter", func(t *testing.T) {
+		fw := &FileWrap{fd: &badWriter{}, data: make([]byte, 10)}
+		_, err := fw.Write([]byte("hello"))
+		require.EqualError(t, err, "write failed:test file: mock write error")
+	})
+
+	t.Run("WriteAt_badWriter", func(t *testing.T) {
+		fw := &FileWrap{fd: &badWriter{}, data: make([]byte, 10)}
+		_, err := fw.WriteAt(0, []byte("hello"))
+		require.EqualError(t, err, "write failed for file:test file: mock write error")
+	})
+}
+
+func TestFileWrap_TrySync(t *testing.T) {
+	t.Run("TrySync_fd_is_nil", func(t *testing.T) {
+		fw := &FileWrap{}
+
+		require.NoError(t, fw.TrySync())
+	})
+}

--- a/lib/raftlog/meta.go
+++ b/lib/raftlog/meta.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package raftlog
+
+// Constants to use when writing to meta and entry files.
+const (
+	// metaFileSize is the size of the raft.meta file.
+	//lint:ignore U1000 keep this
+	metaFileSize = 1 << 20 // 1MB
+)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->


<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->



### What is changed and how it works?
add file implement for raft entry logs

### How Has This Been Tested?

- [x] self tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
