### PR TITLE
feat(log): add the prefetching of bloomfilter cache

### DIFF
--- a/app/ts-store/run/server.go
+++ b/app/ts-store/run/server.go
@@ -139,6 +139,7 @@ func NewServer(c config.Config, info app.ServerInfo, logger *Logger.Logger) (app
 	s.sherlockService = sherlock.NewService(conf.Sherlock)
 	s.sherlockService.WithLogger(s.Logger)
 	logstore.InitializeVlmCache()
+	logstore.StartHotDataDetector()
 
 	return s, nil
 }

--- a/engine/index/bloomfilter/filter_reader.go
+++ b/engine/index/bloomfilter/filter_reader.go
@@ -170,7 +170,7 @@ func NewVerticalFilterReader(path string, obsOpts *obs.ObsOptions, expr influxql
 	v := &VerticalFilterReader{
 		r:           dr,
 		groupIndex:  -1,
-		bloomFilter: bloomfilter.DefaultOneHitBloomFilter(version),
+		bloomFilter: bloomfilter.DefaultOneHitBloomFilter(version, logstore.GetConstant(version).FilterDataMemSize),
 	}
 	v.version = version
 	verticalFilterLen, err := dr.Size()

--- a/lib/bloomfilter/bloomfilter.go
+++ b/lib/bloomfilter/bloomfilter.go
@@ -17,8 +17,6 @@ package bloomfilter
 
 import (
 	"encoding/binary"
-
-	"github.com/openGemini/openGemini/lib/logstore"
 )
 
 var tableLow = make([]uint64, 256)
@@ -205,7 +203,7 @@ func NewOneHitBloomFilter(bytes []byte, version uint32) Bloomfilter {
 	}
 }
 
-func DefaultOneHitBloomFilter(version uint32) Bloomfilter {
-	bytes := make([]byte, logstore.GetConstant(version).FilterDataMemSize)
+func DefaultOneHitBloomFilter(version uint32, bloomfiterSize int64) Bloomfilter {
+	bytes := make([]byte, bloomfiterSize)
 	return NewOneHitBloomFilter(bytes, version)
 }

--- a/lib/bloomfilter/bloomfilter_test.go
+++ b/lib/bloomfilter/bloomfilter_test.go
@@ -19,14 +19,13 @@ import (
 	"math/bits"
 	"testing"
 
-	"github.com/openGemini/openGemini/lib/logstore"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBloomFilter(t *testing.T) {
-	version := []uint32{0, 2, 3}
+	version := [][2]uint32{{0, 32*1024 + 64}, {2, 256*1024 + 64}, {3, 256*1024 + 64}}
 	for _, v := range version {
-		bf := DefaultOneHitBloomFilter(v)
+		bf := DefaultOneHitBloomFilter(v[0], int64(v[1]))
 		bf.Add(Hash([]byte("a")))
 		bf.Add(Hash([]byte("b")))
 		bf.Add(Hash([]byte("writeChan")))
@@ -41,9 +40,9 @@ func TestBloomFilter(t *testing.T) {
 }
 
 func TestBloomFilterWithConflict(t *testing.T) {
-	version := []uint32{0, 2, 3}
+	version := [][2]uint32{{0, 32*1024 + 64}, {2, 256*1024 + 64}, {3, 256*1024 + 64}}
 	for _, v := range version {
-		bf := DefaultOneHitBloomFilter(v)
+		bf := DefaultOneHitBloomFilter(v[0], int64(v[1]))
 		bf.Add(Hash([]byte("a")))
 		bf.Add(Hash([]byte("b")))
 		bf.Add(Hash([]byte("writeChan")))
@@ -58,10 +57,14 @@ func TestBloomFilterWithConflict(t *testing.T) {
 	}
 }
 
+const (
+	Prime_64 uint64 = 0x9E3779B185EBCA87
+)
+
 func Hash(bytes []byte) uint64 {
 	var hash uint64 = 0
 	for _, b := range bytes {
-		hash ^= bits.RotateLeft64(hash, 11) ^ (uint64(b) * logstore.Prime_64)
+		hash ^= bits.RotateLeft64(hash, 11) ^ (uint64(b) * Prime_64)
 	}
 	return hash
 }

--- a/lib/logstore/hot_data_detector.go
+++ b/lib/logstore/hot_data_detector.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstore
+
+import (
+	"sort"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/openGemini/openGemini/lib/bloomfilter"
+	"github.com/openGemini/openGemini/lib/config"
+	"github.com/openGemini/openGemini/lib/errno"
+	"github.com/openGemini/openGemini/lib/logger"
+	"github.com/openGemini/openGemini/lib/obs"
+	"go.uber.org/zap"
+)
+
+var hotDataLogger = logger.NewLogger(errno.ModuleLogStore)
+
+const (
+	MaxReadRequestChanSize = 512
+	MaxTimeBuf             = 256
+	TimeInverval           = 30 * time.Minute
+	FrequencyThreshold     = 10
+)
+
+var (
+	PrefetchTimerInterval = 5 * time.Second
+)
+
+type PrefetchType int
+
+const (
+	PiecePrefetch PrefetchType = iota
+	GroupPrefetch
+)
+
+type LogPath struct {
+	Path     string
+	FileName string
+	Version  uint32
+	ObsOpt   *obs.ObsOptions
+}
+
+type LogReadRequest struct {
+	logPath *LogPath
+	hashes  []uint64
+}
+
+type HitHashes struct {
+	hashes    []uint64
+	visitTime int64
+}
+
+type HotDataValue struct {
+	logPath       *LogPath
+	hitHashes     *RingBuf[*HitHashes]
+	storeReader   BloomFilterReader
+	pieceLruCache BlockCache
+	groupLruCache BlockCache
+	bloomfilter   bloomfilter.Bloomfilter
+	segmentPath   string
+	pathId        uint64
+	visitTime     int64
+	startOffset   int64
+	closing       chan struct{}
+	fetchType     PrefetchType
+}
+
+type HotDataValues []*HotDataValue
+
+func (n HotDataValues) Len() int { return len(n) }
+
+func (n HotDataValues) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
+
+func (n HotDataValues) Less(i, j int) bool {
+	if n[i].hitHashes.Len() == n[j].hitHashes.Len() {
+		return n[i].visitTime > n[j].visitTime
+	}
+	return n[i].hitHashes.Len() > n[j].hitHashes.Len()
+}
+
+func NewHotDataValue(logPath *LogPath) *HotDataValue {
+	pathName := obs.Join(logPath.Path, logPath.FileName)
+	pathId := xxhash.Sum64String(pathName)
+	value := &HotDataValue{
+		hitHashes:   NewRingBuf[*HitHashes](MaxTimeBuf),
+		logPath:     logPath,
+		pathId:      pathId,
+		segmentPath: logPath.Path,
+		closing:     make(chan struct{}),
+	}
+	verticalFilterStoreReader, err := NewBasicBloomfilterReader(logPath.ObsOpt, logPath.Path, logPath.FileName)
+	if err != nil {
+		hotDataLogger.Error("new obsStore reader failed", zap.String("path", logPath.Path), zap.Error(err))
+	} else {
+		value.storeReader = verticalFilterStoreReader
+	}
+	if config.GetLogStoreConfig().IsVlmCachePiecePrefetch() {
+		value.pieceLruCache = GetHotPieceLruCache()
+		value.fetchType = PiecePrefetch
+	}
+	if config.GetLogStoreConfig().IsVlmCacheGroupPrefetch() {
+		value.groupLruCache = GetHotGroupLruCache()
+		value.fetchType = GroupPrefetch
+	}
+	value.bloomfilter = bloomfilter.DefaultOneHitBloomFilter(logPath.Version, GetConstant(logPath.Version).FilterDataMemSize)
+	return value
+}
+
+func (v *HotDataValue) SetVisitTime(visitTime int64, hashes []uint64) {
+	v.hitHashes.Write(&HitHashes{hashes: hashes, visitTime: visitTime})
+	v.visitTime = visitTime
+}
+
+func (v *HotDataValue) Frequency() int {
+	return v.hitHashes.Len()
+}
+
+func (v *HotDataValue) GroupPrefetch() {
+	filterLen, err := v.storeReader.Size()
+	if err != nil {
+		return
+	}
+	verticalGroupDiskSize := GetConstant(v.logPath.Version).VerticalGroupDiskSize
+	for v.startOffset+verticalGroupDiskSize <= filterLen {
+		result := make(map[int64][]byte)
+		err = v.storeReader.ReadBatch([]int64{v.startOffset}, []int64{verticalGroupDiskSize}, -1, true, result)
+		if err != nil {
+			hotDataLogger.Error("prefetch read failed", zap.String("path", v.segmentPath), zap.Error(err))
+			return
+		}
+		key := BlockCacheKey{PathId: v.pathId, Position: uint64(v.startOffset)}
+		v.groupLruCache.Store(key, v.logPath.Version, result[v.startOffset])
+		v.startOffset = v.startOffset + verticalGroupDiskSize
+	}
+}
+
+func (v *HotDataValue) getAllOffsets() ([]int64, []int64) {
+	verticalPieceDiskSize := GetConstant(v.logPath.Version).VerticalPieceDiskSize
+	offsetsSet := make(map[int64]struct{}, 0)
+	it := NewIterator(v.hitHashes)
+	hitHashes, ok := it.Next()
+	for ok {
+		if hitHashes != nil {
+			for _, hash := range hitHashes.hashes {
+				bytesOffset := v.bloomfilter.GetBytesOffset(hash)
+				pieceOffset := (bytesOffset >> 3) * verticalPieceDiskSize
+				offsetsSet[pieceOffset] = struct{}{}
+				if (bytesOffset % 8) != 0 {
+					offsetsSet[pieceOffset+verticalPieceDiskSize] = struct{}{}
+				}
+			}
+		}
+		hitHashes, ok = it.Next()
+	}
+
+	offsets := make([]int64, 0, len(offsetsSet))
+	lens := make([]int64, 0, len(offsetsSet))
+	for offset := range offsetsSet {
+		offsets = append(offsets, offset)
+		lens = append(lens, verticalPieceDiskSize)
+	}
+	sort.Slice(offsets, func(i, j int) bool {
+		return offsets[i] < offsets[j]
+	})
+	return offsets, lens
+}
+
+func (v *HotDataValue) getFileOffsets(offsets []int64, start int64) []int64 {
+	fileOffsets := make([]int64, len(offsets))
+	for i := 0; i < len(offsets); i++ {
+		fileOffsets[i] = offsets[i] + start
+	}
+	return fileOffsets
+}
+
+func (v *HotDataValue) PiecePrefetch() {
+	filterLen, err := v.storeReader.Size()
+	if err != nil {
+		return
+	}
+	verticalGroupDiskSize := GetConstant(v.logPath.Version).VerticalGroupDiskSize
+	if v.startOffset+verticalGroupDiskSize > filterLen {
+		return
+	}
+	offsets, lens := v.getAllOffsets()
+	for v.startOffset+verticalGroupDiskSize <= filterLen {
+		fileOffsets := v.getFileOffsets(offsets, v.startOffset)
+		results := make(map[int64][]byte, len(fileOffsets))
+		err := v.storeReader.ReadBatch(fileOffsets, lens, -1, true, results)
+		if err != nil {
+			hotDataLogger.Error("prefetch filterData failed", zap.String("path", v.segmentPath), zap.Error(err))
+			continue
+		}
+		for offset, result := range results {
+			key := BlockCacheKey{PathId: v.pathId, Position: uint64(offset)}
+			v.pieceLruCache.Store(key, v.logPath.Version, result)
+		}
+		v.startOffset = v.startOffset + verticalGroupDiskSize
+	}
+}
+
+func (v *HotDataValue) PrefetchRutine() {
+	ticker := time.NewTicker(PrefetchTimerInterval)
+	defer ticker.Stop()
+	hotDataLogger.Info("PrefetchRutine start", zap.String("segmentPath", v.segmentPath))
+	for {
+		select {
+		case <-v.closing:
+			hotDataLogger.Info("PrefetchRutine stop", zap.String("segmentPath", v.segmentPath))
+			if v.storeReader != nil {
+				v.storeReader.Close()
+			}
+			return
+		case <-ticker.C:
+			if v.fetchType == PiecePrefetch {
+				v.PiecePrefetch()
+			} else {
+				v.GroupPrefetch()
+			}
+		}
+	}
+}
+
+func (v *HotDataValue) Open() {
+	if v.storeReader == nil {
+		return
+	}
+	go v.PrefetchRutine()
+}
+
+func (v *HotDataValue) Close() {
+	if v.closing != nil {
+		close(v.closing)
+	}
+}
+
+type HotDataDetector struct {
+	logRequestChan chan *LogReadRequest
+	itemsMap       map[string]*HotDataValue // map-key is segmentPath
+	items          []*HotDataValue
+}
+
+func NewHotDataDetector() *HotDataDetector {
+	return &HotDataDetector{
+		logRequestChan: make(chan *LogReadRequest, MaxReadRequestChanSize),
+		itemsMap:       make(map[string]*HotDataValue, 0),
+		items:          make([]*HotDataValue, 0),
+	}
+}
+
+func (d *HotDataDetector) Close() {
+	close(d.logRequestChan)
+	// close reader
+	for i := 0; i < len(d.items); i++ {
+		d.items[i].Close()
+	}
+}
+
+func (d *HotDataDetector) Len() int {
+	return len(d.items)
+}
+
+func (d *HotDataDetector) evictTime() bool {
+	canEvict := false
+	t := time.Now().UTC().UnixNano()
+	for i := 0; i < len(d.items); i++ {
+		hitHashes := d.items[i].hitHashes
+		for !hitHashes.Empty() {
+			hitHash := hitHashes.ReadOldest()
+			if hitHash == nil {
+				continue
+			}
+			if hitHash.visitTime+int64(TimeInverval) > t {
+				break
+			}
+			hitHashes.RemoveOldest()
+		}
+		if d.items[i].Frequency() < FrequencyThreshold {
+			canEvict = true
+		}
+	}
+	if canEvict {
+		sort.Sort(HotDataValues(d.items))
+	}
+	return canEvict
+}
+
+func (d *HotDataDetector) Evict() bool {
+	if !d.evictTime() {
+		return false
+	}
+	i := len(d.items)
+	for ; i > 0; i-- {
+		if d.items[i-1].Frequency() != 0 {
+			break
+		}
+		d.items[i-1].Close()
+		hotDataLogger.Info("Evict logPath prefetcher", zap.String("segmentPath", d.items[i-1].segmentPath))
+		delete(d.itemsMap, d.items[i-1].segmentPath)
+	}
+	d.items = d.items[:i]
+	return true
+}
+
+func (d *HotDataDetector) ForceEvict() bool {
+	i := len(d.items)
+	if i == 0 {
+		return true
+	}
+	// evict
+	if d.items[i-1].Frequency() > FrequencyThreshold {
+		return false
+	}
+	d.items[i-1].Close()
+	hotDataLogger.Info("Evict", zap.String("segmentPath", d.items[i-1].segmentPath))
+	delete(d.itemsMap, d.items[i-1].segmentPath)
+	d.items = d.items[:i-1]
+	return true
+}
+
+func (d *HotDataDetector) addNewItems(request *LogReadRequest) {
+	canForceEvict := d.Evict()
+	// add new value
+	prefetchNums := int(config.GetLogStoreConfig().GetVlmCachePrefetchNums())
+	if (len(d.items) < prefetchNums) || (canForceEvict && d.ForceEvict()) {
+		t := time.Now().UTC().UnixNano()
+		value := NewHotDataValue(request.logPath)
+		value.SetVisitTime(t, request.hashes)
+		d.itemsMap[value.segmentPath] = value
+		d.items = append(d.items, value)
+		value.Open()
+		return
+	}
+}
+
+func (d *HotDataDetector) DetectHotLogPath(request *LogReadRequest) {
+	if request == nil || request.logPath == nil {
+		return
+	}
+	logInfo, err := obs.ParseLogPath(request.logPath.Path)
+	if err != nil {
+		hotDataLogger.Error("ParseLogPath failed", zap.Error(err))
+		return
+	}
+	t := time.Now().UTC().UnixNano()
+	if !logInfo.Contains(t) {
+		return
+	}
+	value, ok := d.itemsMap[request.logPath.Path]
+	if ok {
+		value.SetVisitTime(t, request.hashes)
+		return
+	}
+	d.addNewItems(request)
+}
+
+func (d *HotDataDetector) Running() {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	hotDataLogger.Info("hot data detector start")
+	for {
+		select {
+		case request, ok := <-d.logRequestChan:
+			if !ok {
+				hotDataLogger.Info("hot data detector stop")
+				return
+			}
+			d.DetectHotLogPath(request)
+		case <-ticker.C:
+			d.Evict()
+		}
+	}
+}
+
+var hotDataDetector = NewHotDataDetector()
+
+func SendLogRequest(readRequest *LogReadRequest) {
+	hotDataDetector.logRequestChan <- readRequest
+}
+
+func SendLogRequestWithHash(object *LogPath, queryHashes map[string][]uint64) {
+	if !GetVlmCacheInitialized() || !config.GetLogStoreConfig().IsVlmPrefetchEnable() {
+		return
+	}
+
+	hashes := make([]uint64, 0)
+	hashesMap := make(map[uint64]struct{}, 0)
+	for _, tmpHashes := range queryHashes {
+		for _, hash := range tmpHashes {
+			if _, ok := hashesMap[hash]; ok {
+				continue
+			}
+			hashesMap[hash] = struct{}{}
+			hashes = append(hashes, hash)
+		}
+	}
+	SendLogRequest(&LogReadRequest{logPath: object, hashes: hashes})
+}
+
+func HotDataDetectorTaskLen() int {
+	return hotDataDetector.Len()
+}
+
+func StartHotDataDetector() {
+	go hotDataDetector.Running()
+}
+
+func StopHotDataDetector() {
+	hotDataDetector.Close()
+}

--- a/lib/logstore/hot_data_detector_test.go
+++ b/lib/logstore/hot_data_detector_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2024 Huawei Cloud Computing Technologies Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package logstore
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openGemini/openGemini/lib/config"
+	"github.com/openGemini/openGemini/lib/obs"
+	"github.com/openGemini/openGemini/lib/tracing"
+)
+
+func TestHotDataDetector(t *testing.T) {
+	StartHotDataDetector()
+	logstoreConfig := config.NewLogStoreConfig()
+	logstoreConfig.VlmCachePiecePrefetch = true
+	logstoreConfig.VlmCachePrefetchNum = 64
+	config.SetLogStoreConfig(logstoreConfig)
+	SetVlmCacheInitialized(true)
+	startTime := time.Now().Truncate(24 * time.Hour)
+	endTime := startTime.Add(24 * time.Hour)
+	SendLogRequestWithHash(&LogPath{Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", "logstream")},
+		map[string][]uint64{"aa": {1, 2, 3, 4}})
+	SendLogRequestWithHash(&LogPath{Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", "logstream1")},
+		map[string][]uint64{"ab": {4, 5, 3, 4}})
+	SendLogRequestWithHash(&LogPath{Path: "data/cardinality1/0/test1/7_1695859200000000000_1695945600000000000_7/columnstore"},
+		map[string][]uint64{"ac": {1, 2, 6, 7}})
+	time.Sleep(1 * time.Second)
+	if HotDataDetectorTaskLen() != 2 {
+		t.Fatalf("Wrong items count, expect: 2, real:%d", HotDataDetectorTaskLen())
+	}
+	SendLogRequestWithHash(&LogPath{Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", "logstream")},
+		map[string][]uint64{"ad": {1, 8, 3, 9}})
+	time.Sleep(1 * time.Second)
+	if HotDataDetectorTaskLen() != 2 {
+		t.Fatalf("Wrong items count, expect: 2, real:%d", HotDataDetectorTaskLen())
+	}
+
+	hotPathNum := int(config.GetLogStoreConfig().GetVlmCachePrefetchNums())
+	for i := 0; i < hotPathNum+10; i++ {
+		SendLogRequestWithHash(&LogPath{Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", fmt.Sprintf("logstream%d", i))},
+			map[string][]uint64{"ae": {10, 2, 11, 4}})
+	}
+	time.Sleep(1 * time.Second)
+	if HotDataDetectorTaskLen() != hotPathNum {
+		t.Fatalf("Wrong items count, expect: %d, real:%d", hotPathNum, HotDataDetectorTaskLen())
+	}
+}
+
+func TestNewHotDataDetector(t *testing.T) {
+	logstoreConfig := config.NewLogStoreConfig()
+	logstoreConfig.VlmCachePiecePrefetch = true
+	logstoreConfig.VlmCachePrefetchNum = 64
+	config.SetLogStoreConfig(logstoreConfig)
+	newDetector := NewHotDataDetector()
+	go newDetector.Running()
+
+	startTime := time.Now().Truncate(24 * time.Hour)
+	endTime := startTime.Add(24 * time.Hour)
+	hotPathNum := int(config.GetLogStoreConfig().GetVlmCachePrefetchNums())
+	for i := 0; i < 2*MaxTimeBuf; i++ {
+		for j := 0; j < hotPathNum; j++ {
+			newDetector.logRequestChan <- &LogReadRequest{logPath: &LogPath{
+				Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", fmt.Sprintf("logstream%d", j))}}
+		}
+	}
+	for j := 0; j < 2*hotPathNum; j++ {
+		newDetector.logRequestChan <- &LogReadRequest{logPath: &LogPath{
+			Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repo", fmt.Sprintf("logstream%d", j))}}
+	}
+	if len(newDetector.items) != hotPathNum {
+		t.Fatalf("Wrong items count, expect: %d, real:%d", hotPathNum, len(newDetector.items))
+	}
+	newDetector.Close()
+}
+
+type MockBloomFilterReader struct {
+	logPath *LogPath
+}
+
+func (mr *MockBloomFilterReader) ReadBatch(offs, sizes []int64, limit int, isStat bool, results map[int64][]byte) error {
+	for i, off := range offs {
+		results[off] = make([]byte, sizes[i])
+	}
+	return nil
+}
+
+func (mr *MockBloomFilterReader) Size() (int64, error) {
+	return 5 * GetConstant(mr.logPath.Version).VerticalGroupDiskSize, nil
+}
+
+func (mr *MockBloomFilterReader) Close() error {
+	return nil
+}
+
+func (mr *MockBloomFilterReader) StartSpan(span *tracing.Span) {
+}
+
+func (mr *MockBloomFilterReader) EndSpan() {
+}
+
+type MockBlockCache struct {
+}
+
+func (c *MockBlockCache) Store(key BlockCacheKey, version uint32, diskData []byte) {
+}
+
+func (c *MockBlockCache) Fetch(key BlockCacheKey) ([]byte, bool) {
+	return nil, false
+}
+
+func (c *MockBlockCache) FetchWith(key BlockCacheKey, version uint32, size int64) ([]byte, bool) {
+	return nil, false
+}
+
+func TestDataPrefetch(t *testing.T) {
+	startTime := time.Now().Truncate(24 * time.Hour)
+	endTime := startTime.Add(24 * time.Hour)
+	hotDataValue := NewHotDataValue(&LogPath{Path: obs.GetShardPath(0, 0, 1, startTime, endTime, "repoPrefetch", "logstreamPrefetch"), Version: 0})
+	hotDataValue.storeReader = &MockBloomFilterReader{logPath: hotDataValue.logPath}
+	hotDataValue.pieceLruCache = &MockBlockCache{}
+	hotDataValue.groupLruCache = &MockBlockCache{}
+	hotDataValue.SetVisitTime(1, []uint64{123456, 562949953421312, 662949953421312, 1562949953421312, 5562949953421312, 9562949953421312, 1125899906842624})
+	hotDataValue.SetVisitTime(2, []uint64{123456, 562949953421312, 662949953421312, 1562949953421312, 5562949953421312, 9562949953421312, 1125899906842624})
+	hotDataValue.SetVisitTime(3, []uint64{456789, 662949953421312, 762949953421312, 2562949953421312, 6562949953421312, 4562949953421312, 5125899906842624})
+	hotDataValue.SetVisitTime(5, []uint64{456789, 662949953421312, 762949953421312, 2562949953421312, 6562949953421312, 4562949953421312, 5125899906842624})
+	hotDataValue.SetVisitTime(5, []uint64{567890, 762949953421512, 862949953421312, 3562949953421312, 7562949953421312, 8562949953421312, 7125899906842624})
+	hotDataValue.SetVisitTime(6, []uint64{567890, 762949953421512, 862949953421312, 3562949953421312, 7562949953421312, 8562949953421312, 7125899906842624})
+	hotDataValue.SetVisitTime(6, []uint64{567890, 762949953421512, 862949953421312, 3562949953421312, 7562949953421312, 8562949953421312, 7125899906842624})
+
+	PrefetchTimerInterval = 100 * time.Millisecond
+	hotDataValue.fetchType = PiecePrefetch
+	hotDataValue.Open()
+	time.Sleep(500 * time.Millisecond)
+
+	hotDataValue.fetchType = GroupPrefetch
+	hotDataValue.startOffset = 0
+	time.Sleep(500 * time.Millisecond)
+
+	hotDataValue.startOffset = 0
+	offsets, lens := hotDataValue.getAllOffsets()
+	if len(offsets) != len(lens) {
+		t.Fatalf("the len of offsets not equal to len of lens , len(offsets): %d,  len(lens):%d", len(offsets), len(lens))
+	}
+	hotDataValue.Close()
+}

--- a/lib/obs/obs_options_test.go
+++ b/lib/obs/obs_options_test.go
@@ -17,6 +17,7 @@ package obs
 
 import (
 	"testing"
+	"time"
 )
 
 func TestObsOptionsClone(t *testing.T) {
@@ -40,5 +41,45 @@ func TestObsOptionsClone(t *testing.T) {
 	cloneOpts = srcOpts.Clone()
 	if cloneOpts != nil {
 		t.Fatal("ObsOptions clone failed")
+	}
+}
+
+func TestParseLogPath(t *testing.T) {
+	startTime := time.Now().Truncate(24 * time.Hour)
+	endTime := startTime.Add(24 * time.Hour)
+	segPath := GetShardPath(0, 0, 1, startTime, endTime, "repo", "logstream")
+	logInfo, err := ParseLogPath(segPath)
+	if err != nil {
+		t.Fatalf("ParseLogPath error: %+v", err)
+	}
+	if logInfo.RepoName != "repo" {
+		t.Fatalf("ParseLogPath repo failed, expect: repo, real: %s", logInfo.RepoName)
+	}
+	if logInfo.StartTime != startTime.UnixNano() {
+		t.Fatalf("ParseLogPath repo failed, expect: %d, real: %d", startTime.UnixNano(), logInfo.StartTime)
+	}
+	if logInfo.EndTime != endTime.UnixNano() {
+		t.Fatalf("ParseLogPath repo failed, expect: %d, real: %d", endTime.UnixNano(), logInfo.EndTime)
+	}
+
+	_, err = ParseLogPath("data/test/test1/7_1695859200000000000_1695945600000000000_7")
+	if err == nil {
+		t.Fatal("Expect ParseLogPath failed")
+	}
+	_, err = ParseLogPath("data/test/abc/test1/7_1695859200000000000_1695945600000000000_7/columnstore")
+	if err == nil {
+		t.Fatal("Expect ParseLogPath failed")
+	}
+	_, err = ParseLogPath("data/test/0/test1/x_1695859200000000000_1695945600000000000_7/columnstore")
+	if err == nil {
+		t.Fatal("Expect ParseLogPath failed")
+	}
+	_, err = ParseLogPath("data/test/0/test1/7_x695859200000000000_1695945600000000000_7/columnstore")
+	if err == nil {
+		t.Fatal("Expect ParseLogPath failed")
+	}
+	_, err = ParseLogPath("data/test/0/test1/a_1695859200000000000_x695945600000000000_7/columnstore")
+	if err == nil {
+		t.Fatal("Expect ParseLogPath failed")
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
提升bf缓存命中率
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close/fix/resolve/ref #634

### What is changed and how it works?
Please describe how it works
识别bf缓存的热数据，根据顺序将obs的数据预取到缓存中

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] TestHotDataDetector
- [X] TestNewHotDataDetector
- [X] TestDataPrefetch
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
