### PR TITLE
chore: unnecessary use of fmt.Sprintf from tests

### DIFF
--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -162,7 +162,7 @@ func (s *RemoteServer) DropDatabase(db string) error {
 
 // Reset attempts to remove all database state by dropping everything
 func (s *RemoteServer) Reset() error {
-	stmt := fmt.Sprintf("SHOW+DATABASES")
+	stmt := "SHOW+DATABASES"
 	results, err := s.HTTPPost(s.URL()+"/query?q="+stmt, nil)
 	if err != nil {
 		return err
@@ -213,7 +213,7 @@ func (s *RemoteServer) CheckDropDatabases(dbs []string) error {
 }
 
 func (s *RemoteServer) ContainDatabase(name string) bool {
-	stmt := fmt.Sprintf("SHOW+DATABASES")
+	stmt := "SHOW+DATABASES"
 	results, err := s.HTTPPost(s.URL()+"/query?q="+stmt, nil)
 	if err != nil {
 		return false

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -45,7 +45,7 @@ func killInfluxDB3(t *testing.T) error {
 	output, err := cmd.Output()
 	if err != nil {
 		fmt.Printf("kill ts-store 3 error :%s failed with error:%s\n", command, err.Error())
-		t.Error(fmt.Sprintf("InitTestEnv kill ts-store 3 error command: %s - err: %s\n", command, err.Error()))
+		t.Errorf("InitTestEnv kill ts-store 3 error command: %s - err: %s\n", command, err.Error())
 		return err
 	} else {
 		fmt.Printf("kill ts-store 3 suc:%s finished with output:\n%s\n", command, string(output))
@@ -64,7 +64,7 @@ func startInfluxDB3(t *testing.T) {
 	output, err := cmd.Output()
 	if err != nil {
 		fmt.Printf("start ts-store 3 error:%s failed with error:%s\n", command, err.Error())
-		t.Fatal(fmt.Sprintf("start ts-store 3 error command: %s - err: %s\n", command, err.Error()))
+		t.Fatalf("start ts-store 3 error command: %s - err: %s\n", command, err.Error())
 	} else {
 		time.Sleep(2 * time.Second)
 		fmt.Printf("start influxdb3 suc:%s finished with output:\n%s\n", command, string(output))
@@ -90,7 +90,7 @@ func InitTestEnv(t *testing.T, bodyType string, body io.Reader) error {
 		res, err := http.Post(b, "", body)
 		if err != nil {
 			fmt.Printf("InitTestEnv movePT error: %s, status: %s\n", err.Error(), res.Status)
-			t.Error(fmt.Sprintf("InitTestEnv movePT error command: %s - err: %s", b, err.Error()))
+			t.Errorf("InitTestEnv movePT error command: %s - err: %s", b, err.Error())
 			return err
 		} else {
 			fmt.Printf("movePT suc status: %s\n ", res.Status)
@@ -127,7 +127,7 @@ func ReleasTestEnv(t *testing.T, bodyType string, body io.Reader) error {
 		res, err := http.Post(b, "", body)
 		if err != nil {
 			fmt.Printf("ReleasTestEnv movePT error: %s, status: %s\n", err.Error(), res.Status)
-			t.Error(fmt.Sprintf("ReleasTestEnv movePT error command: %s - err: %s", b, err.Error()))
+			t.Errorf("ReleasTestEnv movePT error command: %s - err: %s", b, err.Error())
 			return err
 		} else {
 			fmt.Printf("release movePT suc status: %s\n ", res.Status)
@@ -392,17 +392,17 @@ func TestServer_ShowDatabases_NoAuth(t *testing.T) {
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    "create db1",
 				command: "CREATE DATABASE db1",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "create db2",
 				command: "CREATE DATABASE db2",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "show dbs",
 				command: "SHOW DATABASES",
 				exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["db1"],["db2"]]}]}]}`,
@@ -416,7 +416,7 @@ func TestServer_ShowDatabases_NoAuth(t *testing.T) {
 				t.Skipf("SKIP:: %s", query.name)
 			}
 			if err := query.Execute(s); err != nil {
-				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+				t.Errorf("command: %s - err: %s", query.command, query.Error(err))
 			} else if !query.success() {
 				t.Error(query.failureMessage())
 			}
@@ -435,49 +435,49 @@ func TestServer_ShowDatabases_WithAuth(t *testing.T) {
 		t.Skip("Skipping.  Cannot enable auth on remote server")
 	}
 
-	adminParams := map[string][]string{"u": []string{"admin"}, "p": []string{"admin"}}
-	readerParams := map[string][]string{"u": []string{"reader"}, "p": []string{"r"}}
-	writerParams := map[string][]string{"u": []string{"writer"}, "p": []string{"w"}}
-	nobodyParams := map[string][]string{"u": []string{"nobody"}, "p": []string{"n"}}
+	adminParams := map[string][]string{"u": {"admin"}, "p": {"admin"}}
+	readerParams := map[string][]string{"u": {"reader"}, "p": {"r"}}
+	writerParams := map[string][]string{"u": {"writer"}, "p": {"w"}}
+	nobodyParams := map[string][]string{"u": {"nobody"}, "p": {"n"}}
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    "create admin",
 				command: `CREATE USER admin WITH PASSWORD 'admin' WITH ALL PRIVILEGES`,
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "create databases",
 				command: "CREATE DATABASE dbR; CREATE DATABASE dbW",
 				params:  adminParams,
 				exp:     `{"results":[{"statement_id":0},{"statement_id":1}]}`,
 			},
-			&Query{
+			{
 				name:    "show dbs as admin",
 				command: "SHOW DATABASES",
 				params:  adminParams,
 				exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["dbR"],["dbW"]]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "create users",
 				command: `CREATE USER reader WITH PASSWORD 'r'; GRANT READ ON "dbR" TO "reader"; CREATE USER writer WITH PASSWORD 'w'; GRANT WRITE ON "dbW" TO "writer"; CREATE USER nobody WITH PASSWORD 'n'`,
 				params:  adminParams,
 				exp:     `{"results":[{"statement_id":0},{"statement_id":1},{"statement_id":2},{"statement_id":3},{"statement_id":4}]}`,
 			},
-			&Query{
+			{
 				name:    "show dbs as reader",
 				command: "SHOW DATABASES",
 				params:  readerParams,
 				exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["dbR"]]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "show dbs as writer",
 				command: "SHOW DATABASES",
 				params:  writerParams,
 				exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["dbW"]]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "show dbs as nobody",
 				command: "SHOW DATABASES",
 				params:  nobodyParams,
@@ -489,7 +489,7 @@ func TestServer_ShowDatabases_WithAuth(t *testing.T) {
 	for _, query := range test.queries {
 		t.Run(query.name, func(t *testing.T) {
 			if err := query.Execute(s); err != nil {
-				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+				t.Errorf("command: %s - err: %s", query.command, query.Error(err))
 			} else if !query.success() {
 				t.Error(query.failureMessage())
 			}
@@ -509,77 +509,77 @@ func TestServer_UserCommands(t *testing.T) {
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    "show users, no actual users",
 				command: `SHOW USERS`,
 				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["user","admin","rwuser"]}]}]}`,
 			},
-			&Query{
+			{
 				name:    `create user`,
 				command: "CREATE USER jdoe WITH PASSWORD 'Jdoe@1337'",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "show users, 1 existing user",
 				command: `SHOW USERS`,
 				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["user","admin","rwuser"],"values":[["jdoe",false,false]]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "grant all priviledges to jdoe",
 				command: `GRANT ALL PRIVILEGES TO jdoe`,
 				exp:     `{"results":[{"statement_id":0,"error":"forbidden to grant or revoke privileges, because only one admin is allowed for the database"}]}`,
 			},
-			&Query{
+			{
 				name:    "show users, existing user as admin",
 				command: `SHOW USERS`,
 				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["user","admin","rwuser"],"values":[["jdoe",false,false]]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "grant DB privileges to user",
 				command: `GRANT READ ON db0 TO jdoe`,
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "revoke all privileges",
 				command: `REVOKE ALL PRIVILEGES FROM jdoe`,
 				exp:     `{"results":[{"statement_id":0,"error":"forbidden to grant or revoke privileges, because only one admin is allowed for the database"}]}`,
 			},
-			&Query{
+			{
 				name:    `bad create user request, invalid password`,
 				command: "CREATE USER jdoe1 WITH PASSWORD '1337'",
 				exp:     `{"results":[{"statement_id":0,"error":"the password needs to be between 8 and 256 characters long"}]}`,
 			},
-			&Query{
+			{
 				name:    `bad create user request, invalid password`,
 				command: "CREATE USER jdoe1 WITH PASSWORD 'Jdoe1337'",
 				exp:     `{"results":[{"statement_id":0,"error":"The user password must contain more than 8 characters and uppercase letters, lowercase letters, digits, and at least one of the special characters."}]}`,
 			},
-			&Query{
+			{
 				name:    "bad create user request",
 				command: `CREATE USER 0xBAD WITH PASSWORD 'Jdoe@1337'`,
 				exp:     `{"error":"error parsing query: syntax error: unexpected DURATIONVAL, expecting IDENT"}`,
 			},
-			&Query{
+			{
 				name:    "bad create user request, no name",
 				command: `CREATE USER WITH PASSWORD 'Jdoe@1337'`,
 				exp:     `{"error":"error parsing query: syntax error: unexpected WITH, expecting IDENT"}`,
 			},
-			&Query{
+			{
 				name:    "bad create user request, no password",
 				command: `CREATE USER jdoe`,
 				exp:     `{"error":"error parsing query: syntax error: unexpected $end, expecting WITH"}`,
 			},
-			&Query{
+			{
 				name:    "drop user",
 				command: `DROP USER jdoe`,
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    "make sure user was dropped",
 				command: `SHOW USERS`,
 				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["user","admin","rwuser"]}]}]}`,
 			},
-			&Query{
+			{
 				name:    "delete non existing user",
 				command: `DROP USER noone`,
 				exp:     `{"results":[{"statement_id":0,"error":"user not found"}]}`,
@@ -593,7 +593,7 @@ func TestServer_UserCommands(t *testing.T) {
 				t.Skipf("SKIP:: %s", query.name)
 			}
 			if err := query.Execute(s); err != nil {
-				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+				t.Errorf("command: %s - err: %s", query.command, query.Error(err))
 			} else if !query.success() {
 				t.Error(query.failureMessage())
 			}
@@ -691,7 +691,7 @@ func TestServer_Write_MultiField_FieldTypeConflict(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`monitor cmd="test",collectTime="now",cpu=60i,mem=70i,process=1i,startTime="now",stat="running",state="ok",user="root" 1629129600000000000`),
+		`monitor cmd="test",collectTime="now",cpu=60i,mem=70i,process=1i,startTime="now",stat="running",state="ok",user="root" 1629129600000000000`,
 	}
 
 	if res, err := s.Write("db0", "rp0", strings.Join(writes, "\n"), nil); err != nil {
@@ -701,7 +701,7 @@ func TestServer_Write_MultiField_FieldTypeConflict(t *testing.T) {
 	}
 
 	writes = []string{
-		fmt.Sprintf(`monitor cmd=0i,collectTime="now",cpu=60i,mem=70i,process=1i,startTime=0i,stat=0i,state="ok",user=0i 1629129700000000000`),
+		`monitor cmd=0i,collectTime="now",cpu=60i,mem=70i,process=1i,startTime=0i,stat=0i,state="ok",user=0i 1629129700000000000`,
 	}
 	res, err := s.Write("db0", "rp0", strings.Join(writes, "\n"), nil)
 	if err == nil {
@@ -837,7 +837,7 @@ cpu,host=server01 value="disk\" mem\\\" host\\" 1610468600000000000
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "SELECT * FROM db0.rp0.cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM db0.rp0.cpu`,
@@ -921,7 +921,7 @@ func TestServer_Write_LineProtocol_Partial(t *testing.T) {
 	// Verify the data was written.
 	if res, err := s.Query(`SELECT * FROM db0.rp0.cpu GROUP BY *`); err != nil {
 		t.Fatal(err)
-	} else if exp := fmt.Sprintf(`{"results":[{"statement_id":0,"error":"measurement not found"}]}`); exp != res {
+	} else if exp := `{"results":[{"statement_id":0,"error":"measurement not found"}]}`; exp != res {
 		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
 	}
 }
@@ -937,23 +937,23 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "default db and rp",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T01:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "default rp exists",
 			command: `show retention policies ON db0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","hot duration","warm duration","index duration","replicaN","default"],"values":[["autogen","0s","168h0m0s","0s","0s","168h0m0s",1,false],["rp0","0s","168h0m0s","0s","0s","168h0m0s",1,true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "default rp",
 			command: `SELECT * FROM db0..cpu GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T01:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "default dp",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM rp0.cpu GROUP BY *`,
@@ -1000,12 +1000,12 @@ func TestServer_Query_Multiple_Measurements(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "measurement in one shard but not another shouldn't panic server",
 			command: `SELECT host,value  FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","value"],"values":[["2000-01-01T00:00:00Z","server01",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "measurement in one shard but not another shouldn't panic server",
 			command: `SELECT host,value  FROM db0.rp0.cpu GROUP BY host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","host","value"],"values":[["2000-01-01T00:00:00Z","server01",100]]}]}]}`,
@@ -1047,17 +1047,17 @@ func TestServer_Query_IdenticalTagValues(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "measurements with identical tag values - SELECT *, no GROUP BY",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"t1":"","t2":"val2"},"columns":["time","value"],"values":[["2000-01-01T00:01:00Z",2]]},{"name":"cpu","tags":{"t1":"val1","t2":""},"columns":["time","value"],"values":[["2000-01-01T00:00:00Z",1]]},{"name":"cpu","tags":{"t1":"val2","t2":""},"columns":["time","value"],"values":[["2000-01-01T00:02:00Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "measurements with identical tag values - SELECT *, with GROUP BY",
 			command: `SELECT value FROM db0.rp0.cpu GROUP BY t1,t2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"t1":"","t2":"val2"},"columns":["time","value"],"values":[["2000-01-01T00:01:00Z",2]]},{"name":"cpu","tags":{"t1":"val1","t2":""},"columns":["time","value"],"values":[["2000-01-01T00:00:00Z",1]]},{"name":"cpu","tags":{"t1":"val2","t2":""},"columns":["time","value"],"values":[["2000-01-01T00:02:00Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "measurements with identical tag values - SELECT value no GROUP BY",
 			command: `SELECT value FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",1],["2000-01-01T00:01:00Z",2],["2000-01-01T00:02:00Z",3]]}]}]}`,
@@ -1096,7 +1096,7 @@ func TestServer_Query_NoShards(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "selecting value should succeed",
 			command: `SELECT value FROM db0.rp0.cpu WHERE time < now() - 1d`,
 			exp:     `{"results":[{"statement_id":0}]}`,
@@ -1133,17 +1133,17 @@ func TestServer_Query_NonExistent(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "selecting value should succeed",
 			command: `SELECT value FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2022-06-30T01:54:27Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting non-existent should succeed",
 			command: `SELECT foo FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting columns contains non-existent should succeed",
 			command: `SELECT value, foo FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value","foo"],"values":[["2022-06-30T01:54:27Z",1,null]]}]}]}`,
@@ -1186,62 +1186,62 @@ func TestServer_Query_Math(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "SELECT multiple of float value",
 			command: `SELECT value * 2 from db.rp.float`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"float","columns":["time","value"],"values":[["%s",84]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "SELECT multiple of float value",
 			command: `SELECT 2 * value from db.rp.float`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"float","columns":["time","value"],"values":[["%s",84]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "SELECT multiple of integer value",
 			command: `SELECT value * 2 from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value"],"values":[["%s",84]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "SELECT float multiple of integer value",
 			command: `SELECT value * 2.0 from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value"],"values":[["%s",84]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "SELECT square of float value",
 			command: `SELECT value * value from db.rp.float`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"float","columns":["time","value_value"],"values":[["%s",1764]]}]}]}`, now.Format(time.RFC3339Nano)),
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT square of integer value",
 			command: `SELECT value * value from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value_value"],"values":[["%s",1764]]}]}]}`, now.Format(time.RFC3339Nano)),
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT square of integer, float value",
 			command: `SELECT value * value,value from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value_value","value"],"values":[["%s",1764,42]]}]}]}`, now.Format(time.RFC3339Nano)),
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT square of integer value with alias",
 			command: `SELECT value * value as square from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","square"],"values":[["%s",1764]]}]}]}`, now.Format(time.RFC3339Nano)),
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT sum of aggregates",
 			command: `SELECT max(value) + min(value) from db.rp.integer`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","max_min"],"values":[["1970-01-01T00:00:00Z",84]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","max_min"],"values":[["1970-01-01T00:00:00Z",84]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT square of enclosed integer value",
 			command: `SELECT ((value) * (value)) from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value_value"],"values":[["%s",1764]]}]}]}`, now.Format(time.RFC3339Nano)),
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT square of enclosed integer value",
 			command: `SELECT (value * value) from db.rp.integer`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"integer","columns":["time","value_value"],"values":[["%s",1764]]}]}]}`, now.Format(time.RFC3339Nano)),
@@ -1292,37 +1292,37 @@ func TestServer_Query_Count(t *testing.T) {
 	hour_ago := now.Add(-time.Hour).UTC()
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "selecting count(value) should succeed",
 			command: `SELECT count(value) FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting count(value) with where time should return result",
 			command: fmt.Sprintf(`SELECT count(value) FROM db0.rp0.cpu WHERE time >= '%s'`, hour_ago.Format(time.RFC3339Nano)),
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["%s",1]]}]}]}`, hour_ago.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "selecting count(value) with filter that excludes all results should return 0",
 			command: fmt.Sprintf(`SELECT count(value) FROM db0.rp0.cpu WHERE value=100 AND time >= '%s'`, hour_ago.Format(time.RFC3339Nano)),
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting count(value1) with matching filter against value2 should return correct result",
 			command: fmt.Sprintf(`SELECT count(value1) FROM db0.rp0.ram WHERE value2=2 AND time >= '%s'`, hour_ago.Format(time.RFC3339Nano)),
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"ram","columns":["time","count"],"values":[["%s",1]]}]}]}`, hour_ago.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "selecting count(value1) with non-matching filter against value2 should return correct result",
 			command: fmt.Sprintf(`SELECT count(value1) FROM db0.rp0.ram WHERE value2=3 AND time >= '%s'`, hour_ago.Format(time.RFC3339Nano)),
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting count(*) should expand the wildcard",
 			command: `SELECT count(*) FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_value"],"values":[["1970-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting count(2) should error",
 			command: `SELECT count(2) FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"expected field argument in count()"}]}`,
@@ -1407,22 +1407,22 @@ func TestServer_Query_Now(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "where with time < now() should work",
 			command: `SELECT * FROM db0.rp0.cpu where time < now()`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","value"],"values":[["%s","server01",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "where with time < now() and GROUP BY * should work",
 			command: `SELECT * FROM db0.rp0.cpu where time < now() GROUP BY *`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "where with time > now() should return an empty result",
 			command: `SELECT * FROM db0.rp0.cpu where time > now()`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "where with time > now() with GROUP BY * should return an empty result",
 			command: `SELECT * FROM db0.rp0.cpu where time > now() GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0}]}`,
@@ -1461,37 +1461,37 @@ func TestServer_Query_EpochPrecision(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "nanosecond precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"n"}},
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[[%d,1]]}]}]}`, now.UnixNano()),
 		},
-		&Query{
+		{
 			name:    "microsecond precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"u"}},
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[[%d,1]]}]}]}`, now.UnixNano()/int64(time.Microsecond)),
 		},
-		&Query{
+		{
 			name:    "millisecond precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"ms"}},
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[[%d,1]]}]}]}`, now.UnixNano()/int64(time.Millisecond)),
 		},
-		&Query{
+		{
 			name:    "second precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"s"}},
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[[%d,1]]}]}]}`, now.UnixNano()/int64(time.Second)),
 		},
-		&Query{
+		{
 			name:    "minute precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"m"}},
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[[%d,1]]}]}]}`, now.UnixNano()/int64(time.Minute)),
 		},
-		&Query{
+		{
 			name:    "hour precision",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			params:  url.Values{"epoch": []string{"h"}},
@@ -1549,132 +1549,132 @@ func TestServer_Query_Tags(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "tag without field should return error",
 			command: `SELECT host FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"statement must have at least one field in select clause"}]}`,
 			skip:    true, // FIXME(benbjohnson): tags should stream as values
 		},
-		&Query{
+		{
 			name:    "field with tag should succeed",
 			command: `SELECT host, value FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","value"],"values":[["%s","server01",100],["%s","server02",50]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "field with tag and GROUP BY should succeed",
 			command: `SELECT host, value FROM db0.rp0.cpu GROUP BY host`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","host","value"],"values":[["%s","server01",100]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","host","value"],"values":[["%s","server02",50]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "field with two tags should succeed",
 			command: `SELECT host, value, core FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","value","core"],"values":[["%s","server01",100,4],["%s","server02",50,2]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "field with two tags and GROUP BY should succeed",
 			command: `SELECT host, value, core FROM db0.rp0.cpu GROUP BY host`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","host","value","core"],"values":[["%s","server01",100,4]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","host","value","core"],"values":[["%s","server02",50,2]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "select * with tags should succeed",
 			command: `SELECT * FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core","host","value"],"values":[["%s",4,"server01",100],["%s",2,"server02",50]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "select * with tags with GROUP BY * should succeed",
 			command: `SELECT * FROM db0.rp0.cpu GROUP BY *`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","core","value"],"values":[["%s",4,100]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","core","value"],"values":[["%s",2,50]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "group by tag",
 			command: `SELECT value FROM db0.rp0.cpu GROUP by host`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",100]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","value"],"values":[["%s",50]]}]}]}`, now.Format(time.RFC3339Nano), now.Add(1).Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "single field (EQ tag value1)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server01'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (2 EQ tags)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server01' AND region = 'us-west'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (OR different tags)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server03' OR region = 'us-west'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",300],["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (OR with non-existent tag value)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server01' OR host = 'server66'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (OR with all tag values)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server01' OR host = 'server02' OR host = 'server03'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2010-02-28T01:03:37.703820946Z",200],["2012-02-28T01:03:38.703820946Z",300],["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (1 EQ and 1 NEQ tag)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server01' AND region != 'us-west'`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (EQ tag value2)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host = 'server02'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2010-02-28T01:03:37.703820946Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host != 'server01'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2010-02-28T01:03:37.703820946Z",200],["2012-02-28T01:03:38.703820946Z",300]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1 AND NEQ tag value2)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host != 'server01' AND host != 'server02'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",300]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1 OR NEQ tag value2)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host != 'server01' OR host != 'server02'`, // Yes, this is always true, but that's the point.
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2010-02-28T01:03:37.703820946Z",200],["2012-02-28T01:03:38.703820946Z",300],["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1 AND NEQ tag value2 AND NEQ tag value3)",
 			command: `SELECT value FROM db0.rp0.cpu1 WHERE host != 'server01' AND host != 'server02' AND host != 'server03'`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1, point without any tags)",
 			command: `SELECT value FROM db0.rp0.cpu2 WHERE host != 'server01'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu2","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field (NEQ tag value1, point without any tags)",
 			command: `SELECT value FROM db0.rp0.cpu3 WHERE company !~ /acme01/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu3","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",200]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "single field (regex tag match)",
 			command: `SELECT value FROM db0.rp0.cpu3 WHERE company =~ /acme01/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "single field (regex tag match)",
 			command: `SELECT value FROM db0.rp0.cpu3 WHERE company !~ /acme[23]/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu3","columns":["time","value"],"values":[["2012-02-28T01:03:38.703820946Z",200],["2015-02-28T01:03:36.703820946Z",100]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "single field (regex tag match with escaping)",
 			command: `SELECT value FROM db0.rp0.status_code WHERE url !~ /https\:\/\/influxdb\.com/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"status_code","columns":["time","value"],"values":[["2015-07-22T08:13:54.929026672Z",404]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "single field (regex tag match with escaping)",
 			command: `SELECT value FROM db0.rp0.status_code WHERE url =~ /https\:\/\/influxdb\.com/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"status_code","columns":["time","value"],"values":[["2015-07-22T09:52:24.914395083Z",418]]}]}]}`,
@@ -1701,10 +1701,7 @@ func TestServer_Query_Tags(t *testing.T) {
 }
 
 func generateBool(i int) bool {
-	if i%2 == 0 {
-		return true
-	}
-	return false
+	return i%2 == 0
 }
 
 func generateFloat(i int) float64 {
@@ -1729,47 +1726,47 @@ func TestServer_Query_Common(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "selecting a from a non-existent database should error",
 			command: `SELECT value FROM db1.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"database not found: db1"}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting a from a non-existent retention policy should error",
 			command: `SELECT value FROM db0.rp1.cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"retention policy not found: rp1"}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting a valid  measurement and field should succeed",
 			command: `SELECT value FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "explicitly selecting time and a valid measurement and field should succeed",
 			command: `SELECT time,value FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "selecting a measurement that doesn't exist should result in empty set",
 			command: `SELECT value FROM db0.rp0.idontexist`,
 			exp:     `{"results":[{"statement_id":0,"error":"measurement not found"}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting a field that doesn't exist should result in empty set",
 			command: `SELECT idontexist FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting 2 fields that contain one non-existent",
 			command: `SELECT idontexist, value  FROM db0.rp0.cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","idontexist","value"],"values":[["%s",null,1]]}]}]}`, now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "selecting wildcard without specifying a database should error",
 			command: `SELECT * FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"database name required"}]}`,
 		},
-		&Query{
+		{
 			name:    "selecting explicit field without specifying a database should error",
 			command: `SELECT value FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"error":"database name required"}]}`,
@@ -1892,12 +1889,12 @@ func TestServer_Query_SelectRelativeTime(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "single point with time pre-calculated for past time queries yesterday",
 			command: `SELECT * FROM db0.rp0.cpu where time >= '` + yesterday.Add(-1*time.Minute).Format(time.RFC3339Nano) + `' GROUP BY *`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",100],["%s",200]]}]}]}`, yesterday.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "single point with time pre-calculated for relative time queries now",
 			command: `SELECT * FROM db0.rp0.cpu where time >= now() - 1m GROUP BY *`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["%s",200]]}]}]}`, now.Format(time.RFC3339Nano)),
@@ -1930,17 +1927,17 @@ func TestServer_Query_SelectGroupByTime_MultipleAggregates(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`test,t=a x=1i 1000000000
+		&Write{data: `test,t=a x=1i 1000000000
 test,t=b y=1i 1000000000
 test,t=a x=2i 2000000000
 test,t=b y=2i 2000000000
 test,t=a x=3i 3000000000
 test,t=b y=3i 3000000000
-`)},
+`},
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "two aggregates with a group by host",
 			command: `SELECT mean(x) as x, mean(y) as y from db0.rp0.test where time >= 1s and time < 4s group by t, time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"test","tags":{"t":"a"},"columns":["time","x","y"],"values":[["1970-01-01T00:00:01Z",1,null],["1970-01-01T00:00:02Z",2,null],["1970-01-01T00:00:03Z",3,null]]},{"name":"test","tags":{"t":"b"},"columns":["time","x","y"],"values":[["1970-01-01T00:00:01Z",null,1],["1970-01-01T00:00:02Z",null,2],["1970-01-01T00:00:03Z",null,3]]}]}]}`,
@@ -1973,17 +1970,17 @@ func TestServer_Query_MathWithFill(t *testing.T) {
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
-		&Write{data: fmt.Sprintf(`cpu value=15 1278010020000000000
-`)},
+		&Write{data: `cpu value=15 1278010020000000000
+`},
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "multiplication with fill previous",
 			command: `SELECT 4*mean(value) FROM db0.rp0.cpu WHERE time >= '2010-07-01 18:47:00' AND time < '2010-07-01 18:48:30' GROUP BY time(30s) FILL(previous)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2010-07-01T18:47:00Z",60],["2010-07-01T18:47:30Z",60],["2010-07-01T18:48:00Z",60]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiplication of mode value with fill previous",
 			command: `SELECT 4*mode(value) FROM db0.rp0.cpu WHERE time >= '2010-07-01 18:47:00' AND time < '2010-07-01 18:48:30' GROUP BY time(30s) FILL(previous)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mode"],"values":[["2010-07-01T18:47:00Z",60],["2010-07-01T18:47:30Z",60],["2010-07-01T18:48:00Z",60]]}]}]}`,
@@ -2034,18 +2031,18 @@ func TestServer_Query_MergeMany(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "GROUP by time",
 			command: `SELECT count(value) FROM db0.rp0.cpu WHERE time >= '1970-01-01T00:00:01Z' AND time <= '1970-01-01T00:00:06Z' GROUP BY time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:01Z",10],["1970-01-01T00:00:02Z",10],["1970-01-01T00:00:03Z",10],["1970-01-01T00:00:04Z",10],["1970-01-01T00:00:05Z",7],["1970-01-01T00:00:06Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			skip:    true,
 			name:    "GROUP by tag - FIXME issue #2875",
 			command: `SELECT count(value) FROM db0.rp0.cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:00Z' group by host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","count"],"values":[["2000-01-01T00:00:00Z",1]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","count"],"values":[["2000-01-01T00:00:00Z",1]]},{"name":"cpu","tags":{"host":"server03"},"columns":["time","count"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "GROUP by field",
 			command: `SELECT count(value) FROM db0.rp0.cpu group by value`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"value":""},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",50]]}]}]}`,
@@ -2092,40 +2089,40 @@ func TestServer_Query_Regex(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "default db and rp",
 			command: `SELECT * FROM /cpu[13]/`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","host","value"],"values":[["2015-02-28T01:03:36.703820946Z","server01",10]]},{"name":"cpu3","columns":["time","host","value"],"values":[["2015-02-28T01:03:36.703820946Z","server01",30]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "default db and rp with GROUP BY *",
 			command: `SELECT * FROM /cpu[13]/ GROUP BY *`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "specifying db and rp",
 			command: `SELECT * FROM db0.rp0./cpu[13]/ GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "default db and specified rp",
 			command: `SELECT * FROM rp0./cpu[13]/ GROUP BY *`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "specified db and default rp",
 			command: `SELECT * FROM db0../cpu[13]/ GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "map field type with a regex source",
 			command: `SELECT value FROM /cpu[13]/`,
 			params:  url.Values{"db": []string{"db0"}},
@@ -2167,7 +2164,7 @@ func TestServer_Query_Aggregates_Int(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// int64
-		&Query{
+		{
 			name:    "stddev with just one point - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT STDDEV(value) FROM int`,
@@ -2209,7 +2206,7 @@ func TestServer_Query_Aggregates_IntMax(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "large mean and stddev - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEAN(value), STDDEV(value) FROM intmax`,
@@ -2257,116 +2254,116 @@ func TestServer_Query_Aggregates_IntMany_NowTime(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "mean and stddev - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEAN(value), STDDEV(value) FROM intmany WHERE time >= '2000-01-01' AND time < '2000-01-01T00:02:00Z' GROUP BY time(10m)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","mean","stddev"],"values":[["2000-01-01T00:00:00Z",5,2.138089935299395]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "first - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT FIRST(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - int - epoch ms",
 			params:  url.Values{"db": []string{"db0"}, "epoch": []string{"ms"}},
 			command: `SELECT FIRST(value) FROM intmany`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","first"],"values":[[%d,2]]}]}]}`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()/int64(time.Millisecond)),
 		},
-		&Query{
+		{
 			name:    "last - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT LAST(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","last"],"values":[["2000-01-01T00:01:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SPREAD(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","spread"],"values":[["1970-01-01T00:00:00Z",7]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - even count - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEDIAN(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","median"],"values":[["1970-01-01T00:00:00Z",4.5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - odd count - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEDIAN(value) FROM intmany where time < '2000-01-01T00:01:10Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","median"],"values":[["1970-01-01T00:00:00Z",4]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - single - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MODE(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","mode"],"values":[["1970-01-01T00:00:00Z",4]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - multiple - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MODE(value) FROM intmany where time < '2000-01-01T00:01:10Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","mode"],"values":[["1970-01-01T00:00:00Z",4]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct as call - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT(value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",2],["1970-01-01T00:00:00Z",4],["1970-01-01T00:00:00Z",5],["1970-01-01T00:00:00Z",7],["1970-01-01T00:00:00Z",9]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct alt syntax - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT value FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",2],["1970-01-01T00:00:00Z",4],["1970-01-01T00:00:00Z",5],["1970-01-01T00:00:00Z",7],["1970-01-01T00:00:00Z",9]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct select tag - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT(host) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"error":"statement must have at least one field in select clause"}]}`,
 			skip:    true, // FIXME(benbjohnson): should be allowed, need to stream tag values
 		},
-		&Query{
+		{
 			name:    "distinct alt select tag - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT host FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"error":"statement must have at least one field in select clause"}]}`,
 			skip:    true, // FIXME(benbjohnson): should be allowed, need to stream tag values
 		},
-		&Query{
+		{
 			name:    "count distinct - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT value) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "count distinct as call - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT(value)) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "count distinct select tag - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT host) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): stream tag values
 		},
-		&Query{
+		{
 			name:    "count distinct as call select tag - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT host) FROM intmany`,
@@ -2414,55 +2411,55 @@ func TestServer_Query_Aggregates_IntMany_GroupBy(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "max order by time with time specified group by 10s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(10s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",4],["2000-01-01T00:00:20Z",4],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:40Z",5],["2000-01-01T00:00:50Z",5],["2000-01-01T00:01:00Z",7],["2000-01-01T00:01:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max order by time without time specified group by 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T00:00:30Z",5],["2000-01-01T00:01:00Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max order by time with time specified group by 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T00:00:30Z",5],["2000-01-01T00:01:00Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min order by time without time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:15Z",4],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:45Z",5],["2000-01-01T00:01:00Z",7]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min order by time with time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, min(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:15Z",4],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:45Z",5],["2000-01-01T00:01:00Z",7]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first order by time without time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:15Z",4],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:45Z",5],["2000-01-01T00:01:00Z",7]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first order by time with time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, first(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:15Z",4],["2000-01-01T00:00:30Z",4],["2000-01-01T00:00:45Z",5],["2000-01-01T00:01:00Z",7]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last order by time without time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","last"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T00:00:15Z",4],["2000-01-01T00:00:30Z",5],["2000-01-01T00:00:45Z",5],["2000-01-01T00:01:00Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last order by time with time specified group by 15s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, last(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:14Z' group by time(15s)`,
@@ -2509,7 +2506,7 @@ func TestServer_Query_Aggregates_IntMany_OrderByDesc(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "aggregate order by time desc",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(value) FROM intmany where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:00Z' group by time(10s) order by time desc`,
@@ -2553,32 +2550,32 @@ func TestServer_Query_Aggregates_IntOverlap(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "aggregation with a null field value - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM intoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intoverlap","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",50]]},{"name":"intoverlap","tags":{"region":"us-west"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple aggregations - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value), MEAN(value) FROM intoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intoverlap","tags":{"region":"us-east"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",50,25]]},{"name":"intoverlap","tags":{"region":"us-west"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",100,100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple aggregations with division - int FIXME issue #2879",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value), mean(value), sum(value) / mean(value) as div FROM intoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intoverlap","tags":{"region":"us-east"},"columns":["time","sum","mean","div"],"values":[["1970-01-01T00:00:00Z",50,25,2]]},{"name":"intoverlap","tags":{"region":"us-west"},"columns":["time","sum","mean","div"],"values":[["1970-01-01T00:00:00Z",100,100,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple first aggregations - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(value), first(otherVal) FROM intoverlap`,
 			exp:     ``,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "multiple last aggregations - int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(value), last(otherVal) FROM intoverlap`,
@@ -2667,110 +2664,110 @@ func TestServer_Query_Aggregates_FloatMany(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "mean and stddev - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEAN(value), STDDEV(value) FROM floatmany WHERE time >= '2000-01-01' AND time < '2000-01-01T00:02:00Z' GROUP BY time(10m)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","mean","stddev"],"values":[["2000-01-01T00:00:00Z",5,2.138089935299395]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "first - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT FIRST(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT LAST(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","last"],"values":[["2000-01-01T00:01:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SPREAD(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","spread"],"values":[["1970-01-01T00:00:00Z",7]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - even count - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEDIAN(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","median"],"values":[["1970-01-01T00:00:00Z",4.5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - odd count - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEDIAN(value) FROM floatmany where time < '2000-01-01T00:01:10Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","median"],"values":[["1970-01-01T00:00:00Z",4]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - single - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MODE(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","mode"],"values":[["1970-01-01T00:00:00Z",4]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - multiple - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MODE(value) FROM floatmany where time < '2000-01-01T00:00:10Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","mode"],"values":[["1970-01-01T00:00:00Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct as call - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",2],["1970-01-01T00:00:00Z",4],["1970-01-01T00:00:00Z",5],["1970-01-01T00:00:00Z",7],["1970-01-01T00:00:00Z",9]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct alt syntax - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT value FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",2],["1970-01-01T00:00:00Z",4],["1970-01-01T00:00:00Z",5],["1970-01-01T00:00:00Z",7],["1970-01-01T00:00:00Z",9]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct select tag - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT(host) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"error":"statement must have at least one field in select clause"}]}`,
 			skip:    true, // FIXME(benbjohnson): show be allowed, stream tag values
 		},
-		&Query{
+		{
 			name:    "distinct alt select tag - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT DISTINCT host FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"error":"statement must have at least one field in select clause"}]}`,
 			skip:    true, // FIXME(benbjohnson): show be allowed, stream tag values
 		},
-		&Query{
+		{
 			name:    "count distinct - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "count distinct as call - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT(value)) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "count distinct select tag - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT host) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): stream tag values
 		},
-		&Query{
+		{
 			name:    "count distinct as call select tag - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT host) FROM floatmany`,
@@ -2814,44 +2811,44 @@ func TestServer_Query_Aggregates_FloatOverlap(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "aggregation with no interval - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT count(value) FROM floatoverlap WHERE time = '2000-01-01 00:00:00'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatoverlap","columns":["time","count"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM floatoverlap WHERE time >= '2000-01-01 00:00:05' AND time <= '2000-01-01T00:00:10Z' GROUP BY time(10s), region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatoverlap","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",null],["2000-01-01T00:00:10Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "aggregation with a null field value - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM floatoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatoverlap","tags":{"region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",50]]},{"name":"floatoverlap","tags":{"region":"us-west"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple aggregations - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value), MEAN(value) FROM floatoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatoverlap","tags":{"region":"us-east"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",50,25]]},{"name":"floatoverlap","tags":{"region":"us-west"},"columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",100,100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple aggregations with division - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) / mean(value) as div FROM floatoverlap GROUP BY region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatoverlap","tags":{"region":"us-east"},"columns":["time","div"],"values":[["1970-01-01T00:00:00Z",2]]},{"name":"floatoverlap","tags":{"region":"us-west"},"columns":["time","div"],"values":[["1970-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "multiple first aggregations - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(value), first(otherVal) FROM intoverlap`,
 			exp:     ``,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "multiple last aggregations - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(value), last(otherVal) FROM intoverlap`,
@@ -2894,25 +2891,25 @@ func TestServer_Query_Aggregates_GroupByOffset(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "group by offset - standard",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM "offset" WHERE time >= '1999-12-31T23:59:55Z' AND time < '2000-01-01T00:00:15Z' GROUP BY time(10s, 5s) FILL(0)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"offset","columns":["time","sum"],"values":[["1999-12-31T23:59:55Z",120],["2000-01-01T00:00:05Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by offset - misaligned time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM "offset" WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:20Z' GROUP BY time(10s, 5s) FILL(0)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"offset","columns":["time","sum"],"values":[["1999-12-31T23:59:55Z",120],["2000-01-01T00:00:05Z",30],["2000-01-01T00:00:15Z",0]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by offset - negative time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM "offset" WHERE time >= '1999-12-31T23:59:55Z' AND time < '2000-01-01T00:00:15Z' GROUP BY time(10s, -5s) FILL(0)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"offset","columns":["time","sum"],"values":[["1999-12-31T23:59:55Z",120],["2000-01-01T00:00:05Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by offset - modulo",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM "offset" WHERE time >= '1999-12-31T23:59:55Z' AND time < '2000-01-01T00:00:15Z' GROUP BY time(10s, 35s) FILL(0)`,
@@ -2954,19 +2951,19 @@ func TestServer_Query_Aggregates_Load(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "group by multiple dimensions",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM load GROUP BY region, host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"load","tags":{"host":"serverA","region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",20]]},{"name":"load","tags":{"host":"serverB","region":"us-east"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",30]]},{"name":"load","tags":{"host":"serverC","region":"us-west"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by multiple dimensions",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value)*2 FROM load`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"load","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",300]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by multiple dimensions",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value)/2 FROM load`,
@@ -3007,7 +3004,7 @@ func TestServer_Query_Aggregates_CPU(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "aggregation with WHERE and AND",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) FROM cpu WHERE region='uk' AND host='serverZ'`,
@@ -3049,42 +3046,42 @@ func TestServer_Query_Aggregates_String(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// strings
-		&Query{
+		{
 			name:    "STDDEV on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT STDDEV(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","stddev"],"values":[["1970-01-01T00:00:00Z",null]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			name:    "MEAN on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEAN(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",0]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			name:    "MEDIAN on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEDIAN(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","median"],"values":[["1970-01-01T00:00:00Z",null]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			name:    "COUNT on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2]]}]}]}`,
 			skip:    false, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			name:    "FIRST on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT FIRST(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","first"],"values":[["2000-01-01T00:00:03Z","first"]]}]}]}`,
 			skip:    false, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			name:    "LAST on string data - string",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT LAST(value) FROM stringdata`,
@@ -3139,20 +3136,20 @@ func TestServer_Query_Aggregates_Math(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "add two selectors",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(DISTINCT(value)) FROM intmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"intmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "use math one two selectors separately",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(rx) * 1, min(rx) * 1 FROM network WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:01:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","max","min"],"values":[["2000-01-01T00:00:00Z",90,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "math with a single selector",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(rx) * 1 FROM network WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:01:30Z'`,
@@ -3190,18 +3187,18 @@ func TestServer_Query_Aggregate_For_String_Functions(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -3209,32 +3206,32 @@ func TestServer_Query_Aggregate_For_String_Functions(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "SELECT str(address, 'shanghai')",
 			command: `SELECT str(address, 'shanghai') FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","str"],"values":[["2021-08-16T16:00:00Z",false],["2021-08-16T16:00:01Z",true],["2021-08-16T16:00:02Z",false],["2021-08-16T16:00:03Z",false],["2021-08-16T16:00:04Z",false],["2021-08-16T16:00:05Z",false],["2021-08-16T16:00:07Z",false],["2021-08-16T16:00:08Z",false],["2021-08-16T16:00:09Z",false],["2021-08-16T16:00:10Z",false],["2021-08-16T16:00:11Z",false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT str(address, 'sh') GROUP BY",
 			command: `SELECT str(address, 'sh') FROM db0.rp0.mst GROUP BY country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","str"],"values":[["2021-08-16T16:00:10Z",false]]},{"name":"mst","tags":{"country":"american"},"columns":["time","str"],"values":[["2021-08-16T16:00:01Z",true]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","str"],"values":[["2021-08-16T16:00:04Z",false],["2021-08-16T16:00:09Z",false]]},{"name":"mst","tags":{"country":"china"},"columns":["time","str"],"values":[["2021-08-16T16:00:00Z",true],["2021-08-16T16:00:05Z",false],["2021-08-16T16:00:11Z",false]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","str"],"values":[["2021-08-16T16:00:02Z",false],["2021-08-16T16:00:07Z",false]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","str"],"values":[["2021-08-16T16:00:03Z",false],["2021-08-16T16:00:08Z",false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT strlen(address)",
 			command: `SELECT strlen(address) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","strlen"],"values":[["2021-08-16T16:00:00Z",8],["2021-08-16T16:00:01Z",8],["2021-08-16T16:00:02Z",6],["2021-08-16T16:00:03Z",9],["2021-08-16T16:00:04Z",7],["2021-08-16T16:00:05Z",5],["2021-08-16T16:00:07Z",5],["2021-08-16T16:00:08Z",4],["2021-08-16T16:00:09Z",8],["2021-08-16T16:00:10Z",6],["2021-08-16T16:00:11Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT strlen(address) GROUP BY",
 			command: `SELECT strlen(address) FROM db0.rp0.mst GROUP BY country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","strlen"],"values":[["2021-08-16T16:00:10Z",6]]},{"name":"mst","tags":{"country":"american"},"columns":["time","strlen"],"values":[["2021-08-16T16:00:01Z",8]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","strlen"],"values":[["2021-08-16T16:00:04Z",7],["2021-08-16T16:00:09Z",8]]},{"name":"mst","tags":{"country":"china"},"columns":["time","strlen"],"values":[["2021-08-16T16:00:00Z",8],["2021-08-16T16:00:05Z",5],["2021-08-16T16:00:11Z",9]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","strlen"],"values":[["2021-08-16T16:00:02Z",6],["2021-08-16T16:00:07Z",5]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","strlen"],"values":[["2021-08-16T16:00:03Z",9],["2021-08-16T16:00:08Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT substr(address, 1, 4)",
 			command: `SELECT substr(address, 1, 4) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","substr"],"values":[["2021-08-16T16:00:00Z","henz"],["2021-08-16T16:00:01Z","hang"],["2021-08-16T16:00:02Z","eiji"],["2021-08-16T16:00:03Z","uang"],["2021-08-16T16:00:04Z","heng"],["2021-08-16T16:00:05Z","uhan"],["2021-08-16T16:00:07Z","nhui"],["2021-08-16T16:00:08Z","ian"],["2021-08-16T16:00:09Z","angz"],["2021-08-16T16:00:10Z","anji"],["2021-08-16T16:00:11Z","heng"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT substr(address, 1, 4) GROUP BY",
 			command: `SELECT substr(address, 1, 4) FROM db0.rp0.mst GROUP BY country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","substr"],"values":[["2021-08-16T16:00:10Z","anji"]]},{"name":"mst","tags":{"country":"american"},"columns":["time","substr"],"values":[["2021-08-16T16:00:01Z","hang"]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","substr"],"values":[["2021-08-16T16:00:04Z","heng"],["2021-08-16T16:00:09Z","angz"]]},{"name":"mst","tags":{"country":"china"},"columns":["time","substr"],"values":[["2021-08-16T16:00:00Z","henz"],["2021-08-16T16:00:05Z","uhan"],["2021-08-16T16:00:11Z","heng"]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","substr"],"values":[["2021-08-16T16:00:02Z","eiji"],["2021-08-16T16:00:07Z","nhui"]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","substr"],"values":[["2021-08-16T16:00:03Z","uang"],["2021-08-16T16:00:08Z","ian"]]}]}]}`,
@@ -3270,18 +3267,18 @@ func TestServer_Query_Sliding_Window_Aggregate(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3290,62 +3287,62 @@ func TestServer_Query_Sliding_Window_Aggregate(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "SELECT sliding_window(max), group by time",
 			command: `select sliding_window(max(*), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window_age","sliding_window_alive","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",35,true,138],["2021-08-16T16:00:01Z",48.8,true,149],["2021-08-16T16:00:02Z",52.7,true,153],["2021-08-16T16:00:03Z",52.7,true,153],["2021-08-16T16:00:04Z",52.7,true,179],["2021-08-16T16:00:05Z",60.8,true,180],["2021-08-16T16:00:06Z",102,true,191]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(min), group by time",
 			command: `select sliding_window(min(*), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window_age","sliding_window_alive","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",3.4,false,70],["2021-08-16T16:00:01Z",3.4,false,80],["2021-08-16T16:00:02Z",3.4,false,90],["2021-08-16T16:00:03Z",28.3,false,121],["2021-08-16T16:00:04Z",28.3,false,138],["2021-08-16T16:00:05Z",28.3,false,149],["2021-08-16T16:00:06Z",28.3,false,153]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(count), group by time",
 			command: `select sliding_window(count(*), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window_address","sliding_window_age","sliding_window_alive","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",5,5,5,5],["2021-08-16T16:00:01Z",5,5,4,5],["2021-08-16T16:00:02Z",4,5,4,5],["2021-08-16T16:00:03Z",4,5,4,4],["2021-08-16T16:00:04Z",4,4,4,4],["2021-08-16T16:00:05Z",4,4,4,4],["2021-08-16T16:00:06Z",4,4,5,4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(sum), group by time",
 			command: `select sliding_window(sum(height), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window"],"values":[["2021-08-16T16:00:00Z",499],["2021-08-16T16:00:01Z",578],["2021-08-16T16:00:02Z",651],["2021-08-16T16:00:03Z",561],["2021-08-16T16:00:04Z",619],["2021-08-16T16:00:05Z",661],["2021-08-16T16:00:06Z",703]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(mean), group by time",
 			command: `select sliding_window(mean(height), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window"],"values":[["2021-08-16T16:00:00Z",99.8],["2021-08-16T16:00:01Z",115.6],["2021-08-16T16:00:02Z",130.2],["2021-08-16T16:00:03Z",140.25],["2021-08-16T16:00:04Z",154.75],["2021-08-16T16:00:05Z",165.25],["2021-08-16T16:00:06Z",175.75]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(spread), group by time",
 			command: `select sliding_window(spread(*), 5) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",31.6,68],["2021-08-16T16:00:01Z",45.4,69],["2021-08-16T16:00:02Z",49.300000000000004,63],["2021-08-16T16:00:03Z",24.400000000000002,32],["2021-08-16T16:00:04Z",24.400000000000002,41],["2021-08-16T16:00:05Z",32.5,31],["2021-08-16T16:00:06Z",73.7,38]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(mean), group by time, tag",
 			command: `select sliding_window(mean(*), 8) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",null,null],["2021-08-16T16:00:01Z",null,null],["2021-08-16T16:00:02Z",null,null],["2021-08-16T16:00:03Z",102,191]]},{"name":"mst","tags":{"country":"american"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",36.6,116.5],["2021-08-16T16:00:01Z",36.6,116.5],["2021-08-16T16:00:02Z",52.7,153],["2021-08-16T16:00:03Z",52.7,153]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",35,138],["2021-08-16T16:00:01Z",35,138],["2021-08-16T16:00:02Z",47.9,159],["2021-08-16T16:00:03Z",47.9,159]]},{"name":"mst","tags":{"country":"china"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",30.549999999999997,109.5],["2021-08-16T16:00:01Z",48.8,149],["2021-08-16T16:00:02Z",48.8,149],["2021-08-16T16:00:03Z",48.8,149]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",15.85,90],["2021-08-16T16:00:01Z",15.85,90],["2021-08-16T16:00:02Z",15.85,90],["2021-08-16T16:00:03Z",28.3,null]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",30,121],["2021-08-16T16:00:01Z",30,150],["2021-08-16T16:00:02Z",30,150],["2021-08-16T16:00:03Z",30,150]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(spread), group by time,tag",
 			command: `select sliding_window(spread(*), 8) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",null,null],["2021-08-16T16:00:01Z",null,null],["2021-08-16T16:00:02Z",null,null],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"american"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",32.2,73],["2021-08-16T16:00:01Z",32.2,73],["2021-08-16T16:00:02Z",0,0],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",0,0],["2021-08-16T16:00:01Z",0,0],["2021-08-16T16:00:02Z",25.799999999999997,42],["2021-08-16T16:00:03Z",25.799999999999997,42]]},{"name":"mst","tags":{"country":"china"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",36.5,79],["2021-08-16T16:00:01Z",0,0],["2021-08-16T16:00:02Z",0,0],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",24.900000000000002,0],["2021-08-16T16:00:01Z",24.900000000000002,0],["2021-08-16T16:00:02Z",24.900000000000002,0],["2021-08-16T16:00:03Z",0,null]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",0,0],["2021-08-16T16:00:01Z",0,58],["2021-08-16T16:00:02Z",0,58],["2021-08-16T16:00:03Z",0,58]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT * FROM (sliding_window(mean), group by time, tag)",
 			command: `select * from (select sliding_window(mean(*), 8) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","country","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z","",null,null],["2021-08-16T16:00:01Z","",null,null],["2021-08-16T16:00:02Z","",null,null],["2021-08-16T16:00:03Z","",102,191],["2021-08-16T16:00:00Z","american",36.6,116.5],["2021-08-16T16:00:01Z","american",36.6,116.5],["2021-08-16T16:00:02Z","american",52.7,153],["2021-08-16T16:00:03Z","american",52.7,153],["2021-08-16T16:00:00Z","canada",35,138],["2021-08-16T16:00:01Z","canada",35,138],["2021-08-16T16:00:02Z","canada",47.9,159],["2021-08-16T16:00:03Z","canada",47.9,159],["2021-08-16T16:00:00Z","china",30.549999999999997,109.5],["2021-08-16T16:00:01Z","china",48.8,149],["2021-08-16T16:00:02Z","china",48.8,149],["2021-08-16T16:00:03Z","china",48.8,149],["2021-08-16T16:00:00Z","germany",15.85,90],["2021-08-16T16:00:01Z","germany",15.85,90],["2021-08-16T16:00:02Z","germany",15.85,90],["2021-08-16T16:00:03Z","germany",28.3,null],["2021-08-16T16:00:00Z","japan",30,121],["2021-08-16T16:00:01Z","japan",30,150],["2021-08-16T16:00:02Z","japan",30,150],["2021-08-16T16:00:03Z","japan",30,150]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT * FROM (SELECT sliding_window(spread), group by time,tag)",
 			command: `select * from (select sliding_window(spread(*), 8) from db0.rp0.mst where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","country","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z","",null,null],["2021-08-16T16:00:01Z","",null,null],["2021-08-16T16:00:02Z","",null,null],["2021-08-16T16:00:03Z","",0,0],["2021-08-16T16:00:00Z","american",32.2,73],["2021-08-16T16:00:01Z","american",32.2,73],["2021-08-16T16:00:02Z","american",0,0],["2021-08-16T16:00:03Z","american",0,0],["2021-08-16T16:00:00Z","canada",0,0],["2021-08-16T16:00:01Z","canada",0,0],["2021-08-16T16:00:02Z","canada",25.799999999999997,42],["2021-08-16T16:00:03Z","canada",25.799999999999997,42],["2021-08-16T16:00:00Z","china",36.5,79],["2021-08-16T16:00:01Z","china",0,0],["2021-08-16T16:00:02Z","china",0,0],["2021-08-16T16:00:03Z","china",0,0],["2021-08-16T16:00:00Z","germany",24.900000000000002,0],["2021-08-16T16:00:01Z","germany",24.900000000000002,0],["2021-08-16T16:00:02Z","germany",24.900000000000002,0],["2021-08-16T16:00:03Z","germany",0,null],["2021-08-16T16:00:00Z","japan",0,0],["2021-08-16T16:00:01Z","japan",0,58],["2021-08-16T16:00:02Z","japan",0,58],["2021-08-16T16:00:03Z","japan",0,58]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(mean(*)), FROM (SELECT *) group by time)",
 			command: `select sliding_window(mean(*), 8) from (select * from db0.rp0.mst) where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",null,null],["2021-08-16T16:00:01Z",null,null],["2021-08-16T16:00:02Z",null,null],["2021-08-16T16:00:03Z",102,191]]},{"name":"mst","tags":{"country":"american"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",36.6,116.5],["2021-08-16T16:00:01Z",36.6,116.5],["2021-08-16T16:00:02Z",52.7,153],["2021-08-16T16:00:03Z",52.7,153]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",35,138],["2021-08-16T16:00:01Z",35,138],["2021-08-16T16:00:02Z",47.9,159],["2021-08-16T16:00:03Z",47.9,159]]},{"name":"mst","tags":{"country":"china"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",30.549999999999997,109.5],["2021-08-16T16:00:01Z",48.8,149],["2021-08-16T16:00:02Z",48.8,149],["2021-08-16T16:00:03Z",48.8,149]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",15.85,90],["2021-08-16T16:00:01Z",15.85,90],["2021-08-16T16:00:02Z",15.85,90],["2021-08-16T16:00:03Z",28.3,null]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",30,121],["2021-08-16T16:00:01Z",30,150],["2021-08-16T16:00:02Z",30,150],["2021-08-16T16:00:03Z",30,150]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT sliding_window(spread), FROM (SELECT *) group by time)",
 			command: `select sliding_window(spread(*), 8) from (select * from db0.rp0.mst) where time >= '2021-08-16T16:00:00Z' and time < '2021-08-16T16:00:11Z' group by time(1s),country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",null,null],["2021-08-16T16:00:01Z",null,null],["2021-08-16T16:00:02Z",null,null],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"american"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",32.2,73],["2021-08-16T16:00:01Z",32.2,73],["2021-08-16T16:00:02Z",0,0],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",0,0],["2021-08-16T16:00:01Z",0,0],["2021-08-16T16:00:02Z",25.799999999999997,42],["2021-08-16T16:00:03Z",25.799999999999997,42]]},{"name":"mst","tags":{"country":"china"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",36.5,79],["2021-08-16T16:00:01Z",0,0],["2021-08-16T16:00:02Z",0,0],["2021-08-16T16:00:03Z",0,0]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",24.900000000000002,0],["2021-08-16T16:00:01Z",24.900000000000002,0],["2021-08-16T16:00:02Z",24.900000000000002,0],["2021-08-16T16:00:03Z",0,null]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","sliding_window_age","sliding_window_height"],"values":[["2021-08-16T16:00:00Z",0,0],["2021-08-16T16:00:01Z",0,58],["2021-08-16T16:00:02Z",0,58],["2021-08-16T16:00:03Z",0,58]]}]}]}`,
@@ -3381,18 +3378,18 @@ func TestServer_Query_Null_Aggregate(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3402,185 +3399,185 @@ func TestServer_Query_Null_Aggregate(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// BUG2021121601543
-		&Query{
+		{
 			name:    "SELECT top(age, 2), country",
 			command: `SELECT top(age, 2), country FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","top","country"],"values":[["2021-08-16T16:00:10Z",102,null],["2021-08-16T16:00:11Z",123,"china"]]}]}]}`,
 		},
 		// BUG2021121601543
-		&Query{
+		{
 			name:    "SELECT top(age, 2), age - height",
 			command: `SELECT top(age, 2), age - height AS value FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","top","value"],"values":[["2021-08-16T16:00:10Z",102,-89],["2021-08-16T16:00:11Z",123,-80]]}]}]}`,
 			//skip:    true,
 		},
 		// BUG2021121601543
-		&Query{
+		{
 			name:    "SELECT max(age), age - height",
 			command: `SELECT max(age), age - height AS value FROM db0.rp0.mst GROUP BY country`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":""},"columns":["time","max","value"],"values":[["2021-08-16T16:00:10Z",102,-89]]},{"name":"mst","tags":{"country":"american"},"columns":["time","max","value"],"values":[["2021-08-16T16:00:06Z",52.7,-100.3]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","max","value"],"values":[["2021-08-16T16:00:09Z",60.8,-119.2]]},{"name":"mst","tags":{"country":"china"},"columns":["time","max","value"],"values":[["2021-08-16T16:00:11Z",123,-80]]},{"name":"mst","tags":{"country":"germany"},"columns":["time","max","value"],"values":[["2021-08-16T16:00:07Z",28.3,null]]},{"name":"mst","tags":{"country":"japan"},"columns":["time","max","value"],"values":[["2021-08-16T16:00:03Z",30,-91]]}]}]}`,
 			//skip:    true,
 		},
 		// BUG2021121702524
-		&Query{
+		{
 			name:    "SELECT BOTTOM(value, 2) FROM (SELECT BOTTOM(age, 3), age - height AS value FROM db0.rp0.mst)",
 			command: `SELECT BOTTOM(value, 2) FROM (SELECT BOTTOM(age, 3), age - height AS value FROM db0.rp0.mst GROUP BY country) WHERE time >= '2021-08-16T16:00:00Z' AND time < '2021-08-16T16:00:11Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","bottom"],"values":[["2021-08-16T16:00:04Z",-103],["2021-08-16T16:00:09Z",-119.2]]}]}]}`,
 			//skip:    true,
 		},
 		// BUG2021121702480
-		&Query{
+		{
 			name:    "SELECT LAST(*) group by time(12m) limit 5",
 			command: `SELECT LAST(*) FROM db0.rp0.mst group by time(12m) order by time limit 5`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","last_address","last_age","last_alive","last_height"],"values":[["2021-08-16T16:00:00Z","zhengzhou",123,false,203],["2021-08-16T16:12:00Z",null,null,null,null],["2021-08-16T16:24:00Z",null,null,null,null],["2021-08-16T16:36:00Z",null,null,null,null],["2021-08-16T16:48:00Z",null,null,null,null]]}]}]}`,
 			//skip:    true,
 		},
 		// BUG2021121702512
-		&Query{
+		{
 			name:    "SELECT FIRST(*) FROM (SELECT * FROM db0.rp0.mst)",
 			command: `SELECT FIRST(*) FROM (SELECT * FROM db0.rp0.mst)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","first_address","first_age","first_alive","first_height"],"values":[["1970-01-01T00:00:00Z","shenzhen",12.3,true,70]]}]}]}`,
 			//skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT DIFFERENCE(*) FROM db0.rp0.mst",
 			command: `SELECT DIFFERENCE(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","difference_age","difference_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",-17.1,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:07Z",-24.400000000000002,null],["2021-08-16T16:00:08Z",null,26],["2021-08-16T16:00:09Z",32.5,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT DIFFERENCE(* 'front') FROM db0.rp0.mst",
 			command: `SELECT DIFFERENCE(*, 'front') FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","difference_age","difference_height"],"values":[["2021-08-16T16:00:01Z",-8.2,-10],["2021-08-16T16:00:02Z",17.1,-10],["2021-08-16T16:00:03Z",-26.6,-31],["2021-08-16T16:00:04Z",-5,-17],["2021-08-16T16:00:05Z",-13.799999999999997,-11],["2021-08-16T16:00:06Z",-3.9000000000000057,-4],["2021-08-16T16:00:07Z",24.400000000000002,null],["2021-08-16T16:00:08Z",null,-26],["2021-08-16T16:00:09Z",-32.5,-1],["2021-08-16T16:00:10Z",-41.2,-11],["2021-08-16T16:00:11Z",-21,-12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT DIFFERENCE(* 'behind') FROM db0.rp0.mst",
 			command: `SELECT DIFFERENCE(*, 'behind') FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","difference_age","difference_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",-17.1,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:07Z",-24.400000000000002,null],["2021-08-16T16:00:08Z",null,26],["2021-08-16T16:00:09Z",32.5,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT DIFFERENCE(* 'absolute') FROM db0.rp0.mst",
 			command: `SELECT DIFFERENCE(*, 'absolute') FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","difference_age","difference_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",17.1,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:07Z",24.400000000000002,null],["2021-08-16T16:00:08Z",null,26],["2021-08-16T16:00:09Z",32.5,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select difference(age, 'front') from ( select * from db0.rp0.mst group by country) group by country order by time desc",
 			command: `select difference(age, 'front') from ( select * from db0.rp0.mst group by country) group by country order by time desc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":"germany"},"columns":["time","difference"],"values":[["2021-08-16T16:00:02Z",24.900000000000002]]},{"name":"mst","tags":{"country":"china"},"columns":["time","difference"],"values":[["2021-08-16T16:00:05Z",74.2],["2021-08-16T16:00:00Z",36.5]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","difference"],"values":[["2021-08-16T16:00:04Z",25.799999999999997]]},{"name":"mst","tags":{"country":"american"},"columns":["time","difference"],"values":[["2021-08-16T16:00:01Z",32.2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select difference(age, 'behind') from ( select * from db0.rp0.mst group by country) group by country order by time desc",
 			command: `select difference(age, 'behind') from ( select * from db0.rp0.mst group by country) group by country order by time desc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":"germany"},"columns":["time","difference"],"values":[["2021-08-16T16:00:02Z",-24.900000000000002]]},{"name":"mst","tags":{"country":"china"},"columns":["time","difference"],"values":[["2021-08-16T16:00:05Z",-74.2],["2021-08-16T16:00:00Z",-36.5]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","difference"],"values":[["2021-08-16T16:00:04Z",-25.799999999999997]]},{"name":"mst","tags":{"country":"american"},"columns":["time","difference"],"values":[["2021-08-16T16:00:01Z",-32.2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select difference(age, 'absolute') from ( select * from db0.rp0.mst group by country) group by country order by time desc",
 			command: `select difference(age, 'absolute') from ( select * from db0.rp0.mst group by country) group by country order by time desc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"country":"germany"},"columns":["time","difference"],"values":[["2021-08-16T16:00:02Z",24.900000000000002]]},{"name":"mst","tags":{"country":"china"},"columns":["time","difference"],"values":[["2021-08-16T16:00:05Z",74.2],["2021-08-16T16:00:00Z",36.5]]},{"name":"mst","tags":{"country":"canada"},"columns":["time","difference"],"values":[["2021-08-16T16:00:04Z",25.799999999999997]]},{"name":"mst","tags":{"country":"american"},"columns":["time","difference"],"values":[["2021-08-16T16:00:01Z",32.2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT NON_NEGATIVE_DIFFERENCE(*) FROM db0.rp0.mst",
 			command: `SELECT NON_NEGATIVE_DIFFERENCE(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","non_negative_difference_age","non_negative_difference_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",null,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:08Z",null,26],["2021-08-16T16:00:09Z",32.5,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT DERIVATIVE(*) FROM db0.rp0.mst",
 			command: `SELECT DERIVATIVE(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","derivative_age","derivative_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",-17.1,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:07Z",-24.400000000000002,null],["2021-08-16T16:00:08Z",null,13],["2021-08-16T16:00:09Z",16.25,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT NON_NEGATIVE_DERIVATIVE(*) FROM db0.rp0.mst",
 			command: `SELECT NON_NEGATIVE_DERIVATIVE(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","non_negative_derivative_age","non_negative_derivative_height"],"values":[["2021-08-16T16:00:01Z",8.2,10],["2021-08-16T16:00:02Z",null,10],["2021-08-16T16:00:03Z",26.6,31],["2021-08-16T16:00:04Z",5,17],["2021-08-16T16:00:05Z",13.799999999999997,11],["2021-08-16T16:00:06Z",3.9000000000000057,4],["2021-08-16T16:00:08Z",null,13],["2021-08-16T16:00:09Z",16.25,1],["2021-08-16T16:00:10Z",41.2,11],["2021-08-16T16:00:11Z",21,12]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "SELECT ELAPSED(*) FROM db0.rp0.mst",
 			command: `SELECT ELAPSED(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","elapsed_address","elapsed_age","elapsed_alive","elapsed_height"],"values":[["2021-08-16T16:00:01Z",1000000000,1000000000,1000000000,1000000000],["2021-08-16T16:00:02Z",1000000000,1000000000,1000000000,1000000000],["2021-08-16T16:00:03Z",1000000000,1000000000,1000000000,1000000000],["2021-08-16T16:00:04Z",1000000000,1000000000,1000000000,1000000000],["2021-08-16T16:00:05Z",1000000000,1000000000,null,1000000000],["2021-08-16T16:00:06Z",null,1000000000,2000000000,1000000000],["2021-08-16T16:00:07Z",2000000000,1000000000,1000000000,null],["2021-08-16T16:00:08Z",1000000000,null,1000000000,2000000000],["2021-08-16T16:00:09Z",1000000000,2000000000,1000000000,1000000000],["2021-08-16T16:00:10Z",1000000000,1000000000,1000000000,1000000000],["2021-08-16T16:00:11Z",1000000000,1000000000,1000000000,1000000000]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT MOVING_AVERAGE(*, 2) FROM db0.rp0.mst",
 			command: `SELECT MOVING_AVERAGE(* ,2) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","moving_average_age","moving_average_height"],"values":[["2021-08-16T16:00:01Z",16.4,75],["2021-08-16T16:00:02Z",11.949999999999998,85],["2021-08-16T16:00:03Z",16.699999999999996,105.5],["2021-08-16T16:00:04Z",32.5,129.5],["2021-08-16T16:00:05Z",41.9,143.5],["2021-08-16T16:00:06Z",50.75,151],["2021-08-16T16:00:07Z",40.5,null],["2021-08-16T16:00:08Z",null,166],["2021-08-16T16:00:09Z",44.55,179.5],["2021-08-16T16:00:10Z",81.4,185.5],["2021-08-16T16:00:11Z",112.5,197]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT CUMULATIVE_SUM(*) FROM db0.rp0.mst",
 			command: `SELECT CUMULATIVE_SUM(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","cumulative_sum_age","cumulative_sum_height"],"values":[["2021-08-16T16:00:00Z",12.3,70],["2021-08-16T16:00:01Z",32.8,150],["2021-08-16T16:00:02Z",36.199999999999996,240],["2021-08-16T16:00:03Z",66.19999999999999,361],["2021-08-16T16:00:04Z",101.19999999999999,499],["2021-08-16T16:00:05Z",150,648],["2021-08-16T16:00:06Z",202.7,801],["2021-08-16T16:00:07Z",231,null],["2021-08-16T16:00:08Z",null,980],["2021-08-16T16:00:09Z",291.8,1160],["2021-08-16T16:00:10Z",393.8,1351],["2021-08-16T16:00:11Z",516.8,1554]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT INTEGRAL(*) FROM db0.rp0.mst",
 			command: `SELECT INTEGRAL(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","integral_age","integral_height"],"values":[["1970-01-01T00:00:00Z",493.69999999999993,1583.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT COUNT(TIME)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT COUNT(TIME) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT /*+ Exact_Statistic_Query */ COUNT(TIME)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT /*+ Exact_Statistic_Query */ COUNT(TIME) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT rate(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT rate(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","rate_age","rate_height"],"values":[["1970-01-01T00:00:00Z",10.063636363636364,12.090909090909092]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT irate(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT irate(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","irate_age","irate_height"],"values":[["1970-01-01T00:00:00Z",21,12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT absent(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT absent(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","absent_address","absent_age","absent_alive","absent_height"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT spread(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT spread(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","spread_age","spread_height"],"values":[["1970-01-01T00:00:00Z",119.6,133]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT stddev(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT stddev(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","stddev_age","stddev_height"],"values":[["1970-01-01T00:00:00Z",36.90143135927978,46.139117696572626]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT median(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT median(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","median_age","median_height"],"values":[["1970-01-01T00:00:00Z",35,149]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT mode(*)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT mode(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","mode_address","mode_age","mode_alive","mode_height"],"values":[["1970-01-01T00:00:00Z","anhui",3.4,true,70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT count(*), group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT count(*) FROM db0.rp0.mst WHERE time >= 1629129600000000000 and time <= 1629129611000000000 group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_address","count_age","count_alive","count_height"],"values":[["2021-08-16T16:00:00Z",1,1,1,1],["2021-08-16T16:00:01Z",1,1,1,1],["2021-08-16T16:00:02Z",1,1,1,1],["2021-08-16T16:00:03Z",1,1,1,1],["2021-08-16T16:00:04Z",1,1,1,1],["2021-08-16T16:00:05Z",1,1,0,1],["2021-08-16T16:00:06Z",0,1,1,1],["2021-08-16T16:00:07Z",1,1,1,0],["2021-08-16T16:00:08Z",1,0,1,1],["2021-08-16T16:00:09Z",1,1,1,1],["2021-08-16T16:00:10Z",1,1,1,1],["2021-08-16T16:00:11Z",1,1,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT last(*), group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT last(*) FROM db0.rp0.mst WHERE time >= 1629129600000000000 and time <= 1629129611000000000 group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","last_address","last_age","last_alive","last_height"],"values":[["2021-08-16T16:00:00Z","shenzhen",12.3,true,70],["2021-08-16T16:00:01Z","shanghai",20.5,false,80],["2021-08-16T16:00:02Z","beijin",3.4,true,90],["2021-08-16T16:00:03Z","guangzhou",30,false,121],["2021-08-16T16:00:04Z","chengdu",35,true,138],["2021-08-16T16:00:05Z","wuhan",48.8,null,149],["2021-08-16T16:00:06Z",null,52.7,true,153],["2021-08-16T16:00:07Z","anhui",28.3,false,null],["2021-08-16T16:00:08Z","xian",null,true,179],["2021-08-16T16:00:09Z","hangzhou",60.8,false,180],["2021-08-16T16:00:10Z","nanjin",102,true,191],["2021-08-16T16:00:11Z","zhengzhou",123,false,203]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT /*+ specific_series */  *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT /*+ specific_series */  * FROM db0.rp0.mst WHERE country='china' and age=12.3 and "name"='azhu'`,
@@ -3617,10 +3614,10 @@ func TestServer_Query_For_BugList(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`cpu,tag1=1 field1=1 1566786536000000000`),
-		fmt.Sprintf(`cpu,tag1=2 field1=2 1566786537000000000`),
-		fmt.Sprintf(`cpu,tag2=3 field1=3 1566786538000000000`),
-		fmt.Sprintf(`cpu,tag2=4 field1=4 1566786539000000000`),
+		`cpu,tag1=1 field1=1 1566786536000000000`,
+		`cpu,tag1=2 field1=2 1566786537000000000`,
+		`cpu,tag2=3 field1=3 1566786538000000000`,
+		`cpu,tag2=4 field1=4 1566786539000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3630,30 +3627,30 @@ func TestServer_Query_For_BugList(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// BUG2022010501886
-		&Query{
+		{
 			name:    "select * from db0.rp0.cpu",
 			command: `SELECT * FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","field1","tag1","tag2"],"values":[["2019-08-26T02:28:56Z",1,"1",null],["2019-08-26T02:28:57Z",2,"2",null],["2019-08-26T02:28:58Z",3,null,"3"],["2019-08-26T02:28:59Z",4,null,"4"]]}]}]}`,
 		},
 		// BUG2022071101301
-		&Query{
+		{
 			name:    "select min(field1),field1 from db0.rp0.cpu",
 			command: `SELECT MIN(field1),field1 FROM db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","field1"],"values":[["2019-08-26T02:28:56Z",1,1]]}]}]}`,
 		},
 		// BUG2022080600046
-		&Query{
+		{
 			name:    "SELECT TOP(field1, 2),* FROM db0.rp0.cpu LIMIT 2",
 			command: `SELECT TOP(field1, 2),* FROM db0.rp0.cpu LIMIT 2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top","field1","tag1","tag2"],"values":[["2019-08-26T02:28:58Z",3,3,null,"3"],["2019-08-26T02:28:59Z",4,4,null,"4"]]}]}]}`,
 		},
 		// BUG2022120901869
-		&Query{
+		{
 			name:    "SELECT multi-agg(field1) FROM db0.rp0.cpu LIMIT 1",
 			command: `select MOVING_AVERAGE(field2,2) as f8, NON_NEGATIVE_DERIVATIVE(field2) as f1, NON_NEGATIVE_DIFFERENCE(field2) as f2, CUMULATIVE_SUM(field2) as f3, CUMULATIVE_SUM(field2) as f4, DERIVATIVE(field2) as f5, DIFFERENCE(field2) as f6, ELAPSED(field2) as f7, MOVING_AVERAGE(field1,2) as ax, INTEGRAL(field2) as f9 from db0.rp0.cpu limit 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","f8","f1","f2","f3","f4","f5","f6","f7","ax","f9"],"values":[["2019-08-26T02:28:57Z",null,null,null,null,null,null,null,null,1.5,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "SELECT multi-agg(*) FROM db0.rp0.cpu LIMIT 1",
 			command: `select ax, ay from ( select ax , f3 from (select  NON_NEGATIVE_DERIVATIVE(field2) as f1, NON_NEGATIVE_DIFFERENCE(field2) as f2, CUMULATIVE_SUM(field2) as f3, CUMULATIVE_SUM(field2) as f4, DERIVATIVE(field2) as f5, DIFFERENCE(field2) as f6, ELAPSED(field2) as f7, MOVING_AVERAGE(field1,2) as ax, MOVING_AVERAGE(field2,2) as f8, INTEGRAL(field2) as f9 from db0.rp0.cpu limit 1))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","ax","ay"],"values":[["2019-08-26T02:28:57Z",1.5,null]]}]}]}`,
@@ -3689,10 +3686,10 @@ func TestServer_Query_Blank_Row(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,t=di f1=1,f2=3i 1579415564528082073`),
-		fmt.Sprintf(`mst,t=di1 f1=-2,f2=-1i 1579415565558082073`),
-		fmt.Sprintf(`mst,t=di f1=3 1579415566558082073`),
-		fmt.Sprintf(`mst,t=di f1=2,f2=4i 1579415567558882073`),
+		`mst,t=di f1=1,f2=3i 1579415564528082073`,
+		`mst,t=di1 f1=-2,f2=-1i 1579415565558082073`,
+		`mst,t=di f1=3 1579415566558082073`,
+		`mst,t=di f1=2,f2=4i 1579415567558882073`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3701,12 +3698,12 @@ func TestServer_Query_Blank_Row(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select non_negative_difference(*) from mst",
 			command: `select non_negative_difference(*) from db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","non_negative_difference_f1","non_negative_difference_f2"],"values":[["2020-01-19T06:32:46.558082073Z",5,null],["2020-01-19T06:32:47.558882073Z",null,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "non_negative_derivative(*) from mst",
 			command: `select non_negative_derivative(*) from db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","non_negative_derivative_f1","non_negative_derivative_f2"],"values":[["2020-01-19T06:32:46.558082073Z",5,null],["2020-01-19T06:32:47.558882073Z",null,2.4990003998400643]]}]}]}`,
@@ -3742,15 +3739,15 @@ func TestServer_Query_Fill_Bug_List(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,tag1=1 count=0 0`),
-		fmt.Sprintf(`mst,tag1=2 count=4 4000000000`),
-		fmt.Sprintf(`mst,tag1=3 count=2 2000000000`),
-		fmt.Sprintf(`mst,tag1=4 count=0 0`),
-		fmt.Sprintf(`mst,tag1=4 count=1 1000000000`),
-		fmt.Sprintf(`mst,tag1=5 count=3 3000000000`),
-		fmt.Sprintf(`mst,tag1=5 count=4 4000000000`),
-		fmt.Sprintf(`mst,tag1=6 count=0 0`),
-		fmt.Sprintf(`mst,tag1=6 count=4 4000000000`),
+		`mst,tag1=1 count=0 0`,
+		`mst,tag1=2 count=4 4000000000`,
+		`mst,tag1=3 count=2 2000000000`,
+		`mst,tag1=4 count=0 0`,
+		`mst,tag1=4 count=1 1000000000`,
+		`mst,tag1=5 count=3 3000000000`,
+		`mst,tag1=5 count=4 4000000000`,
+		`mst,tag1=6 count=0 0`,
+		`mst,tag1=6 count=4 4000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3759,13 +3756,13 @@ func TestServer_Query_Fill_Bug_List(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select sum(count) from db0.rp0.mst group by time(1s),tag1",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(count) from db0.rp0.mst where time >= 0 and time < 5000000000 group by time(1s),tag1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tag1":"1"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T00:00:01Z",null],["1970-01-01T00:00:02Z",null],["1970-01-01T00:00:03Z",null],["1970-01-01T00:00:04Z",null]]},{"name":"mst","tags":{"tag1":"2"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",null],["1970-01-01T00:00:01Z",null],["1970-01-01T00:00:02Z",null],["1970-01-01T00:00:03Z",null],["1970-01-01T00:00:04Z",4]]},{"name":"mst","tags":{"tag1":"3"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",null],["1970-01-01T00:00:01Z",null],["1970-01-01T00:00:02Z",2],["1970-01-01T00:00:03Z",null],["1970-01-01T00:00:04Z",null]]},{"name":"mst","tags":{"tag1":"4"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T00:00:01Z",1],["1970-01-01T00:00:02Z",null],["1970-01-01T00:00:03Z",null],["1970-01-01T00:00:04Z",null]]},{"name":"mst","tags":{"tag1":"5"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",null],["1970-01-01T00:00:01Z",null],["1970-01-01T00:00:02Z",null],["1970-01-01T00:00:03Z",3],["1970-01-01T00:00:04Z",4]]},{"name":"mst","tags":{"tag1":"6"},"columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T00:00:01Z",null],["1970-01-01T00:00:02Z",null],["1970-01-01T00:00:03Z",null],["1970-01-01T00:00:04Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select sum(count) from db0.rp0.mst group by time(1s),tag1 order by time desc",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(count) from db0.rp0.mst where time >= 0 and time < 5000000000 group by time(1s),tag1 order by time desc`,
@@ -3802,12 +3799,12 @@ func TestServer_SubQuery_Top_Min(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=1,height=11i 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=2,height=12i 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3,height=13i 1629129602000000000`),
-		fmt.Sprintf(`mst,country=china,name=azhu age=4,height=24i 1629129603000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=5,height=25i 1629129604000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=6,height=26i 1629129605000000000`),
+		`mst,country=china,name=azhu age=1,height=11i 1629129600000000000`,
+		`mst,country=american,name=alan age=2,height=12i 1629129601000000000`,
+		`mst,country=germany,name=alang age=3,height=13i 1629129602000000000`,
+		`mst,country=china,name=azhu age=4,height=24i 1629129603000000000`,
+		`mst,country=american,name=alan age=5,height=25i 1629129604000000000`,
+		`mst,country=germany,name=alang age=6,height=26i 1629129605000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3817,7 +3814,7 @@ func TestServer_SubQuery_Top_Min(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// BUG: BUG2022040700537
-		&Query{
+		{
 			name:    "min-top",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT min(value) FROM (SELECT top(age, 2), age - height AS value FROM db0.rp0.mst) GROUP BY country`,
@@ -3854,12 +3851,12 @@ func TestServer_difference_derivative_time_duplicate(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=1,height=11i 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=2,height=12i 1629129600000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3,height=13i 1629129602000000000`),
-		fmt.Sprintf(`mst,country=china,name=azhu age=4,height=24i 1629129602000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=5,height=25i 1629129604000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=6,height=26i 1629129604000000000`),
+		`mst,country=china,name=azhu age=1,height=11i 1629129600000000000`,
+		`mst,country=american,name=alan age=2,height=12i 1629129600000000000`,
+		`mst,country=germany,name=alang age=3,height=13i 1629129602000000000`,
+		`mst,country=china,name=azhu age=4,height=24i 1629129602000000000`,
+		`mst,country=american,name=alan age=5,height=25i 1629129604000000000`,
+		`mst,country=germany,name=alang age=6,height=26i 1629129604000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3869,14 +3866,14 @@ func TestServer_difference_derivative_time_duplicate(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// BUG2022071301614
-		&Query{
+		{
 			name:    "difference",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT difference(*) FROM db0.rp0.mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","difference_age","difference_height"],"values":[["2021-08-16T16:00:02Z",2,2],["2021-08-16T16:00:04Z",2,12]]}]}]}`,
 		},
 		// BUG2022071301614
-		&Query{
+		{
 			name:    "derivative",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `SELECT derivative(*) FROM db0.rp0.mst`,
@@ -3913,12 +3910,12 @@ func TestServer_top_bottom_nul_column(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu height=11i 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=2,height=12i 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang height=13i 1629129602000000000`),
-		fmt.Sprintf(`mst,country=china,name=azhu age=4,height=24i 1629129603000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=5,height=25i 1629129604000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang height=26i 1629129605000000000`),
+		`mst,country=china,name=azhu height=11i 1629129600000000000`,
+		`mst,country=american,name=alan age=2,height=12i 1629129601000000000`,
+		`mst,country=germany,name=alang height=13i 1629129602000000000`,
+		`mst,country=china,name=azhu age=4,height=24i 1629129603000000000`,
+		`mst,country=american,name=alan age=5,height=25i 1629129604000000000`,
+		`mst,country=germany,name=alang height=26i 1629129605000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -3927,13 +3924,13 @@ func TestServer_top_bottom_nul_column(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "top",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select top(sum_age, 3) from (select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where time >= 1629129600000000000 and time <= 1629129605000000000 group by time(1s)) where time >= 1629129600000000000 and time <= 1629129605000000000`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","top"],"values":[["2021-08-16T16:00:01Z",2],["2021-08-16T16:00:03Z",4],["2021-08-16T16:00:04Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select bottom(sum_age, 3) from (select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where time >= 1629129600000000000 and time <= 1629129605000000000 group by time(1s)) where time >= 1629129600000000000 and time <= 1629129605000000000`,
@@ -3990,62 +3987,62 @@ func TestServer_Query_ColumnStore(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// 1. multi-column *
-		&Query{
+		{
 			name:    "count(time)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select count(time) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20480]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "exact count(time)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select /*+ Exact_Statistic_Query */ count(time) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select count(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",20480,20480,20480,20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select mean(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",10239.5,10239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select sum(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",209704960,209704960]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),min(v2)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select min(v1),min(v2) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",0,0]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(v1),max(v2)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select max(v1),max(v2) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",20479,20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select first(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select last(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(*, 50)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select percentile(*, 50) from db0.rp0.cpu`,
@@ -4053,152 +4050,152 @@ func TestServer_Query_ColumnStore(t *testing.T) {
 		},
 
 		// 2. multi-column
-		&Query{
+		{
 			name:    "count(time) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) fill(0) order by time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",3600],["1970-01-01T01:00:00Z",3600],["1970-01-01T02:00:00Z",3600],["1970-01-01T03:00:00Z",3600],["1970-01-01T04:00:00Z",3600],["1970-01-01T05:00:00Z",2480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(time) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(time) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* fill(0) order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",1552],["1970-01-01T01:00:00Z",496],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",2048],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",1056],["1970-01-01T02:00:00Z",992],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",2048],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",560],["1970-01-01T03:00:00Z",1488],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",2048],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",64],["1970-01-01T04:00:00Z",1984],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",1616],["1970-01-01T05:00:00Z",432]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) fill(0) order by time`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",3600,3600,3600,3600],["1970-01-01T01:00:00Z",3600,3600,3600,3600],["1970-01-01T02:00:00Z",3600,3600,3600,3600],["1970-01-01T03:00:00Z",3600,3600,3600,3600],["1970-01-01T04:00:00Z",3600,3600,3600,3600],["1970-01-01T05:00:00Z",2480,2480,2480,2480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* fill(0) order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",1552,1552,1552,1552],["1970-01-01T01:00:00Z",496,496,496,496],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",2048,2048,2048,2048],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",1056,1056,1056,1056],["1970-01-01T02:00:00Z",992,992,992,992],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",2048,2048,2048,2048],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",560,560,560,560],["1970-01-01T03:00:00Z",1488,1488,1488,1488],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",2048,2048,2048,2048],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",64,64,64,64],["1970-01-01T04:00:00Z",1984,1984,1984,1984],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",1616,1616,1616,1616],["1970-01-01T05:00:00Z",432,432,432,432]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",2048,2048,2048,2048]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "mean(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1799.5,1799.5],["1970-01-01T01:00:00Z",5399.5,5399.5],["1970-01-01T02:00:00Z",8999.5,8999.5],["1970-01-01T03:00:00Z",12599.5,12599.5],["1970-01-01T04:00:00Z",16199.5,16199.5],["1970-01-01T05:00:00Z",19239.5,19239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",3071.5,3071.5]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",5119.5,5119.5]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",7167.5,7167.5]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",9215.5,9215.5]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",11263.5,11263.5]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",13311.5,13311.5]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",15359.5,15359.5]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",17407.5,17407.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",2823.5,2823.5],["1970-01-01T01:00:00Z",3847.5,3847.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",5119.5,5119.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",6671.5,6671.5],["1970-01-01T02:00:00Z",7695.5,7695.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",9215.5,9215.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10519.5,10519.5],["1970-01-01T03:00:00Z",11543.5,11543.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",13311.5,13311.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14367.5,14367.5],["1970-01-01T04:00:00Z",15391.5,15391.5],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",17191.5,17191.5],["1970-01-01T05:00:00Z",18215.5,18215.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "sum(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",6478200,6478200],["1970-01-01T01:00:00Z",19438200,19438200],["1970-01-01T02:00:00Z",32398200,32398200],["1970-01-01T03:00:00Z",45358200,45358200],["1970-01-01T04:00:00Z",58318200,58318200],["1970-01-01T05:00:00Z",47713960,47713960]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",2096128,2096128]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",6290432,6290432]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",10484736,10484736]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",14679040,14679040]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",18873344,18873344]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",23067648,23067648]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",27261952,27261952]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",31456256,31456256]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",35650560,35650560]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",39844864,39844864]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",2096128,2096128],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",4382072,4382072],["1970-01-01T01:00:00Z",1908360,1908360],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",10484736,10484736],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",7045104,7045104],["1970-01-01T02:00:00Z",7633936,7633936],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",18873344,18873344],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",5890920,5890920],["1970-01-01T03:00:00Z",17176728,17176728],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",27261952,27261952],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",919520,919520],["1970-01-01T04:00:00Z",30536736,30536736],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",27781464,27781464],["1970-01-01T05:00:00Z",7869096,7869096]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",39844864,39844864]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "min(v1),min(v2) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v1),min(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",0,0],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",7200,7200],["1970-01-01T03:00:00Z",10800,10800],["1970-01-01T04:00:00Z",14400,14400],["1970-01-01T05:00:00Z",18000,18000]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),min(v2) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v1),min(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",0,0]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",2048,2048]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",4096,4096]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",6144,6144]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",8192,8192]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",10240,10240]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",12288,12288]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",14336,14336]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",16384,16384]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",18432,18432]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),min(v2) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v1),min(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",0,0],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",2048,2048],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",4096,4096],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",6144,6144],["1970-01-01T02:00:00Z",7200,7200],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",8192,8192],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10240,10240],["1970-01-01T03:00:00Z",10800,10800],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",12288,12288],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14336,14336],["1970-01-01T04:00:00Z",14400,14400],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",16384,16384],["1970-01-01T05:00:00Z",18000,18000]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","min_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",18432,18432]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "max(v1),max(v2) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v1),max(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",3599,3599],["1970-01-01T01:00:00Z",7199,7199],["1970-01-01T02:00:00Z",10799,10799],["1970-01-01T03:00:00Z",14399,14399],["1970-01-01T04:00:00Z",17999,17999],["1970-01-01T05:00:00Z",20479,20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(v1),max(v2) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v1),max(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",4095,4095]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",6143,6143]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",8191,8191]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",10239,10239]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",12287,12287]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",14335,14335]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",16383,16383]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",18431,18431]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",20479,20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(v1),max(v2) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v1),max(v2) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",2047,2047],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",3599,3599],["1970-01-01T01:00:00Z",4095,4095],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",6143,6143],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",7199,7199],["1970-01-01T02:00:00Z",8191,8191],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10239,10239],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10799,10799],["1970-01-01T03:00:00Z",12287,12287],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14335,14335],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14399,14399],["1970-01-01T04:00:00Z",16383,16383],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",17999,17999],["1970-01-01T05:00:00Z",18431,18431]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","max","max_1"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",20479,20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "first(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",4096,4096,true,"abc4096"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",6144,6144,true,"abc6144"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",8192,8192,true,"abc8192"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",10240,10240,true,"abc10240"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",12288,12288,true,"abc12288"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",14336,14336,true,"abc14336"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",16384,16384,true,"abc16384"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",4096,4096,true,"abc4096"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",6144,6144,true,"abc6144"],["1970-01-01T02:00:00Z",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",8192,8192,true,"abc8192"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",10240,10240,true,"abc10240"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",12288,12288,true,"abc12288"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",14336,14336,true,"abc14336"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",16384,16384,true,"abc16384"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "last(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) order by time asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "last(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * order by az asc, region asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* order by az asc, region asc, time asc`,
@@ -4206,80 +4203,80 @@ func TestServer_Query_ColumnStore(t *testing.T) {
 		},
 
 		// sub-query
-		&Query{
+		{
 			name:    "percentile from (select sum(v1) group by time,*) group by az",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select PERCENTILE(v1, 95) as p95 from (select sum(v1) as v1 from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z'  group by time(1h),region,az order by az,time) group by az`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0"},"columns":["time","p95"],"values":[["1970-01-01T00:00:00Z",2096128]]},{"name":"cpu","tags":{"az":"az_1"},"columns":["time","p95"],"values":[["1970-01-01T00:00:00Z",4382072]]},{"name":"cpu","tags":{"az":"az_2"},"columns":["time","p95"],"values":[["1970-01-01T01:00:00Z",10484736]]},{"name":"cpu","tags":{"az":"az_3"},"columns":["time","p95"],"values":[["1970-01-01T01:00:00Z",7633936]]},{"name":"cpu","tags":{"az":"az_4"},"columns":["time","p95"],"values":[["1970-01-01T02:00:00Z",18873344]]},{"name":"cpu","tags":{"az":"az_5"},"columns":["time","p95"],"values":[["1970-01-01T02:00:00Z",17176728]]},{"name":"cpu","tags":{"az":"az_6"},"columns":["time","p95"],"values":[["1970-01-01T03:00:00Z",27261952]]},{"name":"cpu","tags":{"az":"az_7"},"columns":["time","p95"],"values":[["1970-01-01T03:00:00Z",30536736]]},{"name":"cpu","tags":{"az":"az_8"},"columns":["time","p95"],"values":[["1970-01-01T04:00:00Z",27781464]]},{"name":"cpu","tags":{"az":"az_9"},"columns":["time","p95"],"values":[["1970-01-01T05:00:00Z",39844864]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(v1),mean(v2) from (select v1 from (select v1,v2)),(select v2 from (select v1, v2))",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(v1), mean(v2) from (select v1 from (select v1, v2 from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z') where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' ),(select v2 from (select v1, v2 from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' ) where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum","mean"],"values":[["1970-01-01T00:00:00Z",209704960,10239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select top from (select percentile (select sum group by time,region,az) group by region,az) group by region",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select region,az,top(p95,3) as p95 from (select PERCENTILE(v1, 95) as p95 from (select sum(v1)as v1 from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),region,az order by region,az,time) where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by region,az) where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"region":"region_0"},"columns":["time","region","az","p95"],"values":[["1970-01-01T00:00:00Z","region_0","az_0",2096128]]},{"name":"cpu","tags":{"region":"region_1"},"columns":["time","region","az","p95"],"values":[["1970-01-01T00:00:00Z","region_1","az_1",4382072]]},{"name":"cpu","tags":{"region":"region_2"},"columns":["time","region","az","p95"],"values":[["1970-01-01T01:00:00Z","region_2","az_2",10484736]]},{"name":"cpu","tags":{"region":"region_3"},"columns":["time","region","az","p95"],"values":[["1970-01-01T01:00:00Z","region_3","az_3",7633936]]},{"name":"cpu","tags":{"region":"region_4"},"columns":["time","region","az","p95"],"values":[["1970-01-01T02:00:00Z","region_4","az_4",18873344]]},{"name":"cpu","tags":{"region":"region_5"},"columns":["time","region","az","p95"],"values":[["1970-01-01T02:00:00Z","region_5","az_5",17176728]]},{"name":"cpu","tags":{"region":"region_6"},"columns":["time","region","az","p95"],"values":[["1970-01-01T03:00:00Z","region_6","az_6",27261952]]},{"name":"cpu","tags":{"region":"region_7"},"columns":["time","region","az","p95"],"values":[["1970-01-01T03:00:00Z","region_7","az_7",30536736]]},{"name":"cpu","tags":{"region":"region_8"},"columns":["time","region","az","p95"],"values":[["1970-01-01T04:00:00Z","region_8","az_8",27781464]]},{"name":"cpu","tags":{"region":"region_9"},"columns":["time","region","az","p95"],"values":[["1970-01-01T05:00:00Z","region_9","az_9",39844864]]}]}]}`,
 		},
 		// show tag value & * & mean(v1)
-		&Query{
+		{
 			name:    "show tag values key = region",
 			params:  url.Values{"inner_chunk_size": []string{"1"}, "db": []string{"db0"}},
 			command: `show tag values with key = "region" order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["region","region_0"],["region","region_1"],["region","region_2"],["region","region_3"],["region","region_4"],["region","region_5"],["region","region_6"],["region","region_7"],["region","region_8"],["region","region_9"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "show tag values key = az",
 			params:  url.Values{"inner_chunk_size": []string{"1"}, "db": []string{"db0"}},
 			command: `show tag values with key = "az" order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["az","az_0"],["az","az_1"],["az","az_2"],["az","az_3"],["az","az_4"],["az","az_5"],["az","az_6"],["az","az_7"],["az","az_8"],["az","az_9"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(time)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select(*) az=az_7,region=region_7 limit 3",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select * from db0.rp0.cpu where time >= 6148000000000 and time < 16383000000000 and az = 'az_7' and region = 'region_7' limit 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:56Z","az_7","region_7",14336,14336,true,"abc14336"],["1970-01-01T03:58:57Z","az_7","region_7",14337,14337,false,"abc14337"],["1970-01-01T03:58:58Z","az_7","region_7",14338,14338,true,"abc14338"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "v1,v2,v3 az=az_7 limit 3",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select v1,v2,v3 from db0.rp0.cpu where time >= 6148000000000 and time < 16383000000000 and az = 'az_7' limit 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","v1","v2","v3"],"values":[["1970-01-01T03:58:56Z",14336,14336,true],["1970-01-01T03:58:57Z",14337,14337,false],["1970-01-01T03:58:58Z",14338,14338,true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(v1) group by time(5m)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(v1) as avg_v1 from db0.rp0.cpu where time >= 6148000000000 and time < 16383000000000 and az = 'az_6' group by time(5m) fill(none) order by time desc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","avg_v1"],"values":[["1970-01-01T03:55:00Z",14217.5],["1970-01-01T03:50:00Z",13949.5],["1970-01-01T03:45:00Z",13649.5],["1970-01-01T03:40:00Z",13349.5],["1970-01-01T03:35:00Z",13049.5],["1970-01-01T03:30:00Z",12749.5],["1970-01-01T03:25:00Z",12449.5],["1970-01-01T03:20:00Z",12293.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(v1) group by time(5m),az",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(v1) as avg_v1 from db0.rp0.cpu where time >= 0 and time < '1970-01-01T00:30:00Z' group by time(5m),az `,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0"},"columns":["time","avg_v1"],"values":[["1970-01-01T00:00:00Z",149.5],["1970-01-01T00:05:00Z",449.5],["1970-01-01T00:10:00Z",749.5],["1970-01-01T00:15:00Z",1049.5],["1970-01-01T00:20:00Z",1349.5],["1970-01-01T00:25:00Z",1649.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(v1),min(v1),max(v1) group by time(5m)",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(v1) as avg_v1, min(v1) as min_v1, max(v1) as max_v1 from db0.rp0.cpu where time >= 6148000000000 and time < 16383000000000 and az = 'az_6' group by time(5m) fill(none) order by time desc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","avg_v1","min_v1","max_v1"],"values":[["1970-01-01T03:55:00Z",14217.5,14100,14335],["1970-01-01T03:50:00Z",13949.5,13800,14099],["1970-01-01T03:45:00Z",13649.5,13500,13799],["1970-01-01T03:40:00Z",13349.5,13200,13499],["1970-01-01T03:35:00Z",13049.5,12900,13199],["1970-01-01T03:30:00Z",12749.5,12600,12899],["1970-01-01T03:25:00Z",12449.5,12300,12599],["1970-01-01T03:20:00Z",12293.5,12288,12299]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(v1),min(v1),max(v1) group by time(5m),az",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(v1) as avg_v1, min(v1) as min_v1, max(v1) as max_v1 from db0.rp0.cpu where time >= 0 and time < '1970-01-01T00:30:00Z' group by time(5m),az`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0"},"columns":["time","avg_v1","min_v1","max_v1"],"values":[["1970-01-01T00:00:00Z",149.5,0,299],["1970-01-01T00:05:00Z",449.5,300,599],["1970-01-01T00:10:00Z",749.5,600,899],["1970-01-01T00:15:00Z",1049.5,900,1199],["1970-01-01T00:20:00Z",1349.5,1200,1499],["1970-01-01T00:25:00Z",1649.5,1500,1799]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(v1),count(az) group by time(5m),az",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(v1) as avg_v1, count(az) as count_az from db0.rp0.cpu where time >= 0 and time < '1970-01-01T00:30:00Z' and az = 'az_0' group by time(5m),az`,
@@ -4323,18 +4320,18 @@ func TestServer_Query_TimeCluster(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=12i,height=70,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=20i,height=80,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3i,height=90,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui age=30i,height=121,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu age=35i,height=138,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang age=48i,height=149,address="wuhan",alive=TRUE 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan age=52i,height=153,address="wuhan",alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin age=28i,height=163,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali age=32i,height=173,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada,name=ali age=60i,height=180,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,country=canada,name=ahuang age=102i,height=191,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin age=123i,height=203,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu age=12i,height=70,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan age=20i,height=80,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang age=3i,height=90,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui age=30i,height=121,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu age=35i,height=138,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang age=48i,height=149,address="wuhan",alive=TRUE 1629129605000000000`,
+		`mst,country=american,name=agan age=52i,height=153,address="wuhan",alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin age=28i,height=163,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali age=32i,height=173,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada,name=ali age=60i,height=180,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,country=canada,name=ahuang age=102i,height=191,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin age=123i,height=203,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -4343,19 +4340,19 @@ func TestServer_Query_TimeCluster(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "inner",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where time >= 1629129600000000000 and time <= 1629129604000000000 group by time(1s) fill(none)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["2021-08-16T16:00:00Z",12,70],["2021-08-16T16:00:01Z",20,80],["2021-08-16T16:00:02Z",3,90],["2021-08-16T16:00:03Z",30,121],["2021-08-16T16:00:04Z",35,138]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "outer",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where time >= 1629129600000000000 and time <= 1629129606000000000 group by time(1s) fill(none)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["2021-08-16T16:00:00Z",12,70],["2021-08-16T16:00:01Z",20,80],["2021-08-16T16:00:02Z",3,90],["2021-08-16T16:00:03Z",30,121],["2021-08-16T16:00:04Z",35,138],["2021-08-16T16:00:05Z",48,149],["2021-08-16T16:00:06Z",52,153]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "equal",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where time >= 1629129600000000000 and time <= 1629129605000000000 group by time(1s) fill(none)`,
@@ -4398,18 +4395,18 @@ func TestServer_MeasurementWithShardLists(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu age=12i,height=70,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan age=20i,height=80,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang age=3i,height=90,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui age=30i,height=121,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu age=35i,height=138,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang age=48i,height=149,address="wuhan",alive=TRUE 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan age=52i,height=153,address="wuhan",alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin age=28i,height=163,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali age=32i,height=173,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada,name=ali age=60i,height=180,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,country=canada,name=ahuang age=102i,height=191,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin age=123i,height=203,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu age=12i,height=70,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan age=20i,height=80,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang age=3i,height=90,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui age=30i,height=121,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu age=35i,height=138,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang age=48i,height=149,address="wuhan",alive=TRUE 1629129605000000000`,
+		`mst,country=american,name=agan age=52i,height=153,address="wuhan",alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin age=28i,height=163,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali age=32i,height=173,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada,name=ali age=60i,height=180,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,country=canada,name=ahuang age=102i,height=191,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin age=123i,height=203,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -4418,37 +4415,37 @@ func TestServer_MeasurementWithShardLists(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "china",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where country = 'china'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["1970-01-01T00:00:00Z",183,422]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "germany",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where country = 'germany'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["1970-01-01T00:00:00Z",31,253]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "canada",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where country = 'canada'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["1970-01-01T00:00:00Z",197,509]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "american",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where country = 'american'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["1970-01-01T00:00:00Z",72,233]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "american",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where country = 'american'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_age","sum_height"],"values":[["1970-01-01T00:00:00Z",72,233]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "wuhan",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(age) as sum_age, sum(height) as sum_height from db0.rp0.mst where address = 'wuhan'`,
@@ -4503,99 +4500,99 @@ func TestServer_Query_Complex_Aggregate(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// 1. multi-column *
-		&Query{
+		{
 			name:    "count(time)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select count(time) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "exact count(time)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select /*+ Exact_Statistic_Query */ count(time) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select count(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",20480,20480,20480,20480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select mean(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",10239.5,10239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select sum(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",209704960,209704960]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select min(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",0,0,false]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "max(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select max(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",20479,20479,true]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "first(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select first(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select last(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select spread(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",20479,20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(*, 50)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select percentile(*, 50) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",10239,10239]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "median(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select median(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",10239.5,10239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mode(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select mode(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "rate(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select rate(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "irate(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select irate(*) from db0.rp0.cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*)",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select stddev(*) from db0.rp0.cpu`,
@@ -4603,296 +4600,296 @@ func TestServer_Query_Complex_Aggregate(t *testing.T) {
 		},
 
 		// 2. multi-column
-		&Query{
+		{
 			name:    "count(time) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",3600],["1970-01-01T01:00:00Z",3600],["1970-01-01T02:00:00Z",3600],["1970-01-01T03:00:00Z",3600],["1970-01-01T04:00:00Z",3600],["1970-01-01T05:00:00Z",2480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(time) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(time) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(time) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",2048],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",1552],["1970-01-01T01:00:00Z",496],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",2048],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",1056],["1970-01-01T02:00:00Z",992],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",2048],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",560],["1970-01-01T03:00:00Z",1488],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",2048],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",64],["1970-01-01T04:00:00Z",1984],["1970-01-01T05:00:00Z",0]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",1616],["1970-01-01T05:00:00Z",432]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T01:00:00Z",0],["1970-01-01T02:00:00Z",0],["1970-01-01T03:00:00Z",0],["1970-01-01T04:00:00Z",0],["1970-01-01T05:00:00Z",2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",3600,3600,3600,3600],["1970-01-01T01:00:00Z",3600,3600,3600,3600],["1970-01-01T02:00:00Z",3600,3600,3600,3600],["1970-01-01T03:00:00Z",3600,3600,3600,3600],["1970-01-01T04:00:00Z",3600,3600,3600,3600],["1970-01-01T05:00:00Z",2480,2480,2480,2480]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select count(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,2048,2048],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",1552,1552,1552,1552],["1970-01-01T01:00:00Z",496,496,496,496],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",2048,2048,2048,2048],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",1056,1056,1056,1056],["1970-01-01T02:00:00Z",992,992,992,992],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",2048,2048,2048,2048],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",560,560,560,560],["1970-01-01T03:00:00Z",1488,1488,1488,1488],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",2048,2048,2048,2048],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",64,64,64,64],["1970-01-01T04:00:00Z",1984,1984,1984,1984],["1970-01-01T05:00:00Z",0,0,0,0]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",1616,1616,1616,1616],["1970-01-01T05:00:00Z",432,432,432,432]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","count_v1","count_v2","count_v3","count_v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,0],["1970-01-01T01:00:00Z",0,0,0,0],["1970-01-01T02:00:00Z",0,0,0,0],["1970-01-01T03:00:00Z",0,0,0,0],["1970-01-01T04:00:00Z",0,0,0,0],["1970-01-01T05:00:00Z",2048,2048,2048,2048]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "mean(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1799.5,1799.5],["1970-01-01T01:00:00Z",5399.5,5399.5],["1970-01-01T02:00:00Z",8999.5,8999.5],["1970-01-01T03:00:00Z",12599.5,12599.5],["1970-01-01T04:00:00Z",16199.5,16199.5],["1970-01-01T05:00:00Z",19239.5,19239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",3071.5,3071.5]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",5119.5,5119.5]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",7167.5,7167.5]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",9215.5,9215.5]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",11263.5,11263.5]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",13311.5,13311.5]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",15359.5,15359.5]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",17407.5,17407.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mean(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",2823.5,2823.5],["1970-01-01T01:00:00Z",3847.5,3847.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",5119.5,5119.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",6671.5,6671.5],["1970-01-01T02:00:00Z",7695.5,7695.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",9215.5,9215.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10519.5,10519.5],["1970-01-01T03:00:00Z",11543.5,11543.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",13311.5,13311.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14367.5,14367.5],["1970-01-01T04:00:00Z",15391.5,15391.5],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",17191.5,17191.5],["1970-01-01T05:00:00Z",18215.5,18215.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mean_v1","mean_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "sum(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",6478200,6478200],["1970-01-01T01:00:00Z",19438200,19438200],["1970-01-01T02:00:00Z",32398200,32398200],["1970-01-01T03:00:00Z",45358200,45358200],["1970-01-01T04:00:00Z",58318200,58318200],["1970-01-01T05:00:00Z",47713960,47713960]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",2096128,2096128]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",6290432,6290432]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",10484736,10484736]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",14679040,14679040]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",18873344,18873344]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",23067648,23067648]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",27261952,27261952]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",31456256,31456256]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",35650560,35650560]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",39844864,39844864]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",2096128,2096128],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",4382072,4382072],["1970-01-01T01:00:00Z",1908360,1908360],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",10484736,10484736],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",7045104,7045104],["1970-01-01T02:00:00Z",7633936,7633936],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",18873344,18873344],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",5890920,5890920],["1970-01-01T03:00:00Z",17176728,17176728],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",27261952,27261952],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",919520,919520],["1970-01-01T04:00:00Z",30536736,30536736],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",27781464,27781464],["1970-01-01T05:00:00Z",7869096,7869096]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","sum_v1","sum_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",39844864,39844864]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "min(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",0,0,false],["1970-01-01T01:00:00Z",3600,3600,false],["1970-01-01T02:00:00Z",7200,7200,false],["1970-01-01T03:00:00Z",10800,10800,false],["1970-01-01T04:00:00Z",14400,14400,false],["1970-01-01T05:00:00Z",18000,18000,false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",0,0,false]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",2048,2048,false]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",4096,4096,false]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",6144,6144,false]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",8192,8192,false]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",10240,10240,false]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",12288,12288,false]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",14336,14336,false]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",16384,16384,false]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",18432,18432,false]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "min(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",0,0,false],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",2048,2048,false],["1970-01-01T01:00:00Z",3600,3600,false],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",4096,4096,false],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",6144,6144,false],["1970-01-01T02:00:00Z",7200,7200,false],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",8192,8192,false],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",10240,10240,false],["1970-01-01T03:00:00Z",10800,10800,false],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",12288,12288,false],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",14336,14336,false],["1970-01-01T04:00:00Z",14400,14400,false],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",16384,16384,false],["1970-01-01T05:00:00Z",18000,18000,false]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min_v1","min_v2","min_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",18432,18432,false]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "max(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",3599,3599,true],["1970-01-01T01:00:00Z",7199,7199,true],["1970-01-01T02:00:00Z",10799,10799,true],["1970-01-01T03:00:00Z",14399,14399,true],["1970-01-01T04:00:00Z",17999,17999,true],["1970-01-01T05:00:00Z",20479,20479,true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",2047,2047,true]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",4095,4095,true]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",6143,6143,true]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",8191,8191,true]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",10239,10239,true]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",12287,12287,true]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",14335,14335,true]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",16383,16383,true]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",18431,18431,true]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",20479,20479,true]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "max(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",2047,2047,true],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",3599,3599,true],["1970-01-01T01:00:00Z",4095,4095,true],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",6143,6143,true],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",7199,7199,true],["1970-01-01T02:00:00Z",8191,8191,true],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",10239,10239,true],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",10799,10799,true],["1970-01-01T03:00:00Z",12287,12287,true],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",14335,14335,true],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",14399,14399,true],["1970-01-01T04:00:00Z",16383,16383,true],["1970-01-01T05:00:00Z",null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",17999,17999,true],["1970-01-01T05:00:00Z",18431,18431,true]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","max_v1","max_v2","max_v3"],"values":[["1970-01-01T00:00:00Z",null,null,null],["1970-01-01T01:00:00Z",null,null,null],["1970-01-01T02:00:00Z",null,null,null],["1970-01-01T03:00:00Z",null,null,null],["1970-01-01T04:00:00Z",null,null,null],["1970-01-01T05:00:00Z",20479,20479,true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",4096,4096,true,"abc4096"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",6144,6144,true,"abc6144"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",8192,8192,true,"abc8192"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",10240,10240,true,"abc10240"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",12288,12288,true,"abc12288"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",14336,14336,true,"abc14336"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",16384,16384,true,"abc16384"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select first(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",4096,4096,true,"abc4096"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",6144,6144,true,"abc6144"],["1970-01-01T02:00:00Z",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",8192,8192,true,"abc8192"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",10240,10240,true,"abc10240"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",12288,12288,true,"abc12288"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",14336,14336,true,"abc14336"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",16384,16384,true,"abc16384"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first_v1","first_v2","first_v3","first_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "last(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select last(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",2047,2047,false,"abc2047"],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",4095,4095,false,"abc4095"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",6143,6143,false,"abc6143"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",8191,8191,false,"abc8191"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",10239,10239,false,"abc10239"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",12287,12287,false,"abc12287"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",14335,14335,false,"abc14335"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",16383,16383,false,"abc16383"],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","last_v1","last_v2","last_v3","last_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select spread(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",3599,3599],["1970-01-01T01:00:00Z",3599,3599],["1970-01-01T02:00:00Z",3599,3599],["1970-01-01T03:00:00Z",3599,3599],["1970-01-01T04:00:00Z",3599,3599],["1970-01-01T05:00:00Z",2479,2479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select spread(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "spread(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select spread(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",2047,2047],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",1551,1551],["1970-01-01T01:00:00Z",495,495],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",2047,2047],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",1055,1055],["1970-01-01T02:00:00Z",991,991],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",2047,2047],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",559,559],["1970-01-01T03:00:00Z",1487,1487],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",2047,2047],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",63,63],["1970-01-01T04:00:00Z",1983,1983],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",1615,1615],["1970-01-01T05:00:00Z",431,431]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","spread_v1","spread_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",2047,2047]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(*, 10) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select percentile(*, 10) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",359,359],["1970-01-01T01:00:00Z",3959,3959],["1970-01-01T02:00:00Z",7559,7559],["1970-01-01T03:00:00Z",11159,11159],["1970-01-01T04:00:00Z",14759,14759],["1970-01-01T05:00:00Z",18247,18247]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(*, 50) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select percentile(*, 50) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",1023,1023]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",3071,3071]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",5119,5119]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",7167,7167]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",9215,9215]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",11263,11263]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",13311,13311]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",15359,15359]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",17407,17407]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",19455,19455]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(*, 90) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select percentile(*, 90) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",1842,1842],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",3444,3444],["1970-01-01T01:00:00Z",4045,4045],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",5938,5938],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",7093,7093],["1970-01-01T02:00:00Z",8092,8092],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10034,10034],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10743,10743],["1970-01-01T03:00:00Z",12138,12138],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14130,14130],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14393,14393],["1970-01-01T04:00:00Z",16185,16185],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",17837,17837],["1970-01-01T05:00:00Z",18388,18388]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",20274,20274]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "median(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select median(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",1799.5,1799.5],["1970-01-01T01:00:00Z",5399.5,5399.5],["1970-01-01T02:00:00Z",8999.5,8999.5],["1970-01-01T03:00:00Z",12599.5,12599.5],["1970-01-01T04:00:00Z",16199.5,16199.5],["1970-01-01T05:00:00Z",19239.5,19239.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "median(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select median(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",3071.5,3071.5]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",5119.5,5119.5]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",7167.5,7167.5]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",9215.5,9215.5]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",11263.5,11263.5]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",13311.5,13311.5]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",15359.5,15359.5]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",17407.5,17407.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "median(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select median(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",1023.5,1023.5],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",2823.5,2823.5],["1970-01-01T01:00:00Z",3847.5,3847.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",5119.5,5119.5],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",6671.5,6671.5],["1970-01-01T02:00:00Z",7695.5,7695.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",9215.5,9215.5],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",10519.5,10519.5],["1970-01-01T03:00:00Z",11543.5,11543.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",13311.5,13311.5],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",14367.5,14367.5],["1970-01-01T04:00:00Z",15391.5,15391.5],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",17191.5,17191.5],["1970-01-01T05:00:00Z",18215.5,18215.5]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","median_v1","median_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",19455.5,19455.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mode(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mode(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,7200,true,"abc10000"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mode(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mode(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",4096,4096,true,"abc4096"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",6144,6144,true,"abc6144"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",8192,8192,true,"abc10000"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",10240,10240,true,"abc10240"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",12288,12288,true,"abc12288"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",14336,14336,true,"abc14336"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",16384,16384,true,"abc16384"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mode(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select mode(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",0,0,true,"abc0"],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",2048,2048,true,"abc2048"],["1970-01-01T01:00:00Z",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",4096,4096,true,"abc4096"],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",6144,6144,true,"abc6144"],["1970-01-01T02:00:00Z",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",8192,8192,true,"abc10000"],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",10240,10240,true,"abc10240"],["1970-01-01T03:00:00Z",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",12288,12288,true,"abc12288"],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",14336,14336,true,"abc14336"],["1970-01-01T04:00:00Z",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",16384,16384,true,"abc16384"],["1970-01-01T05:00:00Z",18000,18000,true,"abc18000"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","mode_v1","mode_v2","mode_v3","mode_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "rate(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select rate(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",3600,3600],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",3600,3600],["1970-01-01T05:00:00Z",3600.0000000000005,3600.0000000000005]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "rate(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select rate(*) from db0.rp0.cpu group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "rate(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select rate(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h), *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",3600,3600],["1970-01-01T01:00:00Z",3599.9999999999995,3599.9999999999995],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",3599.9999999999995,3599.9999999999995],["1970-01-01T04:00:00Z",3600.0000000000005,3600.0000000000005],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",3600,3600],["1970-01-01T05:00:00Z",3600,3600]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","rate_v1","rate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",3600.0000000000005,3600.0000000000005]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "irate(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select irate(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",3600,3600],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",3600,3600],["1970-01-01T05:00:00Z",3600,3600]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "irate(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select irate(*) from db0.rp0.cpu group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "irate(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select irate(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h), *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",3600,3600],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",3600,3600],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",3600,3600],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",3600,3600],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",3600,3600],["1970-01-01T04:00:00Z",3600,3600],["1970-01-01T05:00:00Z",null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",3600,3600],["1970-01-01T05:00:00Z",3600,3600]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","irate_v1","irate_v2"],"values":[["1970-01-01T00:00:00Z",null,null],["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null],["1970-01-01T04:00:00Z",null,null],["1970-01-01T05:00:00Z",3600,3600]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "absent(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select absent(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1],["1970-01-01T01:00:00Z",1,1,1,1],["1970-01-01T02:00:00Z",1,1,1,1],["1970-01-01T03:00:00Z",1,1,1,1],["1970-01-01T04:00:00Z",1,1,1,1],["1970-01-01T05:00:00Z",1,1,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "absent(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select absent(*) from db0.rp0.cpu group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "absent(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"2"}},
 			command: `select absent(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h), *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",1,1,1,1],["1970-01-01T01:00:00Z",1,1,1,1],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",1,1,1,1],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",1,1,1,1],["1970-01-01T02:00:00Z",1,1,1,1],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",1,1,1,1],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",1,1,1,1],["1970-01-01T03:00:00Z",1,1,1,1],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",1,1,1,1],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",1,1,1,1],["1970-01-01T04:00:00Z",1,1,1,1],["1970-01-01T05:00:00Z",null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",1,1,1,1],["1970-01-01T05:00:00Z",1,1,1,1]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","absent_v1","absent_v2","absent_v3","absent_v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null],["1970-01-01T05:00:00Z",1,1,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",1039.3748120865737,1039.3748120865737],["1970-01-01T01:00:00Z",1039.3748120865741,1039.3748120865741],["1970-01-01T02:00:00Z",1039.374812086576,1039.374812086576],["1970-01-01T03:00:00Z",1039.3748120865687,1039.3748120865687],["1970-01-01T04:00:00Z",1039.3748120865687,1039.3748120865687],["1970-01-01T05:00:00Z",716.0586568152081,716.0586568152081]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
@@ -4900,19 +4897,19 @@ func TestServer_Query_Complex_Aggregate(t *testing.T) {
 		},
 		// 3. single column + aux + group by
 		// TODO: The order of tag aux of TSDB2.0 is different TSDB1.0.
-		&Query{
+		{
 			name:    "min(v1),* group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v1),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,"az_0","region_0",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,"az_1","region_1",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,"az_3","region_3",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",10800,"az_5","region_5",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,"az_7","region_7",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,"az_8","region_8",18000,18000,true,"abc18000"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v2),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v2),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,true,"abc0"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:08Z",2048,2048,2048,true,"abc2048"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:16Z",4096,4096,4096,true,"abc4096"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:24Z",6144,6144,6144,true,"abc6144"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:32Z",8192,8192,8192,true,"abc8192"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:40Z",10240,10240,10240,true,"abc10240"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:48Z",12288,12288,12288,true,"abc12288"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:56Z",14336,14336,14336,true,"abc14336"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:04Z",16384,16384,16384,true,"abc16384"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:12Z",18432,18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v3),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select min(v3),*  from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
@@ -4920,19 +4917,19 @@ func TestServer_Query_Complex_Aggregate(t *testing.T) {
 			skip:    true,
 		},
 
-		&Query{
+		{
 			name:    "max(v1),* group by time",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v1),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",3599,"az_1","region_1",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",7199,"az_3","region_3",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",10799,"az_5","region_5",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",14399,"az_7","region_7",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",17999,"az_8","region_8",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",20479,"az_9","region_9",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(v2),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v2),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:07Z",2047,2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:15Z",4095,4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:23Z",6143,6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:31Z",8191,8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:39Z",10239,10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:47Z",12287,12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:55Z",14335,14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:03Z",16383,16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:11Z",18431,18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","max","v1","v2","v3","v4"],"values":[["1970-01-01T05:41:19Z",20479,20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max(v3),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"1"}},
 			command: `select max(v3),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
@@ -4940,227 +4937,227 @@ func TestServer_Query_Complex_Aggregate(t *testing.T) {
 			skip:    true,
 		},
 
-		&Query{
+		{
 			name:    "first(v2),* group by time",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select first(v2),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,"az_0","region_0",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,"az_1","region_1",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,"az_3","region_3",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",10800,"az_5","region_5",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,"az_7","region_7",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,"az_8","region_8",18000,18000,true,"abc18000"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(v3),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select first(v3),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",true,0,0,true,"abc0"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:08Z",true,2048,2048,true,"abc2048"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:16Z",true,4096,4096,true,"abc4096"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:24Z",true,6144,6144,true,"abc6144"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:32Z",true,8192,8192,true,"abc8192"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:40Z",true,10240,10240,true,"abc10240"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:48Z",true,12288,12288,true,"abc12288"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:56Z",true,14336,14336,true,"abc14336"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:04Z",true,16384,16384,true,"abc16384"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:12Z",true,18432,18432,true,"abc18432"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first(v4),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select first(v4),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z","abc0",0,0,true,"abc0"],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z","abc2048",2048,2048,true,"abc2048"],["1970-01-01T01:00:00Z","abc3600",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z","abc4096",4096,4096,true,"abc4096"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z","abc6144",6144,6144,true,"abc6144"],["1970-01-01T02:00:00Z","abc7200",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z","abc8192",8192,8192,true,"abc8192"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z","abc10240",10240,10240,true,"abc10240"],["1970-01-01T03:00:00Z","abc10800",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z","abc12288",12288,12288,true,"abc12288"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z","abc14336",14336,14336,true,"abc14336"],["1970-01-01T04:00:00Z","abc14400",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z","abc16384",16384,16384,true,"abc16384"],["1970-01-01T05:00:00Z","abc18000",18000,18000,true,"abc18000"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","first","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z","abc18432",18432,18432,true,"abc18432"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "last(v2),* group by time",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select last(v2),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",3599,"az_1","region_1",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",7199,"az_3","region_3",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",10799,"az_5","region_5",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",14399,"az_7","region_7",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",17999,"az_8","region_8",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",20479,"az_9","region_9",20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(v3),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select last(v3),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:07Z",false,2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:15Z",false,4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:23Z",false,6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:31Z",false,8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:39Z",false,10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:47Z",false,12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:55Z",false,14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:03Z",false,16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:11Z",false,18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T05:41:19Z",false,20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last(v4),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select last(v4),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z","abc2047",2047,2047,false,"abc2047"],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z","abc3599",3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z","abc4095",4095,4095,false,"abc4095"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z","abc6143",6143,6143,false,"abc6143"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z","abc7199",7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z","abc8191",8191,8191,false,"abc8191"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z","abc10239",10239,10239,false,"abc10239"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z","abc10799",10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z","abc12287",12287,12287,false,"abc12287"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z","abc14335",14335,14335,false,"abc14335"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z","abc14399",14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z","abc16383",16383,16383,false,"abc16383"],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z","abc17999",17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z","abc18431",18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","last","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z","abc20479",20479,20479,false,"abc20479"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "percentile(v1, 0.01),* group by time",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select percentile(v1, 0.01),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","percentile","az","region","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,"az_0","region_0",0,0,true,"abc0"],["1970-01-01T01:00:00Z",3600,"az_1","region_1",3600,3600,true,"abc3600"],["1970-01-01T02:00:00Z",7200,"az_3","region_3",7200,7200,true,"abc7200"],["1970-01-01T03:00:00Z",10800,"az_5","region_5",10800,10800,true,"abc10800"],["1970-01-01T04:00:00Z",14400,"az_7","region_7",14400,14400,true,"abc14400"],["1970-01-01T05:00:00Z",18000,"az_8","region_8",18000,18000,true,"abc18000"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(v1, 50),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select percentile(v1, 50),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:17:03Z",1023,1023,1023,false,"abc1023"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:51:11Z",3071,3071,3071,false,"abc3071"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T01:25:19Z",5119,5119,5119,false,"abc5119"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T01:59:27Z",7167,7167,7167,false,"abc7167"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T02:33:35Z",9215,9215,9215,false,"abc9215"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T03:07:43Z",11263,11263,11263,false,"abc11263"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T03:41:51Z",13311,13311,13311,false,"abc13311"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T04:15:59Z",15359,15359,15359,false,"abc15359"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T04:50:07Z",17407,17407,17407,false,"abc17407"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T05:24:15Z",19455,19455,19455,false,"abc19455"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile(v2, 99.99),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select percentile(v2, 99.99),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",2047,2047,2047,false,"abc2047"],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",3599,3599,3599,false,"abc3599"],["1970-01-01T01:00:00Z",4095,4095,4095,false,"abc4095"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",6143,6143,6143,false,"abc6143"],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",7199,7199,7199,false,"abc7199"],["1970-01-01T02:00:00Z",8191,8191,8191,false,"abc8191"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",10239,10239,10239,false,"abc10239"],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",10799,10799,10799,false,"abc10799"],["1970-01-01T03:00:00Z",12287,12287,12287,false,"abc12287"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",14335,14335,14335,false,"abc14335"],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",14399,14399,14399,false,"abc14399"],["1970-01-01T04:00:00Z",16383,16383,16383,false,"abc16383"],["1970-01-01T05:00:00Z",null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",17999,17999,17999,false,"abc17999"],["1970-01-01T05:00:00Z",18431,18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","percentile","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,null,null],["1970-01-01T05:00:00Z",20479,20479,20479,false,"abc20479"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "top(v1, 3) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select top(v1, 3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["1970-01-01T00:59:57Z",3597],["1970-01-01T00:59:58Z",3598],["1970-01-01T00:59:59Z",3599],["1970-01-01T01:59:57Z",7197],["1970-01-01T01:59:58Z",7198],["1970-01-01T01:59:59Z",7199],["1970-01-01T02:59:57Z",10797],["1970-01-01T02:59:58Z",10798],["1970-01-01T02:59:59Z",10799],["1970-01-01T03:59:57Z",14397],["1970-01-01T03:59:58Z",14398],["1970-01-01T03:59:59Z",14399],["1970-01-01T04:59:57Z",17997],["1970-01-01T04:59:58Z",17998],["1970-01-01T04:59:59Z",17999],["1970-01-01T05:41:17Z",20477],["1970-01-01T05:41:18Z",20478],["1970-01-01T05:41:19Z",20479]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top(v2, 4),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select top(v2, 4),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:04Z",2044,2044,2044,true,"abc2044"],["1970-01-01T00:34:05Z",2045,2045,2045,false,"abc2045"],["1970-01-01T00:34:06Z",2046,2046,2046,true,"abc2046"],["1970-01-01T00:34:07Z",2047,2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:12Z",4092,4092,4092,true,"abc4092"],["1970-01-01T01:08:13Z",4093,4093,4093,false,"abc4093"],["1970-01-01T01:08:14Z",4094,4094,4094,true,"abc4094"],["1970-01-01T01:08:15Z",4095,4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:20Z",6140,6140,6140,true,"abc6140"],["1970-01-01T01:42:21Z",6141,6141,6141,false,"abc6141"],["1970-01-01T01:42:22Z",6142,6142,6142,true,"abc6142"],["1970-01-01T01:42:23Z",6143,6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:28Z",8188,8188,8188,true,"abc8188"],["1970-01-01T02:16:29Z",8189,8189,8189,false,"abc8189"],["1970-01-01T02:16:30Z",8190,8190,8190,true,"abc8190"],["1970-01-01T02:16:31Z",8191,8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:36Z",10236,10236,10236,true,"abc10236"],["1970-01-01T02:50:37Z",10237,10237,10237,false,"abc10237"],["1970-01-01T02:50:38Z",10238,10238,10238,true,"abc10238"],["1970-01-01T02:50:39Z",10239,10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:44Z",12284,12284,12284,true,"abc12284"],["1970-01-01T03:24:45Z",12285,12285,12285,false,"abc12285"],["1970-01-01T03:24:46Z",12286,12286,12286,true,"abc12286"],["1970-01-01T03:24:47Z",12287,12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:52Z",14332,14332,14332,true,"abc14332"],["1970-01-01T03:58:53Z",14333,14333,14333,false,"abc14333"],["1970-01-01T03:58:54Z",14334,14334,14334,true,"abc14334"],["1970-01-01T03:58:55Z",14335,14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:00Z",16380,16380,16380,true,"abc16380"],["1970-01-01T04:33:01Z",16381,16381,16381,false,"abc16381"],["1970-01-01T04:33:02Z",16382,16382,16382,true,"abc16382"],["1970-01-01T04:33:03Z",16383,16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:08Z",18428,18428,18428,true,"abc18428"],["1970-01-01T05:07:09Z",18429,18429,18429,false,"abc18429"],["1970-01-01T05:07:10Z",18430,18430,18430,true,"abc18430"],["1970-01-01T05:07:11Z",18431,18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T05:41:16Z",20476,20476,20476,true,"abc20476"],["1970-01-01T05:41:17Z",20477,20477,20477,false,"abc20477"],["1970-01-01T05:41:18Z",20478,20478,20478,true,"abc20478"],["1970-01-01T05:41:19Z",20479,20479,20479,false,"abc20479"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top(v2, 5),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select top(v2, 5),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:03Z",2043,2043,2043,false,"abc2043"],["1970-01-01T00:34:04Z",2044,2044,2044,true,"abc2044"],["1970-01-01T00:34:05Z",2045,2045,2045,false,"abc2045"],["1970-01-01T00:34:06Z",2046,2046,2046,true,"abc2046"],["1970-01-01T00:34:07Z",2047,2047,2047,false,"abc2047"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T00:59:55Z",3595,3595,3595,false,"abc3595"],["1970-01-01T00:59:56Z",3596,3596,3596,true,"abc3596"],["1970-01-01T00:59:57Z",3597,3597,3597,false,"abc3597"],["1970-01-01T00:59:58Z",3598,3598,3598,true,"abc3598"],["1970-01-01T00:59:59Z",3599,3599,3599,false,"abc3599"],["1970-01-01T01:08:11Z",4091,4091,4091,false,"abc4091"],["1970-01-01T01:08:12Z",4092,4092,4092,true,"abc4092"],["1970-01-01T01:08:13Z",4093,4093,4093,false,"abc4093"],["1970-01-01T01:08:14Z",4094,4094,4094,true,"abc4094"],["1970-01-01T01:08:15Z",4095,4095,4095,false,"abc4095"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:19Z",6139,6139,6139,false,"abc6139"],["1970-01-01T01:42:20Z",6140,6140,6140,true,"abc6140"],["1970-01-01T01:42:21Z",6141,6141,6141,false,"abc6141"],["1970-01-01T01:42:22Z",6142,6142,6142,true,"abc6142"],["1970-01-01T01:42:23Z",6143,6143,6143,false,"abc6143"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T01:59:55Z",7195,7195,7195,false,"abc7195"],["1970-01-01T01:59:56Z",7196,7196,7196,true,"abc7196"],["1970-01-01T01:59:57Z",7197,7197,7197,false,"abc7197"],["1970-01-01T01:59:58Z",7198,7198,7198,true,"abc7198"],["1970-01-01T01:59:59Z",7199,7199,7199,false,"abc7199"],["1970-01-01T02:16:27Z",8187,8187,8187,false,"abc8187"],["1970-01-01T02:16:28Z",8188,8188,8188,true,"abc8188"],["1970-01-01T02:16:29Z",8189,8189,8189,false,"abc8189"],["1970-01-01T02:16:30Z",8190,8190,8190,true,"abc8190"],["1970-01-01T02:16:31Z",8191,8191,8191,false,"abc8191"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:35Z",10235,10235,10235,false,"abc10235"],["1970-01-01T02:50:36Z",10236,10236,10236,true,"abc10236"],["1970-01-01T02:50:37Z",10237,10237,10237,false,"abc10237"],["1970-01-01T02:50:38Z",10238,10238,10238,true,"abc10238"],["1970-01-01T02:50:39Z",10239,10239,10239,false,"abc10239"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T02:59:55Z",10795,10795,10795,false,"abc10795"],["1970-01-01T02:59:56Z",10796,10796,10796,true,"abc10796"],["1970-01-01T02:59:57Z",10797,10797,10797,false,"abc10797"],["1970-01-01T02:59:58Z",10798,10798,10798,true,"abc10798"],["1970-01-01T02:59:59Z",10799,10799,10799,false,"abc10799"],["1970-01-01T03:24:43Z",12283,12283,12283,false,"abc12283"],["1970-01-01T03:24:44Z",12284,12284,12284,true,"abc12284"],["1970-01-01T03:24:45Z",12285,12285,12285,false,"abc12285"],["1970-01-01T03:24:46Z",12286,12286,12286,true,"abc12286"],["1970-01-01T03:24:47Z",12287,12287,12287,false,"abc12287"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:51Z",14331,14331,14331,false,"abc14331"],["1970-01-01T03:58:52Z",14332,14332,14332,true,"abc14332"],["1970-01-01T03:58:53Z",14333,14333,14333,false,"abc14333"],["1970-01-01T03:58:54Z",14334,14334,14334,true,"abc14334"],["1970-01-01T03:58:55Z",14335,14335,14335,false,"abc14335"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T03:59:55Z",14395,14395,14395,false,"abc14395"],["1970-01-01T03:59:56Z",14396,14396,14396,true,"abc14396"],["1970-01-01T03:59:57Z",14397,14397,14397,false,"abc14397"],["1970-01-01T03:59:58Z",14398,14398,14398,true,"abc14398"],["1970-01-01T03:59:59Z",14399,14399,14399,false,"abc14399"],["1970-01-01T04:32:59Z",16379,16379,16379,false,"abc16379"],["1970-01-01T04:33:00Z",16380,16380,16380,true,"abc16380"],["1970-01-01T04:33:01Z",16381,16381,16381,false,"abc16381"],["1970-01-01T04:33:02Z",16382,16382,16382,true,"abc16382"],["1970-01-01T04:33:03Z",16383,16383,16383,false,"abc16383"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T04:59:55Z",17995,17995,17995,false,"abc17995"],["1970-01-01T04:59:56Z",17996,17996,17996,true,"abc17996"],["1970-01-01T04:59:57Z",17997,17997,17997,false,"abc17997"],["1970-01-01T04:59:58Z",17998,17998,17998,true,"abc17998"],["1970-01-01T04:59:59Z",17999,17999,17999,false,"abc17999"],["1970-01-01T05:07:07Z",18427,18427,18427,false,"abc18427"],["1970-01-01T05:07:08Z",18428,18428,18428,true,"abc18428"],["1970-01-01T05:07:09Z",18429,18429,18429,false,"abc18429"],["1970-01-01T05:07:10Z",18430,18430,18430,true,"abc18430"],["1970-01-01T05:07:11Z",18431,18431,18431,false,"abc18431"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","top","v1","v2","v3","v4"],"values":[["1970-01-01T05:41:15Z",20475,20475,20475,false,"abc20475"],["1970-01-01T05:41:16Z",20476,20476,20476,true,"abc20476"],["1970-01-01T05:41:17Z",20477,20477,20477,false,"abc20477"],["1970-01-01T05:41:18Z",20478,20478,20478,true,"abc20478"],["1970-01-01T05:41:19Z",20479,20479,20479,false,"abc20479"]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "bottom(v1, 3) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select bottom(v1, 3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["1970-01-01T00:00:00Z",0],["1970-01-01T00:00:01Z",1],["1970-01-01T00:00:02Z",2],["1970-01-01T01:00:00Z",3600],["1970-01-01T01:00:01Z",3601],["1970-01-01T01:00:02Z",3602],["1970-01-01T02:00:00Z",7200],["1970-01-01T02:00:01Z",7201],["1970-01-01T02:00:02Z",7202],["1970-01-01T03:00:00Z",10800],["1970-01-01T03:00:01Z",10801],["1970-01-01T03:00:02Z",10802],["1970-01-01T04:00:00Z",14400],["1970-01-01T04:00:01Z",14401],["1970-01-01T04:00:02Z",14402],["1970-01-01T05:00:00Z",18000],["1970-01-01T05:00:01Z",18001],["1970-01-01T05:00:02Z",18002]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom(v2, 4),* group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select bottom(v2, 4),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,true,"abc0"],["1970-01-01T00:00:01Z",1,1,1,false,"abc1"],["1970-01-01T00:00:02Z",2,2,2,true,"abc2"],["1970-01-01T00:00:03Z",3,3,3,false,"abc3"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:08Z",2048,2048,2048,true,"abc2048"],["1970-01-01T00:34:09Z",2049,2049,2049,false,"abc2049"],["1970-01-01T00:34:10Z",2050,2050,2050,true,"abc2050"],["1970-01-01T00:34:11Z",2051,2051,2051,false,"abc2051"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:16Z",4096,4096,4096,true,"abc4096"],["1970-01-01T01:08:17Z",4097,4097,4097,false,"abc4097"],["1970-01-01T01:08:18Z",4098,4098,4098,true,"abc4098"],["1970-01-01T01:08:19Z",4099,4099,4099,false,"abc4099"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:24Z",6144,6144,6144,true,"abc6144"],["1970-01-01T01:42:25Z",6145,6145,6145,false,"abc6145"],["1970-01-01T01:42:26Z",6146,6146,6146,true,"abc6146"],["1970-01-01T01:42:27Z",6147,6147,6147,false,"abc6147"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:32Z",8192,8192,8192,true,"abc8192"],["1970-01-01T02:16:33Z",8193,8193,8193,false,"abc8193"],["1970-01-01T02:16:34Z",8194,8194,8194,true,"abc8194"],["1970-01-01T02:16:35Z",8195,8195,8195,false,"abc8195"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:40Z",10240,10240,10240,true,"abc10240"],["1970-01-01T02:50:41Z",10241,10241,10241,false,"abc10241"],["1970-01-01T02:50:42Z",10242,10242,10242,true,"abc10242"],["1970-01-01T02:50:43Z",10243,10243,10243,false,"abc10243"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:48Z",12288,12288,12288,true,"abc12288"],["1970-01-01T03:24:49Z",12289,12289,12289,false,"abc12289"],["1970-01-01T03:24:50Z",12290,12290,12290,true,"abc12290"],["1970-01-01T03:24:51Z",12291,12291,12291,false,"abc12291"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:56Z",14336,14336,14336,true,"abc14336"],["1970-01-01T03:58:57Z",14337,14337,14337,false,"abc14337"],["1970-01-01T03:58:58Z",14338,14338,14338,true,"abc14338"],["1970-01-01T03:58:59Z",14339,14339,14339,false,"abc14339"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:04Z",16384,16384,16384,true,"abc16384"],["1970-01-01T04:33:05Z",16385,16385,16385,false,"abc16385"],["1970-01-01T04:33:06Z",16386,16386,16386,true,"abc16386"],["1970-01-01T04:33:07Z",16387,16387,16387,false,"abc16387"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:12Z",18432,18432,18432,true,"abc18432"],["1970-01-01T05:07:13Z",18433,18433,18433,false,"abc18433"],["1970-01-01T05:07:14Z",18434,18434,18434,true,"abc18434"],["1970-01-01T05:07:15Z",18435,18435,18435,false,"abc18435"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom(v2, 5),* group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select bottom(v2, 5),* from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T00:00:00Z",0,0,0,true,"abc0"],["1970-01-01T00:00:01Z",1,1,1,false,"abc1"],["1970-01-01T00:00:02Z",2,2,2,true,"abc2"],["1970-01-01T00:00:03Z",3,3,3,false,"abc3"],["1970-01-01T00:00:04Z",4,4,4,true,"abc4"]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T00:34:08Z",2048,2048,2048,true,"abc2048"],["1970-01-01T00:34:09Z",2049,2049,2049,false,"abc2049"],["1970-01-01T00:34:10Z",2050,2050,2050,true,"abc2050"],["1970-01-01T00:34:11Z",2051,2051,2051,false,"abc2051"],["1970-01-01T00:34:12Z",2052,2052,2052,true,"abc2052"],["1970-01-01T01:00:00Z",3600,3600,3600,true,"abc3600"],["1970-01-01T01:00:01Z",3601,3601,3601,false,"abc3601"],["1970-01-01T01:00:02Z",3602,3602,3602,true,"abc3602"],["1970-01-01T01:00:03Z",3603,3603,3603,false,"abc3603"],["1970-01-01T01:00:04Z",3604,3604,3604,true,"abc3604"]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T01:08:16Z",4096,4096,4096,true,"abc4096"],["1970-01-01T01:08:17Z",4097,4097,4097,false,"abc4097"],["1970-01-01T01:08:18Z",4098,4098,4098,true,"abc4098"],["1970-01-01T01:08:19Z",4099,4099,4099,false,"abc4099"],["1970-01-01T01:08:20Z",4100,4100,4100,true,"abc4100"]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T01:42:24Z",6144,6144,6144,true,"abc6144"],["1970-01-01T01:42:25Z",6145,6145,6145,false,"abc6145"],["1970-01-01T01:42:26Z",6146,6146,6146,true,"abc6146"],["1970-01-01T01:42:27Z",6147,6147,6147,false,"abc6147"],["1970-01-01T01:42:28Z",6148,6148,6148,true,"abc6148"],["1970-01-01T02:00:00Z",7200,7200,7200,true,"abc7200"],["1970-01-01T02:00:01Z",7201,7201,7201,false,"abc7201"],["1970-01-01T02:00:02Z",7202,7202,7202,true,"abc7202"],["1970-01-01T02:00:03Z",7203,7203,7203,false,"abc7203"],["1970-01-01T02:00:04Z",7204,7204,7204,true,"abc7204"]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T02:16:32Z",8192,8192,8192,true,"abc8192"],["1970-01-01T02:16:33Z",8193,8193,8193,false,"abc8193"],["1970-01-01T02:16:34Z",8194,8194,8194,true,"abc8194"],["1970-01-01T02:16:35Z",8195,8195,8195,false,"abc8195"],["1970-01-01T02:16:36Z",8196,8196,8196,true,"abc8196"]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T02:50:40Z",10240,10240,10240,true,"abc10240"],["1970-01-01T02:50:41Z",10241,10241,10241,false,"abc10241"],["1970-01-01T02:50:42Z",10242,10242,10242,true,"abc10242"],["1970-01-01T02:50:43Z",10243,10243,10243,false,"abc10243"],["1970-01-01T02:50:44Z",10244,10244,10244,true,"abc10244"],["1970-01-01T03:00:00Z",10800,10800,10800,true,"abc10800"],["1970-01-01T03:00:01Z",10801,10801,10801,false,"abc10801"],["1970-01-01T03:00:02Z",10802,10802,10802,true,"abc10802"],["1970-01-01T03:00:03Z",10803,10803,10803,false,"abc10803"],["1970-01-01T03:00:04Z",10804,10804,10804,true,"abc10804"]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T03:24:48Z",12288,12288,12288,true,"abc12288"],["1970-01-01T03:24:49Z",12289,12289,12289,false,"abc12289"],["1970-01-01T03:24:50Z",12290,12290,12290,true,"abc12290"],["1970-01-01T03:24:51Z",12291,12291,12291,false,"abc12291"],["1970-01-01T03:24:52Z",12292,12292,12292,true,"abc12292"]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T03:58:56Z",14336,14336,14336,true,"abc14336"],["1970-01-01T03:58:57Z",14337,14337,14337,false,"abc14337"],["1970-01-01T03:58:58Z",14338,14338,14338,true,"abc14338"],["1970-01-01T03:58:59Z",14339,14339,14339,false,"abc14339"],["1970-01-01T03:59:00Z",14340,14340,14340,true,"abc14340"],["1970-01-01T04:00:00Z",14400,14400,14400,true,"abc14400"],["1970-01-01T04:00:01Z",14401,14401,14401,false,"abc14401"],["1970-01-01T04:00:02Z",14402,14402,14402,true,"abc14402"],["1970-01-01T04:00:03Z",14403,14403,14403,false,"abc14403"],["1970-01-01T04:00:04Z",14404,14404,14404,true,"abc14404"]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T04:33:04Z",16384,16384,16384,true,"abc16384"],["1970-01-01T04:33:05Z",16385,16385,16385,false,"abc16385"],["1970-01-01T04:33:06Z",16386,16386,16386,true,"abc16386"],["1970-01-01T04:33:07Z",16387,16387,16387,false,"abc16387"],["1970-01-01T04:33:08Z",16388,16388,16388,true,"abc16388"],["1970-01-01T05:00:00Z",18000,18000,18000,true,"abc18000"],["1970-01-01T05:00:01Z",18001,18001,18001,false,"abc18001"],["1970-01-01T05:00:02Z",18002,18002,18002,true,"abc18002"],["1970-01-01T05:00:03Z",18003,18003,18003,false,"abc18003"],["1970-01-01T05:00:04Z",18004,18004,18004,true,"abc18004"]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","bottom","v1","v2","v3","v4"],"values":[["1970-01-01T05:07:12Z",18432,18432,18432,true,"abc18432"],["1970-01-01T05:07:13Z",18433,18433,18433,false,"abc18433"],["1970-01-01T05:07:14Z",18434,18434,18434,true,"abc18434"],["1970-01-01T05:07:15Z",18435,18435,18435,false,"abc18435"],["1970-01-01T05:07:16Z",18436,18436,18436,true,"abc18436"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "distinct(v3)",
 			command: `select distinct(v3) from db0.rp0.cpu`,
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "distinct(v3) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select distinct(v3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "distinct(v3) group by time, *",
 			params:  url.Values{"inner_chunk_size": []string{"10"}},
 			command: `select distinct(v3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","distinct"],"values":[["1970-01-01T00:00:00Z",true],["1970-01-01T00:00:00Z",false],["1970-01-01T01:00:00Z",true],["1970-01-01T01:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","distinct"],"values":[["1970-01-01T01:00:00Z",true],["1970-01-01T01:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","distinct"],"values":[["1970-01-01T01:00:00Z",true],["1970-01-01T01:00:00Z",false],["1970-01-01T02:00:00Z",true],["1970-01-01T02:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","distinct"],"values":[["1970-01-01T02:00:00Z",true],["1970-01-01T02:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","distinct"],"values":[["1970-01-01T02:00:00Z",true],["1970-01-01T02:00:00Z",false],["1970-01-01T03:00:00Z",true],["1970-01-01T03:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","distinct"],"values":[["1970-01-01T03:00:00Z",true],["1970-01-01T03:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","distinct"],"values":[["1970-01-01T03:00:00Z",true],["1970-01-01T03:00:00Z",false],["1970-01-01T04:00:00Z",true],["1970-01-01T04:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","distinct"],"values":[["1970-01-01T04:00:00Z",true],["1970-01-01T04:00:00Z",false],["1970-01-01T05:00:00Z",true],["1970-01-01T05:00:00Z",false]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","distinct"],"values":[["1970-01-01T05:00:00Z",true],["1970-01-01T05:00:00Z",false]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,4095,6290432,2048,3071.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",4096,6143,10484736,2048,5119.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",6144,8191,14679040,2048,7167.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",8192,10239,18873344,2048,9215.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",10240,12287,23067648,2048,11263.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",12288,14335,27261952,2048,13311.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",14336,16383,31456256,2048,15359.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",16384,18431,35650560,2048,17407.5,2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",18432,20479,39844864,2048,19455.5,2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,3599,6478200,3600,1799.5,3599,1039.3748120865737],["1970-01-01T01:00:00Z",3600,7199,19438200,3600,5399.5,3599,1039.3748120865741],["1970-01-01T02:00:00Z",7200,10799,32398200,3600,8999.5,3599,1039.374812086576],["1970-01-01T03:00:00Z",10800,14399,45358200,3600,12599.5,3599,1039.3748120865687],["1970-01-01T04:00:00Z",14400,17999,58318200,3600,16199.5,3599,1039.3748120865687],["1970-01-01T05:00:00Z",18000,20479,47713960,2480,19239.5,2479,716.0586568152081]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) group by time,*",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),spread(v2),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,2047,591.3509956024425],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,3599,4382072,1552,2823.5,1551,448.16812321568193],["1970-01-01T01:00:00Z",3600,4095,1908360,496,3847.5,495,143.32713164877984],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",4096,6143,10484736,2048,5119.5,2047,591.3509956024425],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",6144,7199,7045104,1056,6671.5,1055,304.98524554475995],["1970-01-01T02:00:00Z",7200,8191,7633936,992,7695.5,991,286.5100347282796],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",8192,10239,18873344,2048,9215.5,2047,591.3509956024425],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",10240,10799,5890920,560,10519.5,559,161.80234856144702],["1970-01-01T03:00:00Z",10800,12287,17176728,1488,11543.5,1487,429.69291360226663],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",12288,14335,27261952,2048,13311.5,2047,591.3509956024425],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",14336,14399,919520,64,14367.5,63,18.618986725025255],["1970-01-01T04:00:00Z",14400,16383,30536736,1984,15391.5,1983,572.8757864202909],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",16384,17999,27781464,1616,17191.5,1615,466.64333274997085],["1970-01-01T05:00:00Z",18000,18431,7869096,432,18215.5,431,124.85191228018863]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","max","sum","count","mean","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null],["1970-01-01T05:00:00Z",18432,20479,39844864,2048,19455.5,2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by *",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,true,"abc2047",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,4095,6290432,2048,3071.5,true,"abc4095",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",4096,6143,10484736,2048,5119.5,true,"abc6143",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",6144,8191,14679040,2048,7167.5,true,"abc8191",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",8192,10239,18873344,2048,9215.5,true,"abc10239",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",10240,12287,23067648,2048,11263.5,true,"abc12287",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",12288,14335,27261952,2048,13311.5,true,"abc14335",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",14336,16383,31456256,2048,15359.5,true,"abc16383",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",16384,18431,35650560,2048,17407.5,true,"abc18431",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",18432,20479,39844864,2048,19455.5,true,"abc20479",2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,3599,6478200,3600,1799.5,true,"abc3599",3599,1039.3748120865737],["1970-01-01T01:00:00Z",3600,7199,19438200,3600,5399.5,true,"abc7199",3599,1039.3748120865741],["1970-01-01T02:00:00Z",7200,10799,32398200,3600,8999.5,true,"abc10799",3599,1039.374812086576],["1970-01-01T03:00:00Z",10800,14399,45358200,3600,12599.5,true,"abc14399",3599,1039.3748120865687],["1970-01-01T04:00:00Z",14400,17999,58318200,3600,16199.5,true,"abc17999",3599,1039.3748120865687],["1970-01-01T05:00:00Z",18000,20479,47713960,2480,19239.5,true,"abc20479",2479,716.0586568152081]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time,*",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),*`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,true,"abc2047",2047,591.3509956024425],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,3599,4382072,1552,2823.5,true,"abc3599",1551,448.16812321568193],["1970-01-01T01:00:00Z",3600,4095,1908360,496,3847.5,true,"abc4095",495,143.32713164877984],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",4096,6143,10484736,2048,5119.5,true,"abc6143",2047,591.3509956024425],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",6144,7199,7045104,1056,6671.5,true,"abc7199",1055,304.98524554475995],["1970-01-01T02:00:00Z",7200,8191,7633936,992,7695.5,true,"abc8191",991,286.5100347282796],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",8192,10239,18873344,2048,9215.5,true,"abc10239",2047,591.3509956024425],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",10240,10799,5890920,560,10519.5,true,"abc10799",559,161.80234856144702],["1970-01-01T03:00:00Z",10800,12287,17176728,1488,11543.5,true,"abc12287",1487,429.69291360226663],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_6","region":"region_6"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",12288,14335,27261952,2048,13311.5,true,"abc14335",2047,591.3509956024425],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_7","region":"region_7"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",14336,14399,919520,64,14367.5,true,"abc14399",63,18.618986725025255],["1970-01-01T04:00:00Z",14400,16383,30536736,1984,15391.5,true,"abc16383",1983,572.8757864202909],["1970-01-01T05:00:00Z",null,null,null,0,null,null,null,null,null]]},{"name":"cpu","tags":{"az":"az_8","region":"region_8"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",16384,17999,27781464,1616,17191.5,true,"abc17999",1615,466.64333274997085],["1970-01-01T05:00:00Z",18000,18431,7869096,432,18215.5,true,"abc18431",431,124.85191228018863]]},{"name":"cpu","tags":{"az":"az_9","region":"region_9"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T04:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T05:00:00Z",18432,20479,39844864,2048,19455.5,true,"abc20479",2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by * limit 3",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,true,"abc2047",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,4095,6290432,2048,3071.5,true,"abc4095",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",4096,6143,10484736,2048,5119.5,true,"abc6143",2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time limit 3",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) limit 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,3599,6478200,3600,1799.5,true,"abc3599",3599,1039.3748120865737],["1970-01-01T01:00:00Z",3600,7199,19438200,3600,5399.5,true,"abc7199",3599,1039.3748120865741],["1970-01-01T02:00:00Z",7200,10799,32398200,3600,8999.5,true,"abc10799",3599,1039.374812086576]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time,* limit 3",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* limit 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",0,2047,2096128,2048,1023.5,true,"abc2047",2047,591.3509956024425],["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by * limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",2048,4095,6290432,2048,3071.5,true,"abc4095",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",4096,6143,10484736,2048,5119.5,true,"abc6143",2047,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T00:00:00Z",6144,8191,14679040,2048,7167.5,true,"abc8191",2047,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T01:00:00Z",3600,7199,19438200,3600,5399.5,true,"abc7199",3599,1039.3748120865741],["1970-01-01T02:00:00Z",7200,10799,32398200,3600,8999.5,true,"abc10799",3599,1039.374812086576],["1970-01-01T03:00:00Z",10800,14399,45358200,3600,12599.5,true,"abc14399",3599,1039.3748120865687]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) group by time,* limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select min(v1),max(v2),sum(v1),count(v2),mean(v1),first(v3),last(v4),spread(v1),stddev(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","min","max","sum","count","mean","first","last","spread","stddev"],"values":[["1970-01-01T01:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T02:00:00Z",null,null,null,0,null,null,null,null,null],["1970-01-01T03:00:00Z",null,null,null,0,null,null,null,null,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by * limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T00:00:00Z",591.3509956024425,591.3509956024425]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by time limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h) limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T01:00:00Z",1039.3748120865741,1039.3748120865741],["1970-01-01T02:00:00Z",1039.374812086576,1039.374812086576],["1970-01-01T03:00:00Z",1039.3748120865687,1039.3748120865687]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev(*) group by time,* limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select stddev(*) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by time(1h),* limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","stddev_v1","stddev_v2"],"values":[["1970-01-01T01:00:00Z",null,null],["1970-01-01T02:00:00Z",null,null],["1970-01-01T03:00:00Z",null,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile group by time,* limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select percentile(v1, 50) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile"],"values":[["1970-01-01T00:51:11Z",3071]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile"],"values":[["1970-01-01T01:25:19Z",5119]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile"],"values":[["1970-01-01T01:59:27Z",7167]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top group by time,* limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select top(v1, 3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","top"],"values":[["1970-01-01T01:08:13Z",4093],["1970-01-01T01:08:14Z",4094],["1970-01-01T01:08:15Z",4095]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","top"],"values":[["1970-01-01T01:42:21Z",6141],["1970-01-01T01:42:22Z",6142],["1970-01-01T01:42:23Z",6143]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","top"],"values":[["1970-01-01T02:16:29Z",8189],["1970-01-01T02:16:30Z",8190],["1970-01-01T02:16:31Z",8191]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom group by time,* limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select bottom(v1, 3) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","bottom"],"values":[["1970-01-01T00:34:08Z",2048],["1970-01-01T00:34:09Z",2049],["1970-01-01T00:34:10Z",2050]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","bottom"],"values":[["1970-01-01T01:08:16Z",4096],["1970-01-01T01:08:17Z",4097],["1970-01-01T01:08:18Z",4098]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","bottom"],"values":[["1970-01-01T01:42:24Z",6144],["1970-01-01T01:42:25Z",6145],["1970-01-01T01:42:26Z",6146]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "difference group by * limit 3 offset 1",
 			params:  url.Values{"inner_chunk_size": []string{"5"}},
 			command: `select difference(v1) from db0.rp0.cpu where time >= '1970-01-01T00:00:00Z' AND time <= '1970-01-01T05:41:19Z' group by * limit 3 offset 1`,
@@ -5240,25 +5237,25 @@ func TestServer_Query_Null_Group(t *testing.T) {
 		&Write{data: strings.Join(writes, "\n")},
 	}
 	test.addQueries([]*Query{
-		&Query{ //BUG:BUG2022060902489
+		{ //BUG:BUG2022060902489
 			name:    "percentile with group by * : innerChunkSize=1",
 			params:  url.Values{"db": []string{"db0"}, "inner_chunk_size": []string{"1"}},
 			command: `SELECT percentile(*,95) FROM cpu group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",1945,1945]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",3993,3993]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,6041]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",8089,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",10137,10137]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",12185,12185]]}]}]}`,
 		},
-		&Query{ //BUG:BUG2022060902489
+		{ //BUG:BUG2022060902489
 			name:    "percentile with group by * : innerChunkSize=1024",
 			params:  url.Values{"db": []string{"db0"}, "inner_chunk_size": []string{"1024"}},
 			command: `SELECT percentile(*,95) FROM cpu group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"az":"az_0","region":"region_0"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",1945,1945]]},{"name":"cpu","tags":{"az":"az_1","region":"region_1"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",3993,3993]]},{"name":"cpu","tags":{"az":"az_2","region":"region_2"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",null,6041]]},{"name":"cpu","tags":{"az":"az_3","region":"region_3"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",8089,null]]},{"name":"cpu","tags":{"az":"az_4","region":"region_4"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",10137,10137]]},{"name":"cpu","tags":{"az":"az_5","region":"region_5"},"columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",12185,12185]]}]}]}`,
 		},
-		&Query{ //BUG:BUG2022060902489
+		{ //BUG:BUG2022060902489
 			name:    "percentile : innerChunkSize=1",
 			params:  url.Values{"db": []string{"db0"}, "inner_chunk_size": []string{"1"}},
 			command: `SELECT percentile(*,95) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","percentile_v1","percentile_v2"],"values":[["1970-01-01T00:00:00Z",11775,11775]]}]}]}`,
 		},
-		&Query{ //BUG:BUG2022060902489
+		{ //BUG:BUG2022060902489
 			name:    "percentile : innerChunkSize=1024",
 			params:  url.Values{"db": []string{"db0"}, "inner_chunk_size": []string{"1024"}},
 			command: `SELECT percentile(*,95) FROM cpu`,
@@ -5311,19 +5308,19 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "baseline",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM network`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","core","cores","host","region","rx","tx"],"values":[["2000-01-01T00:00:00Z",2,"1","server01","west",10,20],["2000-01-01T00:00:10Z",3,"2","server02","west",40,50],["2000-01-01T00:00:20Z",4,"3","server03","east",40,55],["2000-01-01T00:00:30Z",1,"4","server04","east",40,60],["2000-01-01T00:00:40Z",2,"1","server05","west",50,70],["2000-01-01T00:00:50Z",3,"2","server06","east",50,40],["2000-01-01T00:01:00Z",4,"3","server07","west",70,30],["2000-01-01T00:01:10Z",1,"4","server08","east",90,10],["2000-01-01T00:01:20Z",2,"1","server09","east",5,4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",90]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max - baseline 30s - epoch ms",
 			params:  url.Values{"db": []string{"db0"}, "epoch": []string{"ms"}},
 			command: `SELECT max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
@@ -5334,257 +5331,257 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 				mustParseTime(time.RFC3339Nano, "2000-01-01T00:01:00Z").UnixNano()/int64(time.Millisecond),
 			),
 		},
-		&Query{
+		{
 			name:    "max - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","max"],"values":[["2000-01-01T00:00:00Z",50,40],["2000-01-01T00:00:30Z",70,50],["2000-01-01T00:01:00Z",10,90]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",90]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, max(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","max"],"values":[["2000-01-01T00:00:00Z",50,40],["2000-01-01T00:00:30Z",70,50],["2000-01-01T00:01:00Z",10,90]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","min"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","min"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max,min - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(rx), min(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","max","min"],"values":[["2000-01-01T00:00:00Z",40,10],["2000-01-01T00:00:30Z",50,40],["2000-01-01T00:01:00Z",90,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:00Z",70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, first(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","first"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:00Z",30,70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, first(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:30Z",40],["2000-01-01T00:01:00Z",70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, first(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","first"],"values":[["2000-01-01T00:00:00Z",20,10],["2000-01-01T00:00:30Z",60,40],["2000-01-01T00:01:00Z",30,70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","last"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","last"],"values":[["2000-01-01T00:00:00Z",55,40],["2000-01-01T00:00:30Z",40,50],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","last"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - time and tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, tx, last(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","tx","last"],"values":[["2000-01-01T00:00:00Z",55,40],["2000-01-01T00:00:30Z",40,50],["2000-01-01T00:01:00Z",4,5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT count(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","count"],"values":[["2000-01-01T00:00:00Z",3],["2000-01-01T00:00:30Z",3],["2000-01-01T00:01:00Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, count(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","count"],"values":[["2000-01-01T00:00:00Z",3],["2000-01-01T00:00:30Z",3],["2000-01-01T00:01:00Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, count(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 		},
-		&Query{
+		{
 			name:    "distinct - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT distinct(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","distinct"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70],["2000-01-01T00:01:00Z",90],["2000-01-01T00:01:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, distinct(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","distinct"],"values":[["2000-01-01T00:00:00Z",10],["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70],["2000-01-01T00:01:00Z",90],["2000-01-01T00:01:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "distinct - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, distinct(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"aggregate function distinct() cannot be combined with other functions or fields"}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mean - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",30],["2000-01-01T00:00:30Z",46.666666666666664],["2000-01-01T00:01:00Z",55]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, mean(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",30],["2000-01-01T00:00:30Z",46.666666666666664],["2000-01-01T00:01:00Z",55]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, mean(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 		},
-		&Query{
+		{
 			name:    "median - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT median(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","median"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, median(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","median"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "median - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, median(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mode(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","mode"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, mode(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","mode"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "mode - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, mode(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "spread - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT spread(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","spread"],"values":[["2000-01-01T00:00:00Z",30],["2000-01-01T00:00:30Z",10],["2000-01-01T00:01:00Z",85]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "spread - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, spread(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","spread"],"values":[["2000-01-01T00:00:00Z",30],["2000-01-01T00:00:30Z",10],["2000-01-01T00:01:00Z",85]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "spread - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, spread(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 		},
-		&Query{
+		{
 			name:    "stddev - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT stddev(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","stddev"],"values":[["2000-01-01T00:00:00Z",17.320508075688775],["2000-01-01T00:00:30Z",5.773502691896258],["2000-01-01T00:01:00Z",44.44097208657794]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "stddev - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, stddev(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","stddev"],"values":[["2000-01-01T00:00:00Z",17.320508075688775],["2000-01-01T00:00:30Z",5.773502691896258],["2000-01-01T00:01:00Z",44.44097208657794]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "stddev - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, stddev(rx) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"error":"mixing aggregate and non-aggregate queries is not supported"}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "percentile - baseline 30s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT percentile(rx, 75) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","percentile"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "percentile - time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT time, percentile(rx, 75) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","percentile"],"values":[["2000-01-01T00:00:00Z",40],["2000-01-01T00:00:30Z",50],["2000-01-01T00:01:00Z",70]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "percentile - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT tx, percentile(rx, 75) FROM network where time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T00:01:29Z' group by time(30s)`,
@@ -5634,13 +5631,13 @@ func TestServer_Query_ExactTimeRange(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "query point at exactly one time - rfc3339nano",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu WHERE time = '2000-01-01T00:00:00.000000001Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00.000000001Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query point at exactly one time - timestamp",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu WHERE time = 946684800000000001`,
@@ -5695,31 +5692,31 @@ func TestServer_Query_Selectors(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "max - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(tx) FROM network`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","max"],"values":[["2000-01-01T00:00:40Z",70]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - tx",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(tx) FROM network`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","min"],"values":[["2000-01-01T00:01:20Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(tx) FROM network`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",20]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(tx) FROM network`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"network","columns":["time","last"],"values":[["2000-01-01T00:01:20Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "percentile",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT percentile(tx, 50) FROM network`,
@@ -5792,181 +5789,181 @@ func TestServer_Query_TopBottomInt(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "top - cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 1) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 1) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - 2 values",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 2) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T01:00:10Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - 2 values",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 2) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - 3 values - sorts on tie properly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 3) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T01:00:10Z",7],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - 3 values - sorts on tie properly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 3) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3],["2000-01-01T01:00:00Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - with tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, 2) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top","host"],"values":[["2000-01-01T01:00:10Z",7,"server05"],["2000-01-01T02:00:10Z",9,"server08"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - with tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, 2) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom","host"],"values":[["2000-01-01T00:00:00Z",2,"server01"],["2000-01-01T00:00:10Z",3,"server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - 3 values with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 3) FROM cpu limit 2`,
 			exp:     `{"results":[{"statement_id":0,"error":"limit (3) in top function can not be larger than the LIMIT (2) in the select statement"}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - 3 values with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 3) FROM cpu limit 2`,
 			exp:     `{"results":[{"statement_id":0,"error":"limit (3) in bottom function can not be larger than the LIMIT (2) in the select statement"}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 1) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:10Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 1) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T01:00:00Z",3],["2000-01-01T02:00:00Z",7]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - 2 values hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 2) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:10Z",3],["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:10Z",7],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - 2 values hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 2) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3],["2000-01-01T01:00:00Z",3],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - cpu - 3 values hourly - validates that a bucket can have less than limit if no values exist in that time bucket",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 3) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3],["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:00Z",3],["2000-01-01T01:00:10Z",7],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - cpu - 3 values hourly - validates that a bucket can have less than limit if no values exist in that time bucket",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 3) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3],["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:00Z",3],["2000-01-01T01:00:10Z",7],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - 2 values, two tags",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 2), host, service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host","service"],"values":[["2000-01-01T01:00:00Z",2001,"b","mysql"],["2000-01-01T02:00:00Z",2002,"b","mysql"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - 2 values, two tags",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, 2), host, service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","host","service"],"values":[["2000-01-01T00:00:00Z",1000,"a","redis"],["2000-01-01T01:00:00Z",1001,"a","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - host tag with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, 2) FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host"],"values":[["2000-01-01T02:00:00Z",2002,"b"],["2000-01-01T02:00:00Z",1002,"a"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - host tag with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, 2) FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","host"],"values":[["2000-01-01T00:00:00Z",1000,"a"],["2000-01-01T00:00:00Z",1500,"b"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - host tag with limit 2, service tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, 2), service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host","service"],"values":[["2000-01-01T02:00:00Z",2002,"b","mysql"],["2000-01-01T02:00:00Z",1002,"a","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - host tag with limit 2, service tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, 2), service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","host","service"],"values":[["2000-01-01T00:00:00Z",1000,"a","redis"],["2000-01-01T00:00:00Z",1500,"b","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - service tag with limit 2, host tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, service, 2), host FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","service","host"],"values":[["2000-01-01T02:00:00Z",2002,"mysql","b"],["2000-01-01T02:00:00Z",1502,"redis","b"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - service tag with limit 2, host tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, service, 2), host FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","service","host"],"values":[["2000-01-01T00:00:00Z",1000,"redis","a"],["2000-01-01T00:00:00Z",2000,"mysql","b"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - host and service tag with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, service, 2) FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host","service"],"values":[["2000-01-01T02:00:00Z",2002,"b","mysql"],["2000-01-01T02:00:00Z",1502,"b","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - host and service tag with limit 2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, service, 2) FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","host","service"],"values":[["2000-01-01T00:00:00Z",1000,"a","redis"],["2000-01-01T00:00:00Z",1500,"b","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - host tag with limit 2 with service tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, 2), service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host","service"],"values":[["2000-01-01T02:00:00Z",2002,"b","mysql"],["2000-01-01T02:00:00Z",1002,"a","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - host tag with limit 2 with service tag in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, 2), service FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","bottom","host","service"],"values":[["2000-01-01T00:00:00Z",1000,"a","redis"],["2000-01-01T00:00:00Z",1500,"b","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "top - memory - host and service tag with limit 3",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, host, service, 3) FROM memory`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"memory","columns":["time","top","host","service"],"values":[["2000-01-01T02:00:00Z",2002,"b","mysql"],["2000-01-01T02:00:00Z",1502,"b","redis"],["2000-01-01T02:00:00Z",1002,"a","redis"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bottom - memory - host and service tag with limit 3",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT BOTTOM(value, host, service, 3) FROM memory`,
@@ -6030,21 +6027,21 @@ func TestServer_Query_TopBottomWriteTags(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "top - write - with tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT top(value, host, 2) INTO cpu_top FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"result","columns":["time","written"],"values":[["1970-01-01T00:00:00Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "top - read results with tags",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu_top GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_top","tags":{"host":"server05"},"columns":["time","top"],"values":[["2000-01-01T01:00:10Z",7]]},{"name":"cpu_top","tags":{"host":"server08"},"columns":["time","top"],"values":[["2000-01-01T02:00:10Z",9]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "top - read results as fields",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu_top`,
@@ -6101,14 +6098,14 @@ func TestServer_Query_Aggregates_IdenticalTime(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "last from multiple series with identical timestamp",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT last(value) FROM "series"`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"series","columns":["time","last"],"values":[["2000-01-01T00:00:00Z",5]]}]}]}`,
 			repeat:  100,
 		},
-		&Query{
+		{
 			name:    "first from multiple series with identical timestamp",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT first(value) FROM "series"`,
@@ -6162,37 +6159,37 @@ func TestServer_Query_GroupByTimeCutoffs(t *testing.T) {
 		&Write{data: strings.Join(writes, "\n")},
 	}
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "sum all time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",21]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum all time grouped by time 5s",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T00:00:10Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",3],["2000-01-01T00:00:05Z",12],["2000-01-01T00:00:10Z",6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum all time grouped by time 5s missing first point",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu where time >= '2000-01-01T00:00:01Z' and time <= '2000-01-01T00:00:10Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:05Z",12],["2000-01-01T00:00:10Z",6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum all time grouped by time 5s missing first points (null for bucket)",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu where time >= '2000-01-01T00:00:02Z' and time <= '2000-01-01T00:00:10Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",null],["2000-01-01T00:00:05Z",12],["2000-01-01T00:00:10Z",6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum all time grouped by time 5s missing last point - 2 time intervals",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T00:00:09Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",3],["2000-01-01T00:00:05Z",12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum all time grouped by time 5s missing last 2 points - 2 time intervals",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T00:00:08Z' group by time(5s)`,
@@ -6238,40 +6235,40 @@ func TestServer_Query_MapType(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "query value with a single measurement",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query wildcard with a single measurement",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","value"],"values":[["2000-01-01T00:00:00Z","server01",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query value with multiple measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM cpu, gpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "query wildcard with multiple measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu, gpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","speed","value"],"values":[["2000-01-01T00:00:00Z","server01",null,2]]},{"name":"gpu","columns":["time","host","speed","value"],"values":[["2000-01-01T00:00:00Z","server02",25,null]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "query value with a regex measurement",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM /[cg]pu/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "query wildcard with a regex measurement",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM /[cg]pu/`,
@@ -6322,138 +6319,138 @@ func TestServer_Query_Subqueries(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT STDDEV(value) FROM stringdata`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"stringdata","columns":["time","stddev"],"values":[["1970-01-01T00:00:00Z",null]]}]}]}`,
 			skip:    true, // FIXME(benbjohnson): allow non-float var ref expr in cursor iterator
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM (SELECT mean(usage_user) AS value FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",31.5]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(usage) FROM (SELECT 100 - usage_user AS usage FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",68.5]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT min(usage_user), host FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server02"],["2000-01-01T00:00:20Z","server01"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' GROUP BY host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","host"],"values":[["2000-01-01T00:00:20Z","server01"]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(min) FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",17]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(min) FROM (SELECT (min(usage_user)) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",17]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(min), host FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max","host"],"values":[["2000-01-01T00:00:20Z",23,"server01"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean, host FROM (SELECT mean(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean","host"],"values":[["2000-01-01T00:00:00Z",46,"server01"],["2000-01-01T00:00:00Z",17,"server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT mean(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server01"],["2000-01-01T00:00:00Z","server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max(usage_system) FROM (SELECT min(usage_user), usage_system FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",89]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(top), host FROM (SELECT top(usage_user, host, 2) FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","host"],"values":[["2000-01-01T00:00:10Z",28,"server02"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(top), host FROM (SELECT top(usage_user, 2), host FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","host"],"values":[["2000-01-01T00:00:10Z",45,"server01"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT count(host) FROM (SELECT top(usage_user, host, 2) FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["2000-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(derivative) FROM (SELECT derivative(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["2000-01-01T00:00:00Z",-4.6]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(max) FROM (SELECT 100 - max(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(usage_system) FROM (SELECT max(usage_user), 100 - usage_system FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2000-01-01T00:00:10Z",28]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2000-01-01T00:00:10Z",-44]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(value) FROM (SELECT top(usage_user, 2), usage_user - usage_system AS value FROM cpu) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' GROUP BY host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","min"],"values":[["2000-01-01T00:00:10Z",-10]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","min"],"values":[["2000-01-01T00:00:10Z",-44]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT min(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND host = 'server01'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND value > 0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max FROM (SELECT max(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND host = 'server01'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",70]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND value > 0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND host =~ /server/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",-2]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT top(usage_system, host, 2) FROM (SELECT min(usage_user), usage_system FROM cpu GROUP BY time(20s), host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top","host"],"values":[["2000-01-01T00:00:00Z",89,"server02"],["2000-01-01T00:00:20Z",77,"server01"]]}]}]}`,
 		},
-		&Query{
+		{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT bottom(usage_system, host, 2) FROM (SELECT max(usage_user), usage_system FROM cpu GROUP BY time(20s), host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","bottom","host"],"values":[["2000-01-01T00:00:00Z",30,"server01"],["2000-01-01T00:00:20Z",53,"server02"]]}]}]}`,
@@ -6494,19 +6491,19 @@ func TestServer_Query_SubqueryWithGroupBy(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "group by time(2s) - time(2s), host",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(mean) FROM (SELECT mean(value) FROM cpu GROUP BY time(2s), host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:04Z' GROUP BY time(2s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",7.5],["2000-01-01T00:00:02Z",9.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by time(4s), host - time(2s), host",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(mean) FROM (SELECT mean(value) FROM cpu GROUP BY time(2s), host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:04Z' GROUP BY time(4s), host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",6.5]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",10.5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "group by time(2s), host - time(2s), host, region",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(mean) FROM (SELECT mean(value) FROM cpu GROUP BY time(2s), host, region) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:04Z' GROUP BY time(2s), host`,
@@ -6543,18 +6540,18 @@ func TestServer_Query_SubqueryForLogicalOptimize(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -6562,49 +6559,49 @@ func TestServer_Query_SubqueryForLogicalOptimize(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "sum no_height",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(sum_height) FROM (SELECT sum(height) as sum_height FROM (select * from mst where time >= 1629129600000000000 and time <= 1629129611000000000))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",1554]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum height_alias",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(sum_height) FROM (SELECT sum(a) as sum_height FROM (select height as a from mst where time >= 1629129600000000000 and time <= 1629129611000000000))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",1554]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum height_binary_alias",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(a) as sum_height, sum(a)+sum(b), mean(a) FROM (select height as a, age as b from mst where time >= 1629129600000000000 and time <= 1629129611000000000)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_height","sum_sum","mean"],"values":[["2021-08-16T16:00:00Z",1554,2070.8,141.27272727272728]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum sum_height, *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(sum_height) FROM (SELECT sum(height) as sum_height FROM (select * from mst where time >= 1629129600000000000 and time <= 1629129611000000000)) where time >= 1629129600000000000 and time <= 1629129611000000000 group by time(1s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum"],"values":[["2021-08-16T16:00:00Z",1554],["2021-08-16T16:00:01Z",null],["2021-08-16T16:00:02Z",null],["2021-08-16T16:00:03Z",null],["2021-08-16T16:00:04Z",null],["2021-08-16T16:00:05Z",null],["2021-08-16T16:00:06Z",null],["2021-08-16T16:00:07Z",null],["2021-08-16T16:00:08Z",null],["2021-08-16T16:00:09Z",null],["2021-08-16T16:00:10Z",null],["2021-08-16T16:00:11Z",null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean usage",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select mean(usage) from (select 100 - age as usage from mst where time >= 1629129600000000000 and time <= 1629129611000000000)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",53.01818181818182]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "outer filter#1",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM (SELECT max(age), age-height AS value FROM mst GROUP BY country) WHERE time >= '2021-08-16T16:00:00Z' AND time < '2021-08-16T16:00:11Z' AND value < 0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","country","max","value"],"values":[["2021-08-16T16:00:10Z","",102,-89],["2021-08-16T16:00:06Z","american",52.7,-100.3],["2021-08-16T16:00:09Z","canada",60.8,-119.2],["2021-08-16T16:00:05Z","china",48.8,-100.2],["2021-08-16T16:00:03Z","japan",30,-91]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "outer filter#2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT max FROM (SELECT max(age) FROM mst GROUP BY country) WHERE time >= '2021-08-16T16:00:00Z' AND time < '2021-08-16T16:00:11Z' AND country = 'china'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","max"],"values":[["2021-08-16T16:00:05Z",48.8]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "outer filter#3",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(value) FROM (SELECT max(age), age - height AS value FROM mst GROUP BY country) WHERE time >= '2021-08-16T16:00:00Z' AND time < '2021-08-16T16:00:11Z' AND value < 0`,
@@ -6641,21 +6638,21 @@ func TestServer_Query_NewChunkTagCheckList(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mem,t1=10.172.161.227:31533\,10.172.161.227:31533 value=1 1625558240121000000`),
-		fmt.Sprintf(`mem,t1=10.172.161.227:31533 value=1 1625558240122000000`),
-		fmt.Sprintf(`mem,t1=10.172.161.227:31533\,10.172.161.227:31533\,10.172.161.227:31533 value=1 1625558240123000000`),
-		fmt.Sprintf(`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mem,t1=10.172.161.227:31533\,10.172.161.227:31533 value=1 1625558240121000000`,
+		`mem,t1=10.172.161.227:31533 value=1 1625558240122000000`,
+		`mem,t1=10.172.161.227:31533\,10.172.161.227:31533\,10.172.161.227:31533 value=1 1625558240123000000`,
+		`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -6663,13 +6660,13 @@ func TestServer_Query_NewChunkTagCheckList(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select *  group by * ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from mem group by *::tag`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mem","tags":{"t1":"10.172.161.227:31533"},"columns":["time","value"],"values":[["2021-07-06T07:57:20.122Z",1]]},{"name":"mem","tags":{"t1":"10.172.161.227:31533,10.172.161.227:31533"},"columns":["time","value"],"values":[["2021-07-06T07:57:20.121Z",1]]},{"name":"mem","tags":{"t1":"10.172.161.227:31533,10.172.161.227:31533,10.172.161.227:31533"},"columns":["time","value"],"values":[["2021-07-06T07:57:20.123Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select min(*) group by * ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select min(*) from mst group by *::tag`,
@@ -6706,27 +6703,27 @@ func TestServer_Query_MultiMeasurements(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst1,country=china,name=ada age=15 1625558240121000000`),
-		fmt.Sprintf(`mst1,country=china,name=billy age=27 1625558240122000000`),
-		fmt.Sprintf(`mst1,country=china,name=demon age=57 1625558240123000000`),
-		fmt.Sprintf(`mst1,country=China,name=king age=22 1625558240124000000`),
-		fmt.Sprintf(`mst1,country=Egypt,name=chris age=31 1625558242121000000`),
-		fmt.Sprintf(`mst1,country=Egypt,name=daisy age=40 1625558242122000000`),
-		fmt.Sprintf(`mst1,country=France,name=paul age=45 1625558242123000000`),
-		fmt.Sprintf(`mst1,country=Germany,name=frank age=35 1625558242124000000`),
-		fmt.Sprintf(`mst1,country=Japan,name=jack age=21 1625558242125000000`),
-		fmt.Sprintf(`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst1,country=china,name=ada age=15 1625558240121000000`,
+		`mst1,country=china,name=billy age=27 1625558240122000000`,
+		`mst1,country=china,name=demon age=57 1625558240123000000`,
+		`mst1,country=China,name=king age=22 1625558240124000000`,
+		`mst1,country=Egypt,name=chris age=31 1625558242121000000`,
+		`mst1,country=Egypt,name=daisy age=40 1625558242122000000`,
+		`mst1,country=France,name=paul age=45 1625558242123000000`,
+		`mst1,country=Germany,name=frank age=35 1625558242124000000`,
+		`mst1,country=Japan,name=jack age=21 1625558242125000000`,
+		`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin no=12i,age=123,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -6734,55 +6731,55 @@ func TestServer_Query_MultiMeasurements(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select * from measurements ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM mst,mst1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst,mst1","columns":["time","address","age","alive","country","height","name","no"],"values":[["2021-07-06T07:57:20.121Z",null,15,null,"china",null,"ada",null],["2021-07-06T07:57:20.122Z",null,27,null,"china",null,"billy",null],["2021-07-06T07:57:20.123Z",null,57,null,"china",null,"demon",null],["2021-07-06T07:57:20.124Z",null,22,null,"China",null,"king",null],["2021-07-06T07:57:22.121Z",null,31,null,"Egypt",null,"chris",null],["2021-07-06T07:57:22.122Z",null,40,null,"Egypt",null,"daisy",null],["2021-07-06T07:57:22.123Z",null,45,null,"France",null,"paul",null],["2021-07-06T07:57:22.124Z",null,35,null,"Germany",null,"frank",null],["2021-07-06T07:57:22.125Z",null,21,null,"Japan",null,"jack",null],["2021-08-16T16:00:00Z","shenzhen",12.3,true,"china",70,"azhu",1],["2021-08-16T16:00:01Z","shanghai",20.5,false,"american",80,"alan",2],["2021-08-16T16:00:02Z","beijin",3.4,true,"germany",90,"alang",3],["2021-08-16T16:00:03Z","guangzhou",30,false,"japan",121,"ahui",4],["2021-08-16T16:00:04Z","chengdu",35,true,"canada",138,"aqiu",5],["2021-08-16T16:00:05Z","wuhan",48.8,null,"china",149,"agang",6],["2021-08-16T16:00:06Z",null,52.7,true,"american",153,"agan",7],["2021-08-16T16:00:07Z","anhui",28.3,false,"germany",null,"alin",8],["2021-08-16T16:00:08Z","xian",null,true,"japan",179,"ali",9],["2021-08-16T16:00:09Z","hangzhou",60.8,false,"canada",180,null,10],["2021-08-16T16:00:10Z","nanjin",102,true,null,191,"ahuang",11],["2021-08-16T16:00:11Z","zhengzhou",123,false,"china",203,"ayin",12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select * from measurements where ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM mst,mst1 where country='china'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst,mst1","columns":["time","address","age","alive","country","height","name","no"],"values":[["2021-07-06T07:57:20.121Z",null,15,null,"china",null,"ada",null],["2021-07-06T07:57:20.122Z",null,27,null,"china",null,"billy",null],["2021-07-06T07:57:20.123Z",null,57,null,"china",null,"demon",null],["2021-08-16T16:00:00Z","shenzhen",12.3,true,"china",70,"azhu",1],["2021-08-16T16:00:05Z","wuhan",48.8,null,"china",149,"agang",6],["2021-08-16T16:00:11Z","zhengzhou",123,false,"china",203,"ayin",12]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select field from measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT age FROM mst,mst1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst,mst1","columns":["time","age"],"values":[["2021-07-06T07:57:20.121Z",15],["2021-07-06T07:57:20.122Z",27],["2021-07-06T07:57:20.123Z",57],["2021-07-06T07:57:20.124Z",22],["2021-07-06T07:57:22.121Z",31],["2021-07-06T07:57:22.122Z",40],["2021-07-06T07:57:22.123Z",45],["2021-07-06T07:57:22.124Z",35],["2021-07-06T07:57:22.125Z",21],["2021-08-16T16:00:00Z",12.3],["2021-08-16T16:00:01Z",20.5],["2021-08-16T16:00:02Z",3.4],["2021-08-16T16:00:03Z",30],["2021-08-16T16:00:04Z",35],["2021-08-16T16:00:05Z",48.8],["2021-08-16T16:00:06Z",52.7],["2021-08-16T16:00:07Z",28.3],["2021-08-16T16:00:09Z",60.8],["2021-08-16T16:00:10Z",102],["2021-08-16T16:00:11Z",123]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select subqueries from measurements_1",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select sum(a),sum(b) from (select min(age) as a from mst1),(select sum(age) as b from mst1)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst1","columns":["time","sum","sum_1"],"values":[["1970-01-01T00:00:00Z",15,293]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select subqueries from measurements_2",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select sum(a)+sum(b) from (select sum(age) as a from mst1),(select sum(age) as b from mst1)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst1","columns":["time","sum_sum"],"values":[["1970-01-01T00:00:00Z",586]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select subqueries from measurements_3",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select sum(a),sum(b) from (select count(age) as a from mst where country='china' and time >= 1629129600000000000 and time <= 1629129611000000000 group by time(1s)),(select count(age) as b from mst where time >= 1629129600000000000 and time <= 1629129611000000000 group by time(1s))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum","sum_1"],"values":[["1970-01-01T00:00:00Z",3,11]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select agg from measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT count(age) FROM mst,mst1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst,mst1","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",20]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select agg subqueries from measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select a from (select sum(age) as a from mst1,mst group by country)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst,mst1","columns":["time","a"],"values":[["1970-01-01T00:00:00Z",102],["1970-01-01T00:00:00Z",22],["1970-01-01T00:00:00Z",71],["1970-01-01T00:00:00Z",45],["1970-01-01T00:00:00Z",35],["1970-01-01T00:00:00Z",21],["1970-01-01T00:00:00Z",73.2],["1970-01-01T00:00:00Z",95.8],["1970-01-01T00:00:00Z",283.1],["1970-01-01T00:00:00Z",31.7],["1970-01-01T00:00:00Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select * from regexe measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from /mst.*/`,
@@ -6819,7 +6816,7 @@ func TestServer_Query_NilColumn(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=ada age=15,address="chengdu" 1625558240121000000`),
+		`mst,country=china,name=ada age=15,address="chengdu" 1625558240121000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -6829,8 +6826,8 @@ func TestServer_Query_NilColumn(t *testing.T) {
 	http.Post(s.URL()+"/debug/ctrl?mod=flush", "", nil)
 
 	writes2 := []string{
-		fmt.Sprintf(`mst,country=china,name=ada age=15 1625558240121000000`),
-		fmt.Sprintf(`mst,country=china,name=bcb height=10,age=15,address="chongqing" 1625558240122000000`),
+		`mst,country=china,name=ada age=15 1625558240121000000`,
+		`mst,country=china,name=bcb height=10,age=15,address="chongqing" 1625558240122000000`,
 	}
 	test.writes = Writes{
 		&Write{data: strings.Join(writes2, "\n")},
@@ -6838,7 +6835,7 @@ func TestServer_Query_NilColumn(t *testing.T) {
 	http.Post(s.URL()+"/debug/ctrl?mod=flush", "", nil)
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select count(*) from measurements ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT count(*) FROM mst`,
@@ -6875,8 +6872,8 @@ func TestServer_Query_MultipleFiles_NoCrossTime(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=China,name=ada age=15 1625558240121000000`),
-		fmt.Sprintf(`mst,country=China,name=billy age=27 1625558240122000000`),
+		`mst,country=China,name=ada age=15 1625558240121000000`,
+		`mst,country=China,name=billy age=27 1625558240122000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writesArray = append(test.writesArray, Writes{
@@ -6884,26 +6881,26 @@ func TestServer_Query_MultipleFiles_NoCrossTime(t *testing.T) {
 	})
 
 	writes2 := []string{
-		fmt.Sprintf(`mst,country=China,name=demon age=57 1625558242123000000`),
-		fmt.Sprintf(`mst,country=China,name=king age=22 1625558242124000000`),
+		`mst,country=China,name=demon age=57 1625558242123000000`,
+		`mst,country=China,name=king age=22 1625558242124000000`,
 	}
 	test.writesArray = append(test.writesArray, Writes{
 		&Write{data: strings.Join(writes2, "\n")},
 	})
 
 	writes3 := []string{
-		fmt.Sprintf(`mst,country=Egypt,name=chris age=31 1625558244121000000`),
-		fmt.Sprintf(`mst,country=Egypt,name=daisy age=40 1625558244122000000`),
-		fmt.Sprintf(`mst,country=France,name=paul age=45 1625558245123000000`),
-		fmt.Sprintf(`mst,country=Germany,name=frank age=36 1625558245124000000`),
-		fmt.Sprintf(`mst,country=Japan,name=jack age=21 1625558245125000000`),
+		`mst,country=Egypt,name=chris age=31 1625558244121000000`,
+		`mst,country=Egypt,name=daisy age=40 1625558244122000000`,
+		`mst,country=France,name=paul age=45 1625558245123000000`,
+		`mst,country=Germany,name=frank age=36 1625558245124000000`,
+		`mst,country=Japan,name=jack age=21 1625558245125000000`,
 	}
 	test.writesArray = append(test.writesArray, Writes{
 		&Write{data: strings.Join(writes3, "\n")},
 	})
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select mean(*) from measurements group by time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(*) FROM mst where time >= 1625558240121000000 and time <= 1625558245125000000 group by time(1s)`,
@@ -6940,18 +6937,18 @@ func TestServer_Query_OutOfOrder_Overlap_Column(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`),
-		fmt.Sprintf(`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`),
-		fmt.Sprintf(`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`),
-		fmt.Sprintf(`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`),
-		fmt.Sprintf(`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`),
-		fmt.Sprintf(`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`),
-		fmt.Sprintf(`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`),
-		fmt.Sprintf(`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`),
-		fmt.Sprintf(`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`),
-		fmt.Sprintf(`mst,country=china,name=ayin no=12i,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`),
+		`mst,country=china,name=azhu no=1i,age=12.3,height=70i,address="shenzhen",alive=TRUE 1629129600000000000`,
+		`mst,country=american,name=alan no=2i,age=20.5,height=80i,address="shanghai",alive=FALSE 1629129601000000000`,
+		`mst,country=germany,name=alang no=3i,age=3.4,height=90i,address="beijin",alive=TRUE 1629129602000000000`,
+		`mst,country=japan,name=ahui no=4i,age=30,height=121i,address="guangzhou",alive=FALSE 1629129603000000000`,
+		`mst,country=canada,name=aqiu no=5i,age=35,height=138i,address="chengdu",alive=TRUE 1629129604000000000`,
+		`mst,country=china,name=agang no=6i,age=48.8,height=149i,address="wuhan" 1629129605000000000`,
+		`mst,country=american,name=agan no=7i,age=52.7,height=153i,alive=TRUE 1629129606000000000`,
+		`mst,country=germany,name=alin no=8i,age=28.3,address="anhui",alive=FALSE 1629129607000000000`,
+		`mst,country=japan,name=ali no=9i,height=179i,address="xian",alive=TRUE 1629129608000000000`,
+		`mst,country=canada no=10i,age=60.8,height=180i,address="hangzhou",alive=FALSE 1629129609000000000`,
+		`mst,name=ahuang no=11i,age=102,height=191i,address="nanjin",alive=TRUE 1629129610000000000`,
+		`mst,country=china,name=ayin no=12i,height=203i,address="zhengzhou",alive=FALSE 1629129611000000000`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -6962,7 +6959,7 @@ func TestServer_Query_OutOfOrder_Overlap_Column(t *testing.T) {
 	}
 
 	writes2 := []string{
-		fmt.Sprintf(`mst,country=china,name=ayin no=12i,age=1,height=20i,address="zhengzhou",alive=FALSE 1629129600000000000`),
+		`mst,country=china,name=ayin no=12i,age=1,height=20i,address="zhengzhou",alive=FALSE 1629129600000000000`,
 	}
 	test.writes = Writes{
 		&Write{data: strings.Join(writes2, "\n")},
@@ -6972,13 +6969,13 @@ func TestServer_Query_OutOfOrder_Overlap_Column(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select last(height),age from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select last(height),age from mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","last","age"],"values":[["2021-08-16T16:00:11Z",203,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select max(height),age from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(height),age from mst`,
@@ -7015,106 +7012,106 @@ func TestServer_Query_PreAgg_StringAux_WithNullValue(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,host=server19900,region=tagval2_19900,core_tag=spring core="field-*_values _1_19900",tx=19900i,yx=19900,rx=True 1648190516508400896`),
-		fmt.Sprintf(`mst,host=server19901,region=tagval2_19901,core_tag=summer core="field-*_values _1_19901",tx=19901i,yx=19901,rx=False 1648190516509400896`),
-		fmt.Sprintf(`mst,host=server19902,region=tagval2_19902 yx=19902,rx=True 1648190516510400896`),
-		fmt.Sprintf(`mst,host=server19903,region=tagval2_19903,core_tag=winter core="field-*_values _1_19903",tx=19903i,yx=19903,rx=False 1648190516511400896`),
-		fmt.Sprintf(`mst,host=server19904,region=tagval2_19904,core_tag=spring core="field-*_values _1_19904",tx=19904i,yx=19904,rx=True 1648190516512400896`),
-		fmt.Sprintf(`mst,host=server19905,region=tagval2_19905 yx=19905,rx=False 1648190516513400896`),
-		fmt.Sprintf(`mst,host=server19906,region=tagval2_19906,core_tag=autumn core="field-*_values _1_19906",tx=19906i,yx=19906,rx=True 1648190516514400896`),
-		fmt.Sprintf(`mst,host=server19907,region=tagval2_19907,core_tag=winter core="field-*_values _1_19907",tx=19907i,yx=19907,rx=False 1648190516515400896`),
-		fmt.Sprintf(`mst,host=server19908,region=tagval2_19908 yx=19908,rx=True 1648190516516400896`),
-		fmt.Sprintf(`mst,host=server19909,region=tagval2_19909,core_tag=summer core="field-*_values _1_19909",tx=19909i,yx=19909,rx=False 1648190516517400896`),
-		fmt.Sprintf(`mst,host=server19910,region=tagval2_19910,core_tag=autumn core="field-*_values _1_19910",tx=19910i,yx=19910,rx=True 1648190516518400896`),
-		fmt.Sprintf(`mst,host=server19911,region=tagval2_19911 yx=19911,rx=False 1648190516519400896`),
-		fmt.Sprintf(`mst,host=server19912,region=tagval2_19912,core_tag=spring core="field-*_values _1_19912",tx=19912i,yx=19912,rx=True 1648190516520400896`),
-		fmt.Sprintf(`mst,host=server19913,region=tagval2_19913,core_tag=summer core="field-*_values _1_19913",tx=19913i,yx=19913,rx=False 1648190516521400896`),
-		fmt.Sprintf(`mst,host=server19914,region=tagval2_19914 yx=19914,rx=True 1648190516522400896`),
-		fmt.Sprintf(`mst,host=server19915,region=tagval2_19915,core_tag=winter core="field-*_values _1_19915",tx=19915i,yx=19915,rx=False 1648190516523400896`),
-		fmt.Sprintf(`mst,host=server19916,region=tagval2_19916,core_tag=spring core="field-*_values _1_19916",tx=19916i,yx=19916,rx=True 1648190516524400896`),
-		fmt.Sprintf(`mst,host=server19917,region=tagval2_19917 yx=19917,rx=False 1648190516525400896`),
-		fmt.Sprintf(`mst,host=server19918,region=tagval2_19918,core_tag=autumn core="field-*_values _1_19918",tx=19918i,yx=19918,rx=True 1648190516526400896`),
-		fmt.Sprintf(`mst,host=server19919,region=tagval2_19919,core_tag=winter core="field-*_values _1_19919",tx=19919i,yx=19919,rx=False 1648190516527400896`),
-		fmt.Sprintf(`mst,host=server19920,region=tagval2_19920 yx=19920,rx=True 1648190516528400896`),
-		fmt.Sprintf(`mst,host=server19921,region=tagval2_19921,core_tag=summer core="field-*_values _1_19921",tx=19921i,yx=19921,rx=False 1648190516529400896`),
-		fmt.Sprintf(`mst,host=server19922,region=tagval2_19922,core_tag=autumn core="field-*_values _1_19922",tx=19922i,yx=19922,rx=True 1648190516530400896`),
-		fmt.Sprintf(`mst,host=server19923,region=tagval2_19923 yx=19923,rx=False 1648190516531400896`),
-		fmt.Sprintf(`mst,host=server19924,region=tagval2_19924,core_tag=spring core="field-*_values _1_19924",tx=19924i,yx=19924,rx=True 1648190516532400896`),
-		fmt.Sprintf(`mst,host=server19925,region=tagval2_19925,core_tag=summer core="field-*_values _1_19925",tx=19925i,yx=19925,rx=False 1648190516533400896`),
-		fmt.Sprintf(`mst,host=server19926,region=tagval2_19926 yx=19926,rx=True 1648190516534400896`),
-		fmt.Sprintf(`mst,host=server19927,region=tagval2_19927,core_tag=winter core="field-*_values _1_19927",tx=19927i,yx=19927,rx=False 1648190516535400896`),
-		fmt.Sprintf(`mst,host=server19928,region=tagval2_19928,core_tag=spring core="field-*_values _1_19928",tx=19928i,yx=19928,rx=True 1648190516536400896`),
-		fmt.Sprintf(`mst,host=server19929,region=tagval2_19929 yx=19929,rx=False 1648190516537400896`),
-		fmt.Sprintf(`mst,host=server19930,region=tagval2_19930,core_tag=autumn core="field-*_values _1_19930",tx=19930i,yx=19930,rx=True 1648190516538400896`),
-		fmt.Sprintf(`mst,host=server19931,region=tagval2_19931,core_tag=winter core="field-*_values _1_19931",tx=19931i,yx=19931,rx=False 1648190516539400896`),
-		fmt.Sprintf(`mst,host=server19932,region=tagval2_19932 yx=19932,rx=True 1648190516540400896`),
-		fmt.Sprintf(`mst,host=server19933,region=tagval2_19933,core_tag=summer core="field-*_values _1_19933",tx=19933i,yx=19933,rx=False 1648190516541400896`),
-		fmt.Sprintf(`mst,host=server19934,region=tagval2_19934,core_tag=autumn core="field-*_values _1_19934",tx=19934i,yx=19934,rx=True 1648190516542400896`),
-		fmt.Sprintf(`mst,host=server19935,region=tagval2_19935 yx=19935,rx=False 1648190516543400896`),
-		fmt.Sprintf(`mst,host=server19936,region=tagval2_19936,core_tag=spring core="field-*_values _1_19936",tx=19936i,yx=19936,rx=True 1648190516544400896`),
-		fmt.Sprintf(`mst,host=server19937,region=tagval2_19937,core_tag=summer core="field-*_values _1_19937",tx=19937i,yx=19937,rx=False 1648190516545400896`),
-		fmt.Sprintf(`mst,host=server19938,region=tagval2_19938 yx=19938,rx=True 1648190516546400896`),
-		fmt.Sprintf(`mst,host=server19939,region=tagval2_19939,core_tag=winter core="field-*_values _1_19939",tx=19939i,yx=19939,rx=False 1648190516547400896`),
-		fmt.Sprintf(`mst,host=server19940,region=tagval2_19940,core_tag=spring core="field-*_values _1_19940",tx=19940i,yx=19940,rx=True 1648190516548400896`),
-		fmt.Sprintf(`mst,host=server19941,region=tagval2_19941 yx=19941,rx=False 1648190516549400896`),
-		fmt.Sprintf(`mst,host=server19942,region=tagval2_19942,core_tag=autumn core="field-*_values _1_19942",tx=19942i,yx=19942,rx=True 1648190516550400896`),
-		fmt.Sprintf(`mst,host=server19943,region=tagval2_19943,core_tag=winter core="field-*_values _1_19943",tx=19943i,yx=19943,rx=False 1648190516551400896`),
-		fmt.Sprintf(`mst,host=server19944,region=tagval2_19944 yx=19944,rx=True 1648190516552400896`),
-		fmt.Sprintf(`mst,host=server19945,region=tagval2_19945,core_tag=summer core="field-*_values _1_19945",tx=19945i,yx=19945,rx=False 1648190516553400896`),
-		fmt.Sprintf(`mst,host=server19946,region=tagval2_19946,core_tag=autumn core="field-*_values _1_19946",tx=19946i,yx=19946,rx=True 1648190516554400896`),
-		fmt.Sprintf(`mst,host=server19947,region=tagval2_19947 yx=19947,rx=False 1648190516555400896`),
-		fmt.Sprintf(`mst,host=server19948,region=tagval2_19948,core_tag=spring core="field-*_values _1_19948",tx=19948i,yx=19948,rx=True 1648190516556400896`),
-		fmt.Sprintf(`mst,host=server19949,region=tagval2_19949,core_tag=summer core="field-*_values _1_19949",tx=19949i,yx=19949,rx=False 1648190516557400896`),
-		fmt.Sprintf(`mst,host=server19950,region=tagval2_19950 yx=19950,rx=True 1648190516558400896`),
-		fmt.Sprintf(`mst,host=server19951,region=tagval2_19951,core_tag=winter core="field-*_values _1_19951",tx=19951i,yx=19951,rx=False 1648190516559400896`),
-		fmt.Sprintf(`mst,host=server19952,region=tagval2_19952,core_tag=spring core="field-*_values _1_19952",tx=19952i,yx=19952,rx=True 1648190516560400896`),
-		fmt.Sprintf(`mst,host=server19953,region=tagval2_19953 yx=19953,rx=False 1648190516561400896`),
-		fmt.Sprintf(`mst,host=server19954,region=tagval2_19954,core_tag=autumn core="field-*_values _1_19954",tx=19954i,yx=19954,rx=True 1648190516562400896`),
-		fmt.Sprintf(`mst,host=server19955,region=tagval2_19955,core_tag=winter core="field-*_values _1_19955",tx=19955i,yx=19955,rx=False 1648190516563400896`),
-		fmt.Sprintf(`mst,host=server19956,region=tagval2_19956 yx=19956,rx=True 1648190516564400896`),
-		fmt.Sprintf(`mst,host=server19957,region=tagval2_19957,core_tag=summer core="field-*_values _1_19957",tx=19957i,yx=19957,rx=False 1648190516565400896`),
-		fmt.Sprintf(`mst,host=server19958,region=tagval2_19958,core_tag=autumn core="field-*_values _1_19958",tx=19958i,yx=19958,rx=True 1648190516566400896`),
-		fmt.Sprintf(`mst,host=server19959,region=tagval2_19959 yx=19959,rx=False 1648190516567400896`),
-		fmt.Sprintf(`mst,host=server19960,region=tagval2_19960,core_tag=spring core="field-*_values _1_19960",tx=19960i,yx=19960,rx=True 1648190516568400896`),
-		fmt.Sprintf(`mst,host=server19961,region=tagval2_19961,core_tag=summer core="field-*_values _1_19961",tx=19961i,yx=19961,rx=False 1648190516569400896`),
-		fmt.Sprintf(`mst,host=server19962,region=tagval2_19962 yx=19962,rx=True 1648190516570400896`),
-		fmt.Sprintf(`mst,host=server19963,region=tagval2_19963,core_tag=winter core="field-*_values _1_19963",tx=19963i,yx=19963,rx=False 1648190516571400896`),
-		fmt.Sprintf(`mst,host=server19964,region=tagval2_19964,core_tag=spring core="field-*_values _1_19964",tx=19964i,yx=19964,rx=True 1648190516572400896`),
-		fmt.Sprintf(`mst,host=server19965,region=tagval2_19965 yx=19965,rx=False 1648190516573400896`),
-		fmt.Sprintf(`mst,host=server19966,region=tagval2_19966,core_tag=autumn core="field-*_values _1_19966",tx=19966i,yx=19966,rx=True 1648190516574400896`),
-		fmt.Sprintf(`mst,host=server19967,region=tagval2_19967,core_tag=winter core="field-*_values _1_19967",tx=19967i,yx=19967,rx=False 1648190516575400896`),
-		fmt.Sprintf(`mst,host=server19968,region=tagval2_19968 yx=19968,rx=True 1648190516576400896`),
-		fmt.Sprintf(`mst,host=server19969,region=tagval2_19969,core_tag=summer core="field-*_values _1_19969",tx=19969i,yx=19969,rx=False 1648190516577400896`),
-		fmt.Sprintf(`mst,host=server19970,region=tagval2_19970,core_tag=autumn core="field-*_values _1_19970",tx=19970i,yx=19970,rx=True 1648190516578400896`),
-		fmt.Sprintf(`mst,host=server19971,region=tagval2_19971 yx=19971,rx=False 1648190516579400896`),
-		fmt.Sprintf(`mst,host=server19972,region=tagval2_19972,core_tag=spring core="field-*_values _1_19972",tx=19972i,yx=19972,rx=True 1648190516580400896`),
-		fmt.Sprintf(`mst,host=server19973,region=tagval2_19973,core_tag=summer core="field-*_values _1_19973",tx=19973i,yx=19973,rx=False 1648190516581400896`),
-		fmt.Sprintf(`mst,host=server19974,region=tagval2_19974 yx=19974,rx=True 1648190516582400896`),
-		fmt.Sprintf(`mst,host=server19975,region=tagval2_19975,core_tag=winter core="field-*_values _1_19975",tx=19975i,yx=19975,rx=False 1648190516583400896`),
-		fmt.Sprintf(`mst,host=server19976,region=tagval2_19976,core_tag=spring core="field-*_values _1_19976",tx=19976i,yx=19976,rx=True 1648190516584400896`),
-		fmt.Sprintf(`mst,host=server19977,region=tagval2_19977 yx=19977,rx=False 1648190516585400896`),
-		fmt.Sprintf(`mst,host=server19978,region=tagval2_19978,core_tag=autumn core="field-*_values _1_19978",tx=19978i,yx=19978,rx=True 1648190516586400896`),
-		fmt.Sprintf(`mst,host=server19979,region=tagval2_19979,core_tag=winter core="field-*_values _1_19979",tx=19979i,yx=19979,rx=False 1648190516587400896`),
-		fmt.Sprintf(`mst,host=server19980,region=tagval2_19980 yx=19980,rx=True 1648190516588400896`),
-		fmt.Sprintf(`mst,host=server19981,region=tagval2_19981,core_tag=summer core="field-*_values _1_19981",tx=19981i,yx=19981,rx=False 1648190516589400896`),
-		fmt.Sprintf(`mst,host=server19982,region=tagval2_19982,core_tag=autumn core="field-*_values _1_19982",tx=19982i,yx=19982,rx=True 1648190516590400896`),
-		fmt.Sprintf(`mst,host=server19983,region=tagval2_19983 yx=19983,rx=False 1648190516591400896`),
-		fmt.Sprintf(`mst,host=server19984,region=tagval2_19984,core_tag=spring core="field-*_values _1_19984",tx=19984i,yx=19984,rx=True 1648190516592400896`),
-		fmt.Sprintf(`mst,host=server19985,region=tagval2_19985,core_tag=summer core="field-*_values _1_19985",tx=19985i,yx=19985,rx=False 1648190516593400896`),
-		fmt.Sprintf(`mst,host=server19986,region=tagval2_19986 yx=19986,rx=True 1648190516594400896`),
-		fmt.Sprintf(`mst,host=server19987,region=tagval2_19987,core_tag=winter core="field-*_values _1_19987",tx=19987i,yx=19987,rx=False 1648190516595400896`),
-		fmt.Sprintf(`mst,host=server19988,region=tagval2_19988,core_tag=spring core="field-*_values _1_19988",tx=19988i,yx=19988,rx=True 1648190516596400896`),
-		fmt.Sprintf(`mst,host=server19989,region=tagval2_19989 yx=19989,rx=False 1648190516597400896`),
-		fmt.Sprintf(`mst,host=server19990,region=tagval2_19990,core_tag=autumn core="field-*_values _1_19990",tx=19990i,yx=19990,rx=True 1648190516598400896`),
-		fmt.Sprintf(`mst,host=server19991,region=tagval2_19991,core_tag=winter core="field-*_values _1_19991",tx=19991i,yx=19991,rx=False 1648190516599400896`),
-		fmt.Sprintf(`mst,host=server19992,region=tagval2_19992 yx=19992,rx=True 1648190516600400896`),
-		fmt.Sprintf(`mst,host=server19993,region=tagval2_19993,core_tag=summer core="field-*_values _1_19993",tx=19993i,yx=19993,rx=False 1648190516601400896`),
-		fmt.Sprintf(`mst,host=server19994,region=tagval2_19994,core_tag=autumn core="field-*_values _1_19994",tx=19994i,yx=19994,rx=True 1648190516602400896`),
-		fmt.Sprintf(`mst,host=server19995,region=tagval2_19995 yx=19995,rx=False 1648190516603400896`),
-		fmt.Sprintf(`mst,host=server19996,region=tagval2_19996,core_tag=spring core="field-*_values _1_19996",tx=19996i,yx=19996,rx=True 1648190516604400896`),
-		fmt.Sprintf(`mst,host=server19997,region=tagval2_19997,core_tag=summer core="field-*_values _1_19997",tx=19997i,yx=19997,rx=False 1648190516605400896`),
-		fmt.Sprintf(`mst,host=server19998,region=tagval2_19998 yx=19998,rx=True 1648190516606400896`),
-		fmt.Sprintf(`mst,host=server19999,region=tagval2_19999,core_tag=winter core="field-*_values _1_19999",tx=19999i,yx=19999,rx=False 1648190516607400896`),
+		`mst,host=server19900,region=tagval2_19900,core_tag=spring core="field-*_values _1_19900",tx=19900i,yx=19900,rx=True 1648190516508400896`,
+		`mst,host=server19901,region=tagval2_19901,core_tag=summer core="field-*_values _1_19901",tx=19901i,yx=19901,rx=False 1648190516509400896`,
+		`mst,host=server19902,region=tagval2_19902 yx=19902,rx=True 1648190516510400896`,
+		`mst,host=server19903,region=tagval2_19903,core_tag=winter core="field-*_values _1_19903",tx=19903i,yx=19903,rx=False 1648190516511400896`,
+		`mst,host=server19904,region=tagval2_19904,core_tag=spring core="field-*_values _1_19904",tx=19904i,yx=19904,rx=True 1648190516512400896`,
+		`mst,host=server19905,region=tagval2_19905 yx=19905,rx=False 1648190516513400896`,
+		`mst,host=server19906,region=tagval2_19906,core_tag=autumn core="field-*_values _1_19906",tx=19906i,yx=19906,rx=True 1648190516514400896`,
+		`mst,host=server19907,region=tagval2_19907,core_tag=winter core="field-*_values _1_19907",tx=19907i,yx=19907,rx=False 1648190516515400896`,
+		`mst,host=server19908,region=tagval2_19908 yx=19908,rx=True 1648190516516400896`,
+		`mst,host=server19909,region=tagval2_19909,core_tag=summer core="field-*_values _1_19909",tx=19909i,yx=19909,rx=False 1648190516517400896`,
+		`mst,host=server19910,region=tagval2_19910,core_tag=autumn core="field-*_values _1_19910",tx=19910i,yx=19910,rx=True 1648190516518400896`,
+		`mst,host=server19911,region=tagval2_19911 yx=19911,rx=False 1648190516519400896`,
+		`mst,host=server19912,region=tagval2_19912,core_tag=spring core="field-*_values _1_19912",tx=19912i,yx=19912,rx=True 1648190516520400896`,
+		`mst,host=server19913,region=tagval2_19913,core_tag=summer core="field-*_values _1_19913",tx=19913i,yx=19913,rx=False 1648190516521400896`,
+		`mst,host=server19914,region=tagval2_19914 yx=19914,rx=True 1648190516522400896`,
+		`mst,host=server19915,region=tagval2_19915,core_tag=winter core="field-*_values _1_19915",tx=19915i,yx=19915,rx=False 1648190516523400896`,
+		`mst,host=server19916,region=tagval2_19916,core_tag=spring core="field-*_values _1_19916",tx=19916i,yx=19916,rx=True 1648190516524400896`,
+		`mst,host=server19917,region=tagval2_19917 yx=19917,rx=False 1648190516525400896`,
+		`mst,host=server19918,region=tagval2_19918,core_tag=autumn core="field-*_values _1_19918",tx=19918i,yx=19918,rx=True 1648190516526400896`,
+		`mst,host=server19919,region=tagval2_19919,core_tag=winter core="field-*_values _1_19919",tx=19919i,yx=19919,rx=False 1648190516527400896`,
+		`mst,host=server19920,region=tagval2_19920 yx=19920,rx=True 1648190516528400896`,
+		`mst,host=server19921,region=tagval2_19921,core_tag=summer core="field-*_values _1_19921",tx=19921i,yx=19921,rx=False 1648190516529400896`,
+		`mst,host=server19922,region=tagval2_19922,core_tag=autumn core="field-*_values _1_19922",tx=19922i,yx=19922,rx=True 1648190516530400896`,
+		`mst,host=server19923,region=tagval2_19923 yx=19923,rx=False 1648190516531400896`,
+		`mst,host=server19924,region=tagval2_19924,core_tag=spring core="field-*_values _1_19924",tx=19924i,yx=19924,rx=True 1648190516532400896`,
+		`mst,host=server19925,region=tagval2_19925,core_tag=summer core="field-*_values _1_19925",tx=19925i,yx=19925,rx=False 1648190516533400896`,
+		`mst,host=server19926,region=tagval2_19926 yx=19926,rx=True 1648190516534400896`,
+		`mst,host=server19927,region=tagval2_19927,core_tag=winter core="field-*_values _1_19927",tx=19927i,yx=19927,rx=False 1648190516535400896`,
+		`mst,host=server19928,region=tagval2_19928,core_tag=spring core="field-*_values _1_19928",tx=19928i,yx=19928,rx=True 1648190516536400896`,
+		`mst,host=server19929,region=tagval2_19929 yx=19929,rx=False 1648190516537400896`,
+		`mst,host=server19930,region=tagval2_19930,core_tag=autumn core="field-*_values _1_19930",tx=19930i,yx=19930,rx=True 1648190516538400896`,
+		`mst,host=server19931,region=tagval2_19931,core_tag=winter core="field-*_values _1_19931",tx=19931i,yx=19931,rx=False 1648190516539400896`,
+		`mst,host=server19932,region=tagval2_19932 yx=19932,rx=True 1648190516540400896`,
+		`mst,host=server19933,region=tagval2_19933,core_tag=summer core="field-*_values _1_19933",tx=19933i,yx=19933,rx=False 1648190516541400896`,
+		`mst,host=server19934,region=tagval2_19934,core_tag=autumn core="field-*_values _1_19934",tx=19934i,yx=19934,rx=True 1648190516542400896`,
+		`mst,host=server19935,region=tagval2_19935 yx=19935,rx=False 1648190516543400896`,
+		`mst,host=server19936,region=tagval2_19936,core_tag=spring core="field-*_values _1_19936",tx=19936i,yx=19936,rx=True 1648190516544400896`,
+		`mst,host=server19937,region=tagval2_19937,core_tag=summer core="field-*_values _1_19937",tx=19937i,yx=19937,rx=False 1648190516545400896`,
+		`mst,host=server19938,region=tagval2_19938 yx=19938,rx=True 1648190516546400896`,
+		`mst,host=server19939,region=tagval2_19939,core_tag=winter core="field-*_values _1_19939",tx=19939i,yx=19939,rx=False 1648190516547400896`,
+		`mst,host=server19940,region=tagval2_19940,core_tag=spring core="field-*_values _1_19940",tx=19940i,yx=19940,rx=True 1648190516548400896`,
+		`mst,host=server19941,region=tagval2_19941 yx=19941,rx=False 1648190516549400896`,
+		`mst,host=server19942,region=tagval2_19942,core_tag=autumn core="field-*_values _1_19942",tx=19942i,yx=19942,rx=True 1648190516550400896`,
+		`mst,host=server19943,region=tagval2_19943,core_tag=winter core="field-*_values _1_19943",tx=19943i,yx=19943,rx=False 1648190516551400896`,
+		`mst,host=server19944,region=tagval2_19944 yx=19944,rx=True 1648190516552400896`,
+		`mst,host=server19945,region=tagval2_19945,core_tag=summer core="field-*_values _1_19945",tx=19945i,yx=19945,rx=False 1648190516553400896`,
+		`mst,host=server19946,region=tagval2_19946,core_tag=autumn core="field-*_values _1_19946",tx=19946i,yx=19946,rx=True 1648190516554400896`,
+		`mst,host=server19947,region=tagval2_19947 yx=19947,rx=False 1648190516555400896`,
+		`mst,host=server19948,region=tagval2_19948,core_tag=spring core="field-*_values _1_19948",tx=19948i,yx=19948,rx=True 1648190516556400896`,
+		`mst,host=server19949,region=tagval2_19949,core_tag=summer core="field-*_values _1_19949",tx=19949i,yx=19949,rx=False 1648190516557400896`,
+		`mst,host=server19950,region=tagval2_19950 yx=19950,rx=True 1648190516558400896`,
+		`mst,host=server19951,region=tagval2_19951,core_tag=winter core="field-*_values _1_19951",tx=19951i,yx=19951,rx=False 1648190516559400896`,
+		`mst,host=server19952,region=tagval2_19952,core_tag=spring core="field-*_values _1_19952",tx=19952i,yx=19952,rx=True 1648190516560400896`,
+		`mst,host=server19953,region=tagval2_19953 yx=19953,rx=False 1648190516561400896`,
+		`mst,host=server19954,region=tagval2_19954,core_tag=autumn core="field-*_values _1_19954",tx=19954i,yx=19954,rx=True 1648190516562400896`,
+		`mst,host=server19955,region=tagval2_19955,core_tag=winter core="field-*_values _1_19955",tx=19955i,yx=19955,rx=False 1648190516563400896`,
+		`mst,host=server19956,region=tagval2_19956 yx=19956,rx=True 1648190516564400896`,
+		`mst,host=server19957,region=tagval2_19957,core_tag=summer core="field-*_values _1_19957",tx=19957i,yx=19957,rx=False 1648190516565400896`,
+		`mst,host=server19958,region=tagval2_19958,core_tag=autumn core="field-*_values _1_19958",tx=19958i,yx=19958,rx=True 1648190516566400896`,
+		`mst,host=server19959,region=tagval2_19959 yx=19959,rx=False 1648190516567400896`,
+		`mst,host=server19960,region=tagval2_19960,core_tag=spring core="field-*_values _1_19960",tx=19960i,yx=19960,rx=True 1648190516568400896`,
+		`mst,host=server19961,region=tagval2_19961,core_tag=summer core="field-*_values _1_19961",tx=19961i,yx=19961,rx=False 1648190516569400896`,
+		`mst,host=server19962,region=tagval2_19962 yx=19962,rx=True 1648190516570400896`,
+		`mst,host=server19963,region=tagval2_19963,core_tag=winter core="field-*_values _1_19963",tx=19963i,yx=19963,rx=False 1648190516571400896`,
+		`mst,host=server19964,region=tagval2_19964,core_tag=spring core="field-*_values _1_19964",tx=19964i,yx=19964,rx=True 1648190516572400896`,
+		`mst,host=server19965,region=tagval2_19965 yx=19965,rx=False 1648190516573400896`,
+		`mst,host=server19966,region=tagval2_19966,core_tag=autumn core="field-*_values _1_19966",tx=19966i,yx=19966,rx=True 1648190516574400896`,
+		`mst,host=server19967,region=tagval2_19967,core_tag=winter core="field-*_values _1_19967",tx=19967i,yx=19967,rx=False 1648190516575400896`,
+		`mst,host=server19968,region=tagval2_19968 yx=19968,rx=True 1648190516576400896`,
+		`mst,host=server19969,region=tagval2_19969,core_tag=summer core="field-*_values _1_19969",tx=19969i,yx=19969,rx=False 1648190516577400896`,
+		`mst,host=server19970,region=tagval2_19970,core_tag=autumn core="field-*_values _1_19970",tx=19970i,yx=19970,rx=True 1648190516578400896`,
+		`mst,host=server19971,region=tagval2_19971 yx=19971,rx=False 1648190516579400896`,
+		`mst,host=server19972,region=tagval2_19972,core_tag=spring core="field-*_values _1_19972",tx=19972i,yx=19972,rx=True 1648190516580400896`,
+		`mst,host=server19973,region=tagval2_19973,core_tag=summer core="field-*_values _1_19973",tx=19973i,yx=19973,rx=False 1648190516581400896`,
+		`mst,host=server19974,region=tagval2_19974 yx=19974,rx=True 1648190516582400896`,
+		`mst,host=server19975,region=tagval2_19975,core_tag=winter core="field-*_values _1_19975",tx=19975i,yx=19975,rx=False 1648190516583400896`,
+		`mst,host=server19976,region=tagval2_19976,core_tag=spring core="field-*_values _1_19976",tx=19976i,yx=19976,rx=True 1648190516584400896`,
+		`mst,host=server19977,region=tagval2_19977 yx=19977,rx=False 1648190516585400896`,
+		`mst,host=server19978,region=tagval2_19978,core_tag=autumn core="field-*_values _1_19978",tx=19978i,yx=19978,rx=True 1648190516586400896`,
+		`mst,host=server19979,region=tagval2_19979,core_tag=winter core="field-*_values _1_19979",tx=19979i,yx=19979,rx=False 1648190516587400896`,
+		`mst,host=server19980,region=tagval2_19980 yx=19980,rx=True 1648190516588400896`,
+		`mst,host=server19981,region=tagval2_19981,core_tag=summer core="field-*_values _1_19981",tx=19981i,yx=19981,rx=False 1648190516589400896`,
+		`mst,host=server19982,region=tagval2_19982,core_tag=autumn core="field-*_values _1_19982",tx=19982i,yx=19982,rx=True 1648190516590400896`,
+		`mst,host=server19983,region=tagval2_19983 yx=19983,rx=False 1648190516591400896`,
+		`mst,host=server19984,region=tagval2_19984,core_tag=spring core="field-*_values _1_19984",tx=19984i,yx=19984,rx=True 1648190516592400896`,
+		`mst,host=server19985,region=tagval2_19985,core_tag=summer core="field-*_values _1_19985",tx=19985i,yx=19985,rx=False 1648190516593400896`,
+		`mst,host=server19986,region=tagval2_19986 yx=19986,rx=True 1648190516594400896`,
+		`mst,host=server19987,region=tagval2_19987,core_tag=winter core="field-*_values _1_19987",tx=19987i,yx=19987,rx=False 1648190516595400896`,
+		`mst,host=server19988,region=tagval2_19988,core_tag=spring core="field-*_values _1_19988",tx=19988i,yx=19988,rx=True 1648190516596400896`,
+		`mst,host=server19989,region=tagval2_19989 yx=19989,rx=False 1648190516597400896`,
+		`mst,host=server19990,region=tagval2_19990,core_tag=autumn core="field-*_values _1_19990",tx=19990i,yx=19990,rx=True 1648190516598400896`,
+		`mst,host=server19991,region=tagval2_19991,core_tag=winter core="field-*_values _1_19991",tx=19991i,yx=19991,rx=False 1648190516599400896`,
+		`mst,host=server19992,region=tagval2_19992 yx=19992,rx=True 1648190516600400896`,
+		`mst,host=server19993,region=tagval2_19993,core_tag=summer core="field-*_values _1_19993",tx=19993i,yx=19993,rx=False 1648190516601400896`,
+		`mst,host=server19994,region=tagval2_19994,core_tag=autumn core="field-*_values _1_19994",tx=19994i,yx=19994,rx=True 1648190516602400896`,
+		`mst,host=server19995,region=tagval2_19995 yx=19995,rx=False 1648190516603400896`,
+		`mst,host=server19996,region=tagval2_19996,core_tag=spring core="field-*_values _1_19996",tx=19996i,yx=19996,rx=True 1648190516604400896`,
+		`mst,host=server19997,region=tagval2_19997,core_tag=summer core="field-*_values _1_19997",tx=19997i,yx=19997,rx=False 1648190516605400896`,
+		`mst,host=server19998,region=tagval2_19998 yx=19998,rx=True 1648190516606400896`,
+		`mst,host=server19999,region=tagval2_19999,core_tag=winter core="field-*_values _1_19999",tx=19999i,yx=19999,rx=False 1648190516607400896`,
 	}
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -7124,7 +7121,7 @@ func TestServer_Query_PreAgg_StringAux_WithNullValue(t *testing.T) {
 	http.Post(s.URL()+"/debug/ctrl?mod=flush", "", nil)
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select max(yx),core,tx,rx from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(yx),core,tx,rx from mst`,
@@ -7158,7 +7155,7 @@ func TestServer_Query_PreAgg_OutOfOrderData(t *testing.T) {
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    "create database with shard group duration and index duration should succeed",
 				command: `CREATE DATABASE db3 WITH SHARD DURATION 12h index duration 24h name rp3`,
 				exp:     `{"results":[{"statement_id":0}]}`,
@@ -7201,45 +7198,45 @@ func TestServer_Query_PreAgg_OutOfOrderData(t *testing.T) {
 	}
 
 	test.queries = []*Query{
-		&Query{
+		{
 			name:    "select count(time) should success",
 			command: `select count(time) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",8]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",8]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select count(*)",
 			command: `select count(*) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_alive","count_no","count_val"],"values":[["1970-01-01T00:00:00Z",7,8,8]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","count_alive","count_no","count_val"],"values":[["1970-01-01T00:00:00Z",7,8,8]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select min(val)",
 			command: `select min(val) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2021-11-25T13:00:00Z",23]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min"],"values":[["2021-11-25T13:00:00Z",23]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select min(val),host,region,aliv",
 			command: `select min(val),host,region,alive from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","host","region","alive"],"values":[["2021-11-25T13:00:00Z",23,"serverB","uswest",null]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","min","host","region","alive"],"values":[["2021-11-25T13:00:00Z",23,"serverB","uswest",null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select max(val)",
 			command: `select max(val) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max"],"values":[["2021-11-25T10:00:00Z",200]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max"],"values":[["2021-11-25T10:00:00Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select first(val)",
 			command: `select first(val) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first"],"values":[["2021-11-25T10:00:00Z",200]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","first"],"values":[["2021-11-25T10:00:00Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select last(val)",
 			command: `select last(val) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last"],"values":[["2021-11-27T09:00:00Z",105]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","last"],"values":[["2021-11-27T09:00:00Z",105]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select sum(val)",
 			command: `select sum(val) from db3.rp3.cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",697.5]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",697.5]]}]}]}`,
 		},
 	}
 
@@ -7272,10 +7269,10 @@ func TestServer_Query_PreAgg_WithEmptyData(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,k=1 f1=1,f2=1,f3=1i,f4=true    1629129601000000000`),
-		fmt.Sprintf(`mst,k=1 f1=2                       1629129602000000000`),
-		fmt.Sprintf(`mst,k=1 f1=3                       1629129603000000000`),
-		fmt.Sprintf(`mst,k=1 f1=4,f2=4,f3=4i,f4=false   1629129604000000000`),
+		`mst,k=1 f1=1,f2=1,f3=1i,f4=true    1629129601000000000`,
+		`mst,k=1 f1=2                       1629129602000000000`,
+		`mst,k=1 f1=3                       1629129603000000000`,
+		`mst,k=1 f1=4,f2=4,f3=4i,f4=false   1629129604000000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -7284,37 +7281,37 @@ func TestServer_Query_PreAgg_WithEmptyData(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "max float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(f2) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "max int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(f3) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "max bool",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(f4) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "min float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select min(f2) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "min int",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select min(f3) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "min bool",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select min(f4) from mst where time>=1629129602000000000 and time < 1629129603000000000`,
@@ -7354,28 +7351,28 @@ func TestServer_Query_PreAgg_Filter(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`mst,country=China,city=Chengdu age=1 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Chengdu age=2 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Hangzhou age=3 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Hangzhou age=4 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Nanjing age=5 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Nanjing age=6 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Beijing age=7 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Beijing age=8 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Shanghai age=9 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Shanghai age=10 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Guangzhou age=11 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Guangzhou age=12 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Shenzheng age=13 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Shenzheng age=14 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Yantai age=15 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Yantai age=16 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Heilongjiang age=17 1625558240120000000`),
-		fmt.Sprintf(`mst,country=China,city=Heilongjiang age=18 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Changsha age=19 1625558240119000000`),
-		fmt.Sprintf(`mst,country=China,city=Changsha age=20 1625558240130000000`),
-		fmt.Sprintf(`mst,country=China,city=Xizhang age=21 1625558240119000000`),
-		fmt.Sprintf(`mst,country=China,city=Xizhang age=22 1625558240130000000`),
+		`mst,country=China,city=Chengdu age=1 1625558240120000000`,
+		`mst,country=China,city=Chengdu age=2 1625558240130000000`,
+		`mst,country=China,city=Hangzhou age=3 1625558240120000000`,
+		`mst,country=China,city=Hangzhou age=4 1625558240130000000`,
+		`mst,country=China,city=Nanjing age=5 1625558240120000000`,
+		`mst,country=China,city=Nanjing age=6 1625558240130000000`,
+		`mst,country=China,city=Beijing age=7 1625558240120000000`,
+		`mst,country=China,city=Beijing age=8 1625558240130000000`,
+		`mst,country=China,city=Shanghai age=9 1625558240120000000`,
+		`mst,country=China,city=Shanghai age=10 1625558240130000000`,
+		`mst,country=China,city=Guangzhou age=11 1625558240120000000`,
+		`mst,country=China,city=Guangzhou age=12 1625558240130000000`,
+		`mst,country=China,city=Shenzheng age=13 1625558240120000000`,
+		`mst,country=China,city=Shenzheng age=14 1625558240130000000`,
+		`mst,country=China,city=Yantai age=15 1625558240120000000`,
+		`mst,country=China,city=Yantai age=16 1625558240130000000`,
+		`mst,country=China,city=Heilongjiang age=17 1625558240120000000`,
+		`mst,country=China,city=Heilongjiang age=18 1625558240130000000`,
+		`mst,country=China,city=Changsha age=19 1625558240119000000`,
+		`mst,country=China,city=Changsha age=20 1625558240130000000`,
+		`mst,country=China,city=Xizhang age=21 1625558240119000000`,
+		`mst,country=China,city=Xizhang age=22 1625558240130000000`,
 	}
 
 	test := NewTest("db0", "rp0")
@@ -7384,37 +7381,37 @@ func TestServer_Query_PreAgg_Filter(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "max age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select max(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"city":"Beijing","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",7]]},{"name":"mst","tags":{"city":"Chengdu","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Guangzhou","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",11]]},{"name":"mst","tags":{"city":"Hangzhou","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",3]]},{"name":"mst","tags":{"city":"Heilongjiang","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",17]]},{"name":"mst","tags":{"city":"Nanjing","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",5]]},{"name":"mst","tags":{"city":"Shanghai","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",9]]},{"name":"mst","tags":{"city":"Shenzheng","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",13]]},{"name":"mst","tags":{"city":"Yantai","country":"China"},"columns":["time","max"],"values":[["2021-07-06T07:57:20.12Z",15]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select min(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"city":"Beijing","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",7]]},{"name":"mst","tags":{"city":"Chengdu","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Guangzhou","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",11]]},{"name":"mst","tags":{"city":"Hangzhou","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",3]]},{"name":"mst","tags":{"city":"Heilongjiang","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",17]]},{"name":"mst","tags":{"city":"Nanjing","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",5]]},{"name":"mst","tags":{"city":"Shanghai","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",9]]},{"name":"mst","tags":{"city":"Shenzheng","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",13]]},{"name":"mst","tags":{"city":"Yantai","country":"China"},"columns":["time","min"],"values":[["2021-07-06T07:57:20.12Z",15]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select first(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"city":"Beijing","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",7]]},{"name":"mst","tags":{"city":"Chengdu","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Guangzhou","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",11]]},{"name":"mst","tags":{"city":"Hangzhou","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",3]]},{"name":"mst","tags":{"city":"Heilongjiang","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",17]]},{"name":"mst","tags":{"city":"Nanjing","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",5]]},{"name":"mst","tags":{"city":"Shanghai","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",9]]},{"name":"mst","tags":{"city":"Shenzheng","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",13]]},{"name":"mst","tags":{"city":"Yantai","country":"China"},"columns":["time","first"],"values":[["2021-07-06T07:57:20.12Z",15]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select last(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"city":"Beijing","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",7]]},{"name":"mst","tags":{"city":"Chengdu","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Guangzhou","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",11]]},{"name":"mst","tags":{"city":"Hangzhou","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",3]]},{"name":"mst","tags":{"city":"Heilongjiang","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",17]]},{"name":"mst","tags":{"city":"Nanjing","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",5]]},{"name":"mst","tags":{"city":"Shanghai","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",9]]},{"name":"mst","tags":{"city":"Shenzheng","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",13]]},{"name":"mst","tags":{"city":"Yantai","country":"China"},"columns":["time","last"],"values":[["2021-07-06T07:57:20.12Z",15]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "count age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select count(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"city":"Beijing","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Chengdu","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Guangzhou","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Hangzhou","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Heilongjiang","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Nanjing","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Shanghai","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Shenzheng","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]},{"name":"mst","tags":{"city":"Yantai","country":"China"},"columns":["time","count"],"values":[["2021-07-06T07:57:20.12Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum age group by *",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select sum(age) from mst where time >=1625558240120000000 and time < 1625558240130000000 group by *`,
@@ -7462,43 +7459,43 @@ func TestServer_Query_Aggregates_FloatMany_New(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "count - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT COUNT(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",100000]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT FIRST(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","first"],"values":[["2000-01-01T00:00:00Z",0]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT LAST(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","last"],"values":[["2000-01-02T03:46:39Z",9999]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sum - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT SUM(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","sum"],"values":[["1970-01-01T00:00:00Z",499950000]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "max - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MAX(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","max"],"values":[["2000-01-01T02:46:39Z",9999]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "min - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MIN(value) FROM floatmany`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"floatmany","columns":["time","min"],"values":[["2000-01-01T00:00:00Z",0]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "mean - float",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT MEAN(value) FROM floatmany`,
@@ -7561,7 +7558,7 @@ func TestServer_Query_SubqueryMath(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "SumThreeValues",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum FROM (SELECT f1 + f2 + f3 AS sum FROM m0)`,
@@ -7609,7 +7606,7 @@ func TestServer_Query_PercentileDerivative(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "nth percentile of derivative",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT percentile(derivative, 95) FROM (SELECT derivative(value, 1s) FROM counter) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:50Z'`,
@@ -7654,7 +7651,7 @@ func TestServer_Query_UnderscoreMeasurement(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "select underscore with underscore prefix",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM _cpu`,
@@ -7725,43 +7722,43 @@ func TestServer_Write_Precision(t *testing.T) {
 	test := NewTest("db0", "rp0")
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "point with nanosecond precision time - no precision specified on write",
 			command: `SELECT * FROM cpu_n0_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_n0_precision","columns":["time","value"],"values":[["2000-01-01T12:34:56.789012345Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with nanosecond precision time",
 			command: `SELECT * FROM cpu_n1_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_n1_precision","columns":["time","value"],"values":[["2000-01-01T12:34:56.789012345Z",1.1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with microsecond precision time",
 			command: `SELECT * FROM cpu_u_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_u_precision","columns":["time","value"],"values":[["2000-01-01T12:34:56.789012Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with millisecond precision time",
 			command: `SELECT * FROM cpu_ms_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_ms_precision","columns":["time","value"],"values":[["2000-01-01T12:34:56.789Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with second precision time",
 			command: `SELECT * FROM cpu_s_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_s_precision","columns":["time","value"],"values":[["2000-01-01T12:34:56Z",300]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with minute precision time",
 			command: `SELECT * FROM cpu_m_precision`,
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu_m_precision","columns":["time","value"],"values":[["2000-01-01T12:34:00Z",400]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "point with hour precision time",
 			command: `SELECT * FROM cpu_h_precision`,
 			params:  url.Values{"db": []string{"db0"}},
@@ -7823,69 +7820,69 @@ func TestServer_Query_Wildcards(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "wildcard",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","region","value","valx"],"values":[["2000-01-01T00:00:00Z","us-east",10,null],["2000-01-01T00:00:10Z","us-east",null,20],["2000-01-01T00:00:20Z","us-east",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "wildcard with group by",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM wildcard GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","tags":{"region":"us-east"},"columns":["time","value","valx"],"values":[["2000-01-01T00:00:00Z",10,null],["2000-01-01T00:00:10Z",null,20],["2000-01-01T00:00:20Z",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "GROUP BY queries",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(value) FROM wgroup GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wgroup","tags":{"region":"us-east"},"columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",15]]},{"name":"wgroup","tags":{"region":"us-west"},"columns":["time","mean"],"values":[["1970-01-01T00:00:00Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "GROUP BY queries with time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT mean(value) FROM wgroup WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:01:00Z' GROUP BY *,TIME(1m)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wgroup","tags":{"region":"us-east"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",15]]},{"name":"wgroup","tags":{"region":"us-west"},"columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",30]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "wildcard and field in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value, * FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","value","region","value_1","valx"],"values":[["2000-01-01T00:00:00Z",10,"us-east",10,null],["2000-01-01T00:00:10Z",null,"us-east",null,20],["2000-01-01T00:00:20Z",30,"us-east",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field and wildcard in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value, * FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","value","region","value_1","valx"],"values":[["2000-01-01T00:00:00Z",10,"us-east",10,null],["2000-01-01T00:00:10Z",null,"us-east",null,20],["2000-01-01T00:00:20Z",30,"us-east",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field and wildcard in group by",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM wildcard GROUP BY region, *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","tags":{"region":"us-east"},"columns":["time","value","valx"],"values":[["2000-01-01T00:00:00Z",10,null],["2000-01-01T00:00:10Z",null,20],["2000-01-01T00:00:20Z",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "wildcard and field in group by",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM wildcard GROUP BY *, region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","tags":{"region":"us-east"},"columns":["time","value","valx"],"values":[["2000-01-01T00:00:00Z",10,null],["2000-01-01T00:00:10Z",null,20],["2000-01-01T00:00:20Z",30,40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "wildcard with multiple measurements",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM m1, m2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"m1","columns":["time","field","host","region","value"],"values":[["2000-01-01T00:00:00Z",null,null,"us-east",10]]},{"name":"m2","columns":["time","field","host","region","value"],"values":[["2000-01-01T00:00:01Z",20,"server01",null,null]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "wildcard with multiple measurements via regex",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM /^m.*/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"m1","columns":["time","field","host","region","value"],"values":[["2000-01-01T00:00:00Z",null,null,"us-east",10]]},{"name":"m2","columns":["time","field","host","region","value"],"values":[["2000-01-01T00:00:01Z",20,"server01",null,null]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "wildcard with multiple measurements via regex and limit",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM db0../^m.*/ LIMIT 2`,
@@ -7942,32 +7939,32 @@ func TestServer_Query_WildcardExpansion(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "wildcard",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","cpu","host","region","value"],"values":[["2000-01-01T00:00:00Z",80,"A","us-east",10],["2000-01-01T00:00:10Z",90,"B","us-east",20],["2000-01-01T00:00:20Z",70,"B","us-west",30],["2000-01-01T00:00:30Z",60,"A","us-east",40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "no wildcard in select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT cpu, host, region, value  FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","cpu","host","region","value"],"values":[["2000-01-01T00:00:00Z",80,"A","us-east",10],["2000-01-01T00:00:10Z",90,"B","us-east",20],["2000-01-01T00:00:20Z",70,"B","us-west",30],["2000-01-01T00:00:30Z",60,"A","us-east",40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "no wildcard in select, preserve column order",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host, cpu, region, value  FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","host","cpu","region","value"],"values":[["2000-01-01T00:00:00Z","A",80,"us-east",10],["2000-01-01T00:00:10Z","B",90,"us-east",20],["2000-01-01T00:00:20Z","B",70,"us-west",30],["2000-01-01T00:00:30Z","A",60,"us-east",40]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "no wildcard with alias",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT cpu as c, host as h, region, value  FROM wildcard`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"wildcard","columns":["time","c","h","region","value"],"values":[["2000-01-01T00:00:00Z",80,"A","us-east",10],["2000-01-01T00:00:10Z",90,"B","us-east",20],["2000-01-01T00:00:20Z",70,"B","us-west",30],["2000-01-01T00:00:30Z",60,"A","us-east",40]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "duplicate tag and field key",
 			command: `SELECT * FROM dupnames`,
 			params:  url.Values{"db": []string{"db0"}},
@@ -8015,41 +8012,41 @@ func TestServer_Query_AcrossShardsAndFields(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "two results for cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT load FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2000-01-01T00:00:00Z",100],["2010-01-01T00:00:00Z",200]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "two results for cpu, multi-select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT core,load FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core","load"],"values":[["2000-01-01T00:00:00Z",null,100],["2010-01-01T00:00:00Z",null,200],["2015-01-01T00:00:00Z",4,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "two results for cpu, wildcard select",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core","load"],"values":[["2000-01-01T00:00:00Z",null,100],["2010-01-01T00:00:00Z",null,200],["2015-01-01T00:00:00Z",4,null]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "one result for core",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT core FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2015-01-01T00:00:00Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "empty result set from non-existent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT foo FROM cpu`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "select existent and non-existent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT foo,load FROM cpu`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","foo","load"],"values":[["2000-01-01T00:00:00Z",null,100],["2010-01-01T00:00:00Z",null,200]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","foo","load"],"values":[["2000-01-01T00:00:00Z",null,100],["2010-01-01T00:00:00Z",null,200]]}]}]}`,
 		},
 	}...)
 
@@ -8095,28 +8092,28 @@ func TestServer_Query_OrderedAcrossShards(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "derivative",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT derivative(value, 24h) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-01-08T00:00:00Z",1],["2010-01-15T00:00:00Z",2],["2010-01-22T00:00:00Z",4],["2010-01-29T00:00:00Z",8]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "non_negative_derivative",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT non_negative_derivative(value, 24h) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","non_negative_derivative"],"values":[["2010-01-08T00:00:00Z",1],["2010-01-15T00:00:00Z",2],["2010-01-22T00:00:00Z",4],["2010-01-29T00:00:00Z",8]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "difference",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT difference(value) FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-01-08T00:00:00Z",7],["2010-01-15T00:00:00Z",14],["2010-01-22T00:00:00Z",28],["2010-01-29T00:00:00Z",56]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "cumulative_sum",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT cumulative_sum(value) FROM cpu`,
@@ -8171,7 +8168,7 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 
 	test.addQueries([]*Query{
 		// non type specific
-		&Query{
+		{
 			name:    "missing measurement with group by",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT load from missing group by *`,
@@ -8179,31 +8176,31 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 		},
 
 		// string
-		&Query{
+		{
 			name:    "single string field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT alert_id FROM cpu WHERE alert_id='alert'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","alert_id"],"values":[["2015-02-28T01:03:36.703820946Z","alert"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "string AND query, all fields in SELECT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT alert_id,tenant_id,_cust FROM cpu WHERE alert_id='alert' AND tenant_id='tenant'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","alert_id","tenant_id","_cust"],"values":[["2015-02-28T01:03:36.703820946Z","alert","tenant","johnson brothers"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "string AND query, all fields in SELECT, one in parenthesis",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT alert_id,tenant_id FROM cpu WHERE alert_id='alert' AND (tenant_id='tenant')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","alert_id","tenant_id"],"values":[["2015-02-28T01:03:36.703820946Z","alert","tenant"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "string underscored field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT alert_id FROM cpu WHERE _cust='johnson brothers'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","alert_id"],"values":[["2015-02-28T01:03:36.703820946Z","alert"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "string no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT alert_id FROM cpu WHERE _cust='acme'`,
@@ -8211,55 +8208,55 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 		},
 
 		// float64
-		&Query{
+		{
 			name:    "float64 GT no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load > 100`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 GTE match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load >= 100`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2009-11-10T23:00:02Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 EQ match upper bound",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load = 100`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2009-11-10T23:00:02Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 LTE match two",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load <= 100`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2009-11-10T23:00:02Z",100],["2009-11-10T23:01:02Z",80]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 GT match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load > 99`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2009-11-10T23:00:02Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 EQ no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load = 99`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 LT match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load < 99`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","load"],"values":[["2009-11-10T23:01:02Z",80]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 LT no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load < 80`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "float64 NE match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select load from cpu where load != 100`,
@@ -8267,55 +8264,55 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 		},
 
 		// int64
-		&Query{
+		{
 			name:    "int64 GT no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core > 4`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 GTE match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core >= 4`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2009-11-10T23:00:02Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 EQ match upper bound",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core = 4`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2009-11-10T23:00:02Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 LTE match two ",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core <= 4`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2009-11-10T23:00:02Z",4],["2009-11-10T23:01:02Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 GT match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core > 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2009-11-10T23:00:02Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 EQ no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core = 3`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 LT match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core < 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","core"],"values":[["2009-11-10T23:01:02Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 LT no match",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core < 2`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "int64 NE match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select core from cpu where core != 4`,
@@ -8323,20 +8320,20 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 		},
 
 		// bool
-		&Query{
+		{
 			name:    "bool EQ match true",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select local from clicks where local = true`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"clicks","columns":["time","local"],"values":[["2014-11-10T23:00:01Z",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "bool EQ match false",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select local from clicks where local = false`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"clicks","columns":["time","local"],"values":[["2014-11-10T23:00:02Z",false]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "bool NE match one",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select local from clicks where local != true`,
@@ -8387,104 +8384,104 @@ func TestServer_Query_Where_With_Tags(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "tag field and time",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where (tennant = 'paul' OR tennant = 'david') AND time > 1s AND (foo = 'bar' OR foo = 'baz' OR foo = 'bap')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:06Z","bap"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "tag or field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tennant = 'paul' OR foo = 'bar'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:04Z","bat"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field or tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where foo = 'bar' OR tennant = 'paul'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:04Z","bat"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "tag or tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tennant = 'todd' OR tennant = 'paul'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:04Z","bat"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field or field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where foo = 'bar' OR foo = 'baz'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "tag or parent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where foo = 'bar' OR ((foo = 'baz'))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "parent field or tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where ((foo = 'baz')) OR foo = 'bar'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "parent field or parent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where ((foo = 'bar')) OR ((foo = 'baz'))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:03Z","baz"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "tag and field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tennant = 'paul' AND foo = 'bar'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field and tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where foo = 'bar' AND tennant = 'paul'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field and field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where foo = 'bar' AND foo = 'bat'`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "tag and parent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tennant = 'paul' AND ((foo = 'bar'))`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "parent field and tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where ((foo = 'bar')) AND tennant = 'paul'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "parent field and parent field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where ((foo = 'bar')) AND ((foo = 'bat'))`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
 
-		&Query{
+		{
 			name:    "non-existant tag and field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tenant != 'paul' AND foo = 'bar'`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "non-existant tag or field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tenant != 'paul' OR foo = 'bar'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"where_events","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z","bar"],["2009-11-10T23:00:05Z","bar"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "where comparing tag and field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from where_events where tennant != foo`,
@@ -8538,70 +8535,70 @@ func TestServer_Query_With_EmptyTags(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "where empty tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host = ''`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:02Z",1]]}]}]}`,
 			skip:    true, //Issue #54
 		},
-		&Query{
+		{
 			name:    "where not empty tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host != ''`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex none",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host !~ /.*/`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex exact",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host =~ /^server01$/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex exact (case insensitive)",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host =~ /(?i)^SeRvEr01$/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex exact (not)",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host !~ /^server01$/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:02Z",1]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex at least one char",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host =~ /.+/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "where regex not at least one char",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host !~ /.+/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:02Z",1]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "group by empty tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu group by host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":""},"columns":["time","value"],"values":[["2009-11-10T23:00:02Z",1]]},{"name":"cpu","tags":{"host":"server01"},"columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "group by missing tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu group by region`,
@@ -8651,73 +8648,73 @@ func TestServer_Query_LimitAndOffset(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "limit on points",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from "limited" LIMIT 2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z",2],["2009-11-10T23:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "limit higher than the number of data points",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from "limited" LIMIT 20`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","foo"],"values":[["2009-11-10T23:00:02Z",2],["2009-11-10T23:00:03Z",3],["2009-11-10T23:00:04Z",4],["2009-11-10T23:00:05Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "limit and offset",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from "limited" LIMIT 2 OFFSET 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","foo"],"values":[["2009-11-10T23:00:03Z",3],["2009-11-10T23:00:04Z",4]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "limit + offset equal to total number of points",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select foo from "limited" LIMIT 3 OFFSET 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","foo"],"values":[["2009-11-10T23:00:05Z",5]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "limit - offset higher than number of points",
 			command: `select foo from "limited" LIMIT 2 OFFSET 20`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit on points with group by time",
 			command: `select mean(foo) from "limited" WHERE time >= '2009-11-10T23:00:02Z' AND time < '2009-11-10T23:00:06Z' GROUP BY TIME(1s) LIMIT 2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","mean"],"values":[["2009-11-10T23:00:02Z",2],["2009-11-10T23:00:03Z",3]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit higher than the number of data points with group by time",
 			command: `select mean(foo) from "limited" WHERE time >= '2009-11-10T23:00:02Z' AND time < '2009-11-10T23:00:06Z' GROUP BY TIME(1s) LIMIT 20`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","mean"],"values":[["2009-11-10T23:00:02Z",2],["2009-11-10T23:00:03Z",3],["2009-11-10T23:00:04Z",4],["2009-11-10T23:00:05Z",5]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit and offset with group by time",
 			command: `select mean(foo) from "limited" WHERE time >= '2009-11-10T23:00:02Z' AND time < '2009-11-10T23:00:06Z' GROUP BY TIME(1s) LIMIT 2 OFFSET 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","mean"],"values":[["2009-11-10T23:00:03Z",3],["2009-11-10T23:00:04Z",4]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit + offset equal to the number of points with group by time",
 			command: `select mean(foo) from "limited" WHERE time >= '2009-11-10T23:00:02Z' AND time < '2009-11-10T23:00:06Z' GROUP BY TIME(1s) LIMIT 3 OFFSET 3`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","columns":["time","mean"],"values":[["2009-11-10T23:00:05Z",5]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit - offset higher than number of points with group by time",
 			command: `select mean(foo) from "limited" WHERE time >= '2009-11-10T23:00:02Z' AND time < '2009-11-10T23:00:06Z' GROUP BY TIME(1s) LIMIT 2 OFFSET 20`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit - group by tennant",
 			command: `select foo from "limited" group by tennant limit 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","tags":{"tennant":"paul"},"columns":["time","foo"],"values":[["2009-11-10T23:00:02Z",2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "limit and offset - group by tennant",
 			command: `select foo from "limited" group by tennant limit 1 offset 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"limited","tags":{"tennant":"paul"},"columns":["time","foo"],"values":[["2009-11-10T23:00:03Z",3]]}]}]}`,
@@ -8766,61 +8763,61 @@ func TestServer_Query_Fill(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "fill with value",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s) FILL(1)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:10Z",1],["2009-11-10T23:00:15Z",10]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill with value, WHERE all values match condition",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' and val < 50 group by time(5s) FILL(1)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:10Z",1],["2009-11-10T23:00:15Z",10]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill with value, WHERE no values match condition",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' and val > 50 group by time(5s) FILL(1)`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill with previous",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s) FILL(previous)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:10Z",4],["2009-11-10T23:00:15Z",10]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill with none, i.e. clear out nulls",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s) FILL(none)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:15Z",10]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill defaults to null",
 			command: `select mean(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:10Z",null],["2009-11-10T23:00:15Z",10]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill defaults to 0 for count",
 			command: `select count(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","count"],"values":[["2009-11-10T23:00:00Z",2],["2009-11-10T23:00:05Z",1],["2009-11-10T23:00:10Z",0],["2009-11-10T23:00:15Z",1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill none drops 0s for count",
 			command: `select count(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s) fill(none)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","count"],"values":[["2009-11-10T23:00:00Z",2],["2009-11-10T23:00:05Z",1],["2009-11-10T23:00:15Z",1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill previous overwrites 0s for count",
 			command: `select count(val) from fills where time >= '2009-11-10T23:00:00Z' and time < '2009-11-10T23:00:20Z' group by time(5s) fill(previous)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","count"],"values":[["2009-11-10T23:00:00Z",2],["2009-11-10T23:00:05Z",1],["2009-11-10T23:00:10Z",1],["2009-11-10T23:00:15Z",1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "fill with implicit start time",
 			command: `select mean(val) from fills where time < '2009-11-10T23:00:20Z' group by time(5s)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"fills","columns":["time","mean"],"values":[["2009-11-10T23:00:00Z",4],["2009-11-10T23:00:05Z",4],["2009-11-10T23:00:10Z",null],["2009-11-10T23:00:15Z",10]]}]}]}`,
@@ -8873,70 +8870,70 @@ func TestServer_Query_By_Chunked_SingleMst(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 1",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"1"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 4",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"4"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false],["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true],["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true],["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 3 and inner chunk size 4",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"3"}, "inner_chunk_size": []string{"4"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false],["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true],["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false],["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true],["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 1 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false]],"partial":true}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 3 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"3"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "query with a single measurement by chunk size 5 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"5"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false],["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
 	}...)
 
@@ -8986,84 +8983,84 @@ func TestServer_Query_ShowMeasurementExactCardinality(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show measurement cardinality using FROM and regex`,
 			command: "SHOW MEASUREMENT CARDINALITY FROM /[cg]pu/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement cardinality using FROM and regex - no matches`,
 			command: "SHOW MEASUREMENT CARDINALITY FROM /.*zzzzz.*/",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement cardinality where tag matches regular expression`,
 			command: "SHOW MEASUREMENT CARDINALITY WHERE region =~ /ca.*/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement cardinality where tag does not match a regular expression`,
 			command: "SHOW MEASUREMENT CARDINALITY WHERE region !~ /ca.*/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement cardinality with time in WHERE clauses errors`,
 			command: `SHOW MEASUREMENT CARDINALITY WHERE time > now() - 1h`,
 			exp:     `{"results":[{"statement_id":0,"error":"SHOW MEASUREMENT CARDINALITY doesn't support time in WHERE clause"}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[3]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality using FROM`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY FROM cpu",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality using FROM and regex`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY FROM /[cg]pu/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality using FROM and regex - no matches`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY FROM /.*zzzzz.*/",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality where tag matches regular expression`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY WHERE region =~ /ca.*/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality where tag does not match a regular expression`,
 			command: "SHOW MEASUREMENT EXACT CARDINALITY WHERE region !~ /ca.*/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show measurement exact cardinality with time in WHERE clauses errors`,
 			command: `SHOW MEASUREMENT EXACT CARDINALITY WHERE time > now() - 1h`,
 			exp:     `{"results":[{"statement_id":0,"error":"SHOW MEASUREMENT CARDINALITY doesn't support time in WHERE clause"}]}`,
@@ -9119,25 +9116,25 @@ func TestServer_Query_ShowSeries(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `create measurement cpu`,
 			command: "CREATE MEASUREMENT cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    `drop measurement cpu`,
 			command: "DROP MEASUREMENT cpu",
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    `show series exact cardinality`,
 			command: "SHOW SERIES EXACT CARDINALITY",
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    `show series cardinality`,
 			command: "SHOW SERIES CARDINALITY",
 			params:  url.Values{"db": []string{"db0"}},
@@ -9189,31 +9186,31 @@ func TestServer_Query_ShowTagKeysWithCondition(t *testing.T) {
 	  these queries are all special mst, because more mst make the results no order, exp not match actual
 	*/
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show tag keys from mst and condition`,
 			command: "SHOW TAG KEYS FROM mst WHERE region=bj4",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["tagKey"],"values":[["cluster"],["label"],["region"],["server"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys with condition and special mst`,
 			command: "SHOW TAG KEYS FROM mst WHERE region=bj4 and time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["tagKey"],"values":[["cluster"],["label"],["region"],["server"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys with time condition`,
 			command: "SHOW TAG KEYS FROM mst WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["tagKey"],"values":[["cluster"],["label"],["others"],["region"],["server"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys with time condition and limit`,
 			command: "SHOW TAG KEYS FROM mst WHERE time > 0 limit 1",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["tagKey"],"values":[["cluster"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys with time condition and limit and offset`,
 			command: "SHOW TAG KEYS FROM mst WHERE time > 0 limit 1 offset 1",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["tagKey"],"values":[["label"]]}]}]}`,
@@ -9271,70 +9268,70 @@ func TestServer_Query_ShowTagKeys(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show tag keys`,
 			command: "SHOW TAG KEYS",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"disk","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys on db0`,
 			command: "SHOW TAG KEYS ON db0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"disk","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "show tag keys from",
 			command: "SHOW TAG KEYS FROM cpu",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag keys from regex",
 			command: "SHOW TAG KEYS FROM /[cg]pu/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag keys measurement not found",
 			command: "SHOW TAG KEYS FROM doesntexist",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag keys with time`,
 			command: "SHOW TAG KEYS WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"disk","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag keys on db0 with time`,
 			command: "SHOW TAG KEYS ON db0 WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"disk","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag keys with time from",
 			command: "SHOW TAG KEYS FROM cpu WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag keys with time from regex",
 			command: "SHOW TAG KEYS FROM /[cg]pu/ WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag keys with time where",
 			command: "SHOW TAG KEYS WHERE host = 'server03' AND time > 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["tagKey"],"values":[["host"],["region"]]},{"name":"gpu","columns":["tagKey"],"values":[["host"],["region"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag keys with time measurement not found",
 			command: "SHOW TAG KEYS FROM doesntexist WHERE time > 0",
 			exp:     `{"results":[{"statement_id":0}]}`,
@@ -9393,177 +9390,177 @@ func TestServer_Query_ShowTagValues(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "show tag values with key",
 			command: "SHOW TAG VALUES WITH KEY = host order by value asc",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag values with key regex",
 			command: "SHOW TAG VALUES WITH KEY =~ /ho/ order by value asc",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY = host WHERE region = 'uswest' order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key regex and where`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY =~ /ho/ WHERE region = 'uswest' order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where matches the regular expression`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region =~ /ca.*/ order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where does not match the regular expression`,
 			command: `SHOW TAG VALUES WITH KEY = region WHERE host !~ /server0[12]/ order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["key","value"],"values":[["region","caeast"]]},{"name":"gpu","columns":["key","value"],"values":[["region","caeast"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where partially matches the regular expression`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region =~ /us/ order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where partially does not match the regular expression`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region !~ /us/ order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key in and where does not match the regular expression`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY IN (host, region) WHERE region = 'uswest' order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["region","uswest"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key regex and where does not match the regular expression`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY =~ /(host|region)/ WHERE region = 'uswest' order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["region","uswest"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values with key and measurement matches regular expression`,
 			command: `SHOW TAG VALUES FROM /[cg]pu/ WITH KEY = host order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag values with key where time",
 			command: "SHOW TAG VALUES WITH KEY = host WHERE time > 0 order by value asc",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag values with key regex where time",
 			command: "SHOW TAG VALUES WITH KEY =~ /ho/ WHERE time > 0 order by value asc",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where time`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY = host WHERE region = 'uswest' AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key regex and where time`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY =~ /ho/ WHERE region = 'uswest' AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where matches the regular expression where time`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region =~ /ca.*/ AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where does not match the regular expression where time`,
 			command: `SHOW TAG VALUES WITH KEY = region WHERE host !~ /server0[12]/ AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["key","value"],"values":[["region","caeast"]]},{"name":"gpu","columns":["key","value"],"values":[["region","caeast"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where partially matches the regular expression where time`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region =~ /us/ AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and where partially does not match the regular expression where time`,
 			command: `SHOW TAG VALUES WITH KEY = host WHERE region !~ /us/ AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key in and where does not match the regular expression where time`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY IN (host, region) WHERE region = 'uswest' AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["region","uswest"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key regex and where does not match the regular expression where time`,
 			command: `SHOW TAG VALUES FROM cpu WITH KEY =~ /(host|region)/ WHERE region = 'uswest' AND time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["region","uswest"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values with key and measurement matches regular expression where time`,
 			command: `SHOW TAG VALUES FROM /[cg]pu/ WITH KEY = host WHERE time > 0 order by value asc`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"],["host","server02"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"],["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag values with value filter",
 			command: "SHOW TAG VALUES WITH KEY = host WHERE value = 'server03' order by value asc",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server03"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "show tag values with no matching value filter",
 			command: "SHOW TAG VALUES WITH KEY = host WHERE value = 'no_such_value' order by value asc",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag values with non-string value filter",
 			command: "SHOW TAG VALUES WITH KEY = host WHERE value = 5000 order by value asc",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag values with limit 1 offset 2",
 			command: "SHOW TAG VALUES FROM cpu WITH KEY = host order by value asc limit 1 offset 2",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag values with limit 1 offset 0",
 			command: "SHOW TAG VALUES WITH KEY = host order by value asc limit 1 offset 0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]},{"name":"disk","columns":["key","value"],"values":[["host","server03"]]},{"name":"gpu","columns":["key","value"],"values":[["host","server02"]]}]}]}`,
@@ -9620,159 +9617,159 @@ func TestServer_Query_ShowTagKeyCardinality(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show tag key cardinality`,
 			command: "SHOW TAG KEY CARDINALITY",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag key cardinality on db0`,
 			command: "SHOW TAG KEY CARDINALITY ON db0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "show tag key cardinality from",
 			command: "SHOW TAG KEY CARDINALITY FROM cpu",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key cardinality from regex",
 			command: "SHOW TAG KEY CARDINALITY FROM /[cg]pu/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key cardinality measurement not found",
 			command: "SHOW TAG KEY CARDINALITY FROM doesntexist",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key cardinality with time in WHERE clause errors",
 			command: "SHOW TAG KEY CARDINALITY FROM cpu WHERE time > now() - 1h",
 			exp:     `{"results":[{"statement_id":0,"error":"SHOW TAG KEY EXACT CARDINALITY doesn't support time in WHERE clause"}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag key exact cardinality`,
 			command: "SHOW TAG KEY EXACT CARDINALITY",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag key exact cardinality on db0`,
 			command: "SHOW TAG KEY EXACT CARDINALITY ON db0",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "show tag key exact cardinality from",
 			command: "SHOW TAG KEY EXACT CARDINALITY FROM cpu",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key exact cardinality from regex",
 			command: "SHOW TAG KEY EXACT CARDINALITY FROM /[cg]pu/",
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key exact cardinality measurement not found",
 			command: "SHOW TAG KEY EXACT CARDINALITY FROM doesntexist",
 			exp:     `{"results":[{"statement_id":0}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    "show tag key exact cardinality with time in WHERE clause errors",
 			command: "SHOW TAG KEY EXACT CARDINALITY FROM cpu WHERE time > now() - 1h",
 			exp:     `{"results":[{"statement_id":0,"error":"SHOW TAG KEY EXACT CARDINALITY doesn't support time in WHERE clause"}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key and where matches the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY WITH KEY = host WHERE region =~ /ca.*/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key and where does not match the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY WITH KEY = region WHERE host !~ /server0[12]/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key and where partially matches the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY WITH KEY = host WHERE region =~ /us/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key and where partially does not match the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY WITH KEY = host WHERE region !~ /us/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key in and where does not match the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY FROM cpu WITH KEY IN (host, region) WHERE region = 'uswest'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key regex and where does not match the regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY FROM cpu WITH KEY =~ /(host|region)/ WHERE region = 'uswest'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values cardinality with key and measurement matches regular expression`,
 			command: `SHOW TAG VALUES CARDINALITY FROM /[cg]pu/ WITH KEY = host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key and where matches the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY WITH KEY = host WHERE region =~ /ca.*/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key and where does not match the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY WITH KEY = region WHERE host !~ /server0[12]/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key and where partially matches the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY WITH KEY = host WHERE region =~ /us/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key and where partially does not match the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY WITH KEY = host WHERE region !~ /us/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"disk","columns":["count"],"values":[[1]]},{"name":"gpu","columns":["count"],"values":[[1]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key in and where does not match the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY FROM cpu WITH KEY IN (host, region) WHERE region = 'uswest'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key regex and where does not match the regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY FROM cpu WITH KEY =~ /(host|region)/ WHERE region = 'uswest'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show tag values exact cardinality with key and measurement matches regular expression`,
 			command: `SHOW TAG VALUES EXACT CARDINALITY FROM /[cg]pu/ WITH KEY = host`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[2]]}]}]}`,
@@ -9828,19 +9825,19 @@ func TestServer_Query_ShowFieldKeys(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show field keys`,
 			command: `SHOW FIELD KEYS`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["fieldKey","fieldType"],"values":[["field1","float"],["field2","float"],["field3","float"]]},{"name":"disk","columns":["fieldKey","fieldType"],"values":[["field8","float"],["field9","float"]]},{"name":"gpu","columns":["fieldKey","fieldType"],"values":[["field4","float"],["field5","float"],["field6","float"],["field7","float"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field keys from measurement`,
 			command: `SHOW FIELD KEYS FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["fieldKey","fieldType"],"values":[["field1","float"],["field2","float"],["field3","float"]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field keys measurement with regex`,
 			command: `SHOW FIELD KEYS FROM /[cg]pu/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["fieldKey","fieldType"],"values":[["field1","float"],["field2","float"],["field3","float"]]},{"name":"gpu","columns":["fieldKey","fieldType"],"values":[["field4","float"],["field5","float"],["field6","float"],["field7","float"]]}]}]}`,
@@ -9896,37 +9893,37 @@ func TestServer_Query_ShowFieldKeyCardinality(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show field key cardinality`,
 			command: `SHOW FIELD KEY CARDINALITY`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[4]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field key cardinality from measurement`,
 			command: `SHOW FIELD KEY CARDINALITY FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field key cardinality measurement with regex`,
 			command: `SHOW FIELD KEY CARDINALITY FROM /[cg]pu/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]},{"name":"gpu","columns":["count"],"values":[[4]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field key exact cardinality`,
 			command: `SHOW FIELD KEY EXACT CARDINALITY`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]},{"name":"disk","columns":["count"],"values":[[2]]},{"name":"gpu","columns":["count"],"values":[[4]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field key exact cardinality from measurement`,
 			command: `SHOW FIELD KEY EXACT CARDINALITY FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `show field key exact cardinality measurement with regex`,
 			command: `SHOW FIELD KEY EXACT CARDINALITY FROM /[cg]pu/`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[3]]},{"name":"gpu","columns":["count"],"values":[[4]]}]}]}`,
@@ -9979,13 +9976,13 @@ func TestServer_Query_TagOrder(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `group by tag1,tag2`,
 			command: `select * from cpu group by host,region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01","region":"useast"},"columns":["time","field1","field2","field3"],"values":[["2009-11-10T23:00:00Z",200,300,400]]},{"name":"cpu","tags":{"host":"server01","region":"uswest"},"columns":["time","field1","field2","field3"],"values":[["2009-11-10T23:00:00Z",200,300,400]]},{"name":"cpu","tags":{"host":"server02","region":"useast"},"columns":["time","field1","field2","field3"],"values":[["2009-11-10T23:00:00Z",200,300,400]]},{"name":"cpu","tags":{"host":"server03","region":""},"columns":["time","field1","field2","field3"],"values":[["2009-11-10T23:00:00Z",100,null,null]]}]}]}`,
 			params:  url.Values{"db": []string{"db0"}},
 		},
-		&Query{
+		{
 			name:    `group by tag2,tag1`,
 			command: `select * from cpu group by region,region`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"region":""},"columns":["time","field1","field2","field3","host"],"values":[["2009-11-10T23:00:00Z",100,null,null,"server03"]]},{"name":"cpu","tags":{"region":"useast"},"columns":["time","field1","field2","field3","host"],"values":[["2009-11-10T23:00:00Z",200,300,400,"server01"],["2009-11-10T23:00:00Z",200,300,400,"server02"]]},{"name":"cpu","tags":{"region":"uswest"},"columns":["time","field1","field2","field3","host"],"values":[["2009-11-10T23:00:00Z",200,300,400,"server01"]]}]}]}`,
@@ -10027,7 +10024,7 @@ func TestServer_Query_EvilIdentifiers(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `query evil identifiers`,
 			command: `SELECT "select", "in-bytes" FROM cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","select","in-bytes"],"values":[["2000-01-01T00:00:00Z",1,2]]}]}]}`,
@@ -10085,28 +10082,28 @@ func TestServer_Query_OrderByTime(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "order on points",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "cpu" ORDER BY time DESC`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:03Z",3],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:01Z",1]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "order desc with tags",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "power" ORDER BY time DESC`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"power","columns":["time","value"],"values":[["2000-01-01T00:00:04Z",4],["2000-01-01T00:00:03Z",3],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:01Z",1]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "order desc with sparse data",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select used, free from "mem" ORDER BY time DESC`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mem","columns":["time","used","free"],"values":[["2000-01-01T00:00:02Z",null,2],["2000-01-01T00:00:02Z",4,null],["2000-01-01T00:00:01Z",null,1],["2000-01-01T00:00:01Z",3,null]]}]}]}`,
 		},
 
-		&Query{
+		{
 			name:    "order desc with an aggregate and sparse data",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select first("used") AS "used", first("free") AS "free" from "mem" WHERE time >= '2000-01-01T00:00:01Z' AND time <= '2000-01-01T00:00:02Z' GROUP BY host, time(1s) FILL(none) ORDER BY time DESC`,
@@ -10151,13 +10148,13 @@ func TestServer_Query_FieldWithMultiplePeriods(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "baseline",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from cpu`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select field with periods",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select "foo.bar.baz" from cpu`,
@@ -10202,13 +10199,13 @@ func TestServer_Query_FieldWithMultiplePeriodsMeasurementPrefixMatch(t *testing.
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "baseline",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from foo`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"foo","columns":["time","foo.bar.baz"],"values":[["2000-01-01T00:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select field with periods",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select "foo.bar.baz" from foo`,
@@ -10257,14 +10254,14 @@ func TestServer_Query_IntoTarget(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "into",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * INTO baz FROM foo`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"result","columns":["time","written"],"values":[["1970-01-01T00:00:00Z",5]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "confirm results",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM baz`,
@@ -10310,7 +10307,7 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `select value at max nano time`,
 			params:  url.Values{"db": []string{"db0"}},
 			command: fmt.Sprintf(`SELECT value FROM cpu WHERE time <= %d`, models.MaxNanoTime),
@@ -10362,67 +10359,67 @@ func TestServer_WhereTimeInclusive(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "all GTE/LTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time >= '2000-01-01T00:00:01Z' and time <= '2000-01-01T00:00:03Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "all GTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time >= '2000-01-01T00:00:01Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "all LTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time <= '2000-01-01T00:00:03Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first GTE/LTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time >= '2000-01-01T00:00:01Z' and time <= '2000-01-01T00:00:01Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last GTE/LTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time >= '2000-01-01T00:00:03Z' and time <= '2000-01-01T00:00:03Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "before GTE/LTE",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time <= '2000-01-01T00:00:00Z'`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "all GT/LT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time > '2000-01-01T00:00:00Z' and time < '2000-01-01T00:00:04Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "first GT/LT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time > '2000-01-01T00:00:00Z' and time < '2000-01-01T00:00:02Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "last GT/LT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time > '2000-01-01T00:00:02Z' and time < '2000-01-01T00:00:04Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "all GT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time > '2000-01-01T00:00:00Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:01Z",1],["2000-01-01T00:00:02Z",2],["2000-01-01T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "all LT",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * from cpu where time < '2000-01-01T00:00:04Z'`,
@@ -10472,13 +10469,13 @@ func TestServer_Query_ImplicitEndTime(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "raw query",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT * FROM cpu`,
 			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["%s",1],["%s",2]]}]}]}`, past.Format(time.RFC3339Nano), future.Format(time.RFC3339Nano)),
 		},
-		&Query{
+		{
 			name:    "aggregate query",
 			params:  url.Values{"db": []string{"db0"}},
 			command: fmt.Sprintf(`SELECT mean(value) FROM cpu WHERE time > '%s' - 1m group by time(1h) FILL(none)`, now.Truncate(time.Minute).Format(time.RFC3339Nano)),
@@ -10523,7 +10520,7 @@ func TestServer_Query_Sample_Wildcard(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "sample() with wildcard",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sample(*, 1) FROM cpu`,
@@ -10571,20 +10568,20 @@ func TestServer_Query_Sample_LimitOffset(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "sample() with limit 1",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sample(float, 3), int FROM cpu LIMIT 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sample","int"],"values":[["2000-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "sample() with offset 1",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sample(float, 3), int FROM cpu OFFSET 1`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sample","int"],"values":[["2000-01-01T00:01:00Z",2,2],["2000-01-01T00:02:00Z",3,3]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "sample() with limit 1 offset 1",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sample(float, 3), int FROM cpu LIMIT 1 OFFSET 1`,
@@ -10630,14 +10627,14 @@ func TestServer_NestedAggregateWithMathPanics(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "dividing by elapsed count should not panic",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) / elapsed(sum(value), 1m) FROM cpu WHERE time > 0 AND time < 10m group by time(1h)`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","sum_elapsed"],"values":[["1970-01-01T00:00:00Z",null],["1970-01-01T00:01:00Z",null],["1970-01-01T00:02:00Z",null],["1970-01-01T00:03:00Z",null],["1970-01-01T00:04:00Z",null],["1970-01-01T00:05:00Z",null],["1970-01-01T00:06:00Z",null],["1970-01-01T00:07:00Z",null],["1970-01-01T00:08:00Z",null],["1970-01-01T00:09:00Z",null]]}]}]}`,
 			skip:    true,
 		},
-		&Query{
+		{
 			name:    "dividing by elapsed count with fill previous should not panic",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT sum(value) / elapsed(sum(value), 1m) FROM cpu WHERE time > 0 AND time < 10m group by time(1h) FILL(previous)`,
@@ -10679,10 +10676,10 @@ func TestServer_Query_SelectRelativeTime1(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "single point with time pre-calculated for past time queries yesterday",
 			command: `select v3 from db0.rp0.cpu where time>='2021-01-12T16:00:00Z'`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","v3"],"values":[["2021-01-12T16:00:00Z",false],["2021-01-13T16:00:00Z",true],["2021-01-14T16:00:00Z",false]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","v3"],"values":[["2021-01-12T16:00:00Z",false],["2021-01-13T16:00:00Z",true],["2021-01-14T16:00:00Z",false]]}]}]}`,
 		},
 	}...)
 
@@ -10712,7 +10709,7 @@ func TestServer_Write_OutOfOrder(t *testing.T) {
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    "create database with shard group duration and index duration should succeed",
 				command: `CREATE DATABASE db3 WITH SHARD DURATION 12h index duration 24h name rp3`,
 				exp:     `{"results":[{"statement_id":0}]}`,
@@ -10755,20 +10752,20 @@ func TestServer_Write_OutOfOrder(t *testing.T) {
 	}
 
 	test.queries = []*Query{
-		&Query{
+		{
 			name:    "select val from in date 2021-11-26 should success",
 			command: `select val from db3.rp3.cpu where time>='2021-11-26T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select val from in date 2021-11-27 should success",
 			command: `select val from db3.rp3.cpu where time>='2021-11-27T00:00:00Z' and time<='2021-11-27T23:00:00Z' and "host"='serverB'`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-27T10:00:00Z",106]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-27T10:00:00Z",106]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "select val from 25 to 26 should success",
 			command: `select val from db3.rp3.cpu where time>='2021-11-25T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-25T13:00:00Z",23.3],["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-25T13:00:00Z",23.3],["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`,
 		},
 	}
 
@@ -10841,13 +10838,13 @@ func TestServer_Query_OutOfOrder(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "out of order query",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "cpu"`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-02T00:00:01Z",111],["2000-01-02T00:00:02Z",222],["2000-01-02T00:00:03Z",333],["2000-01-03T00:00:01Z",1],["2000-01-03T00:00:02Z",2],["2000-01-03T00:00:03Z",3]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "out of order query desc",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "cpu" order by time desc`,
@@ -10890,25 +10887,25 @@ func TestServer_Query_FullSeries(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "full series and no result",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ full_series */ value from cpu where (host = 'server05' AND region = 'uswest')`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "full series and single tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ full_series */ value from cpu where (host = 'server01')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:00Z",100]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "full series normal",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ full_series */ value from cpu where (host = 'server01' AND region = 'uswest')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:00Z",101]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "full series or field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ full_series */ value from cpu where (host = 'server01' AND region = 'uswest' OR value > 99)`,
@@ -10957,25 +10954,25 @@ func TestServer_Query_SpecificSeries(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "specific series and no result",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ specific_series */ value from cpu where (host = 'server05' AND region = 'uswest')`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "specific series and single tag",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ specific_series */ value from cpu where (host = 'server01')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:00Z",100],["2009-11-10T23:00:00Z",101],["2009-11-10T23:00:00Z",102]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "specific series normal",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ specific_series */ value from cpu where (host = 'server01' AND region = 'uswest')`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:00Z",101]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "specific series or field",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select /*+ specific_series */ value from cpu where (host = 'server01' AND region = 'uswest' OR value > 99)`,
@@ -11016,35 +11013,35 @@ func TestServer_HintQuery_FilterNullColumn(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "show series",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `show series`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"columns":["key"],"values":[["mst,tk1=tv1"],["mst,tk1=tv2"],["mst,tk2=tv3"],["mst,tk2=tv4"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["key"],"values":[["mst,tk1=tv1"],["mst,tk1=tv2"],["mst,tk2=tv3"],["mst,tk2=tv4"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field with tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f1,*::tag from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",0,"tv1"],["2021-01-12T16:00:00Z",1,"tv2"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",0,"tv1"],["2021-01-12T16:00:00Z",1,"tv2"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field group by tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f1,*::tag from mst group by *::tag`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"tv1","tk2":""},"columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",0]]},{"name":"mst","tags":{"tk1":"tv2","tk2":""},"columns":["time","f1"],"values":[["2021-01-12T16:00:00Z",1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"tv1","tk2":""},"columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",0]]},{"name":"mst","tags":{"tk1":"tv2","tk2":""},"columns":["time","f1"],"values":[["2021-01-12T16:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field with tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f2,*::tag from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f2","tk2"],"values":[["2021-01-13T16:00:00Z",false,"tv3"],["2021-01-14T16:00:00Z",true,"tv4"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f2","tk2"],"values":[["2021-01-13T16:00:00Z",false,"tv3"],["2021-01-14T16:00:00Z",true,"tv4"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field group tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f2,*::tag from mst group by *::tag`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"","tk2":"tv3"},"columns":["time","f2"],"values":[["2021-01-13T16:00:00Z",false]]},{"name":"mst","tags":{"tk1":"","tk2":"tv4"},"columns":["time","f2"],"values":[["2021-01-14T16:00:00Z",true]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"","tk2":"tv3"},"columns":["time","f2"],"values":[["2021-01-13T16:00:00Z",false]]},{"name":"mst","tags":{"tk1":"","tk2":"tv4"},"columns":["time","f2"],"values":[["2021-01-14T16:00:00Z",true]]}]}]}`,
 		},
 	}...)
 
@@ -11081,47 +11078,47 @@ func TestServer_HintQuery_ManyNullColumns(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "show series",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `show series`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"columns":["key"],"values":[["mst,tk1=tv1"],["mst,tk1=tv2"],["mst,tk2=tv3"],["mst,tk3=tv4"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["key"],"values":[["mst,tk1=tv1"],["mst,tk1=tv2"],["mst,tk2=tv3"],["mst,tk3=tv4"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field f1 with tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f1,*::tag from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",0,"tv1"],["2021-01-12T16:00:00Z",1,"tv2"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",0,"tv1"],["2021-01-12T16:00:00Z",1,"tv2"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field f1 group by tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f1,*::tag from mst group by *::tag`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"tv1","tk2":"","tk3":""},"columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",0]]},{"name":"mst","tags":{"tk1":"tv2","tk2":"","tk3":""},"columns":["time","f1"],"values":[["2021-01-12T16:00:00Z",1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"tv1","tk2":"","tk3":""},"columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",0]]},{"name":"mst","tags":{"tk1":"tv2","tk2":"","tk3":""},"columns":["time","f1"],"values":[["2021-01-12T16:00:00Z",1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field f2 with tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f2,*::tag from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f2","tk2"],"values":[["2021-01-13T16:00:00Z",2,"tv3"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f2","tk2"],"values":[["2021-01-13T16:00:00Z",2,"tv3"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "single field f2 group tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Filter_Null_Column */ f2,*::tag from mst group by *::tag`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"","tk2":"tv3","tk3":""},"columns":["time","f2"],"values":[["2021-01-13T16:00:00Z",2]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","tags":{"tk1":"","tk2":"tv3","tk3":""},"columns":["time","f2"],"values":[["2021-01-13T16:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "exact count query",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Exact_Statistic_Query */ count(*) from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f2","count_f3"],"values":[["1970-01-01T00:00:00Z",2,1,1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f2","count_f3"],"values":[["1970-01-01T00:00:00Z",2,1,1]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "exact first query",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Exact_Statistic_Query */ first(*) from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","first_f1","first_f2","first_f3"],"values":[["1970-01-01T00:00:00Z",0,2,true]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","first_f1","first_f2","first_f3"],"values":[["1970-01-01T00:00:00Z",0,2,true]]}]}]}`,
 		},
 	}...)
 
@@ -11163,17 +11160,17 @@ func TestServer_HintLimit(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "exact limit * query",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Exact_Statistic_Query */ * from mst limit 1`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",1,"tv1"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","tk1"],"values":[["2021-01-11T16:00:00Z",1,"tv1"]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "exact limit field query",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select /*+ Exact_Statistic_Query */ f1 from mst limit 1`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1"],"values":[["2021-01-11T16:00:00Z",1]]}]}]}`,
 		},
 	}...)
 
@@ -11206,11 +11203,11 @@ func TestServer_FullJoin(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "full join on one tag",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select m1.f1, m2.f1 from (select f1 from mst) as m1 full join (select f1 from mst) as m2 on (m1.tk1 = m2.tk1) group by tk1`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"m1,m2","tags":{"tk1":"tv1"},"columns":["time","m1.f1","m2.f1"],"values":[["2021-01-11T16:00:00Z",1,1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"m1,m2","tags":{"tk1":"tv1"},"columns":["time","m1.f1","m2.f1"],"values":[["2021-01-11T16:00:00Z",1,1]]}]}]}`,
 		},
 	}...)
 
@@ -11326,13 +11323,13 @@ func TestServer_Write_Compatible(t *testing.T) {
 			name:    "select count(*) from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select count(*) from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f2","count_f3"],"values":[["1970-01-01T00:00:00Z",2,1,1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f2","count_f3"],"values":[["1970-01-01T00:00:00Z",2,1,1]]}]}]}`,
 		},
 		{
 			name:    "select * from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","f2","f3","tk1","tk3"],"values":[["2022-06-10T22:00:00Z",2,null,null,"tv1",null],["2022-06-10T22:01:00Z",3,2,null,"tv1",null],["2022-06-10T23:00:00Z",null,null,99,null,"tv4"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","f2","f3","tk1","tk3"],"values":[["2022-06-10T22:00:00Z",2,null,null,"tv1",null],["2022-06-10T22:01:00Z",3,2,null,"tv1",null],["2022-06-10T23:00:00Z",null,null,99,null,"tv4"]]}]}]}`,
 		},
 	}...)
 
@@ -11373,13 +11370,13 @@ func TestServer_DuplicateField(t *testing.T) {
 			name:    "select count(*) from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select count(*) from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f3"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1","count_f3"],"values":[["1970-01-01T00:00:00Z",1,1]]}]}]}`,
 		},
 		{
 			name:    "select * from mst",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select * from mst`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","f3","tk1","tk3"],"values":[["2022-06-10T22:00:00Z",2,null,"tv1",null],["2022-06-10T23:00:00Z",null,99,null,"tv4"]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","f1","f3","tk1","tk3"],"values":[["2022-06-10T22:00:00Z",2,null,"tv1",null],["2022-06-10T23:00:00Z",null,99,null,"tv4"]]}]}]}`,
 		},
 	}...)
 	_ = test.init(s)
@@ -11418,17 +11415,17 @@ func TestServer_Field_Not_In_Condition(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "field condition exists",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where f1= 2`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_f1"],"values":[["1970-01-01T00:00:00Z",2]]}]}]}`),
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_f1"],"values":[["1970-01-01T00:00:00Z",2]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field condition not exist",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where f2=3`,
-			exp:     fmt.Sprintf(`{"results":[{"statement_id":0}]}`),
+			exp:     `{"results":[{"statement_id":0}]}`,
 		},
 	}...)
 
@@ -11706,7 +11703,7 @@ func TestServer_HoltWinters(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "holt_winters query",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `SELECT HOLT_WINTERS(FIRST(value),6,4) FROM cpu WHERE  time >= '2020-08-10T07:00:00Z' AND time <= '2020-08-10T08:50:00Z' GROUP BY time(20m)`,
@@ -11776,19 +11773,19 @@ func TestServer_FieldIndex_Query(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    `show series exact cardinality`,
 			command: "SHOW SERIES EXACT CARDINALITY",
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["count"],"values":[[6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    `show series cardinality`,
 			command: "SHOW SERIES CARDINALITY",
 			params:  url.Values{"db": []string{"db0"}},
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["startTime","endTime","count"],"values":[["2009-11-09T00:00:00Z","2009-11-16T00:00:00Z",6]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    `select * from cpu group by field_index`,
 			command: "SELECT * FROM cpu GROUP BY field_index",
 			params:  url.Values{"db": []string{"db0"}},
@@ -11831,37 +11828,37 @@ func TestServer_TagArray(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "field condition exists 1",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where f1=2`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_f1"],"values":[["1970-01-01T00:00:00Z",16]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field condition exist 2",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where f1=10`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_f1"],"values":[["1970-01-01T00:00:00Z",20]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "field condition not exist",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where f2=3`,
 			exp:     `{"results":[{"statement_id":0}]}`,
 		},
-		&Query{
+		{
 			name:    "no filed condition of sum",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","sum_f1"],"values":[["1970-01-01T00:00:00Z",45]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "no filed condition of count",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select count(*) from mst`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"mst","columns":["time","count_f1"],"values":[["1970-01-01T00:00:00Z",11]]}]}]}`,
 		},
-		&Query{
+		{
 			name:    "tag condition",
 			params:  url.Values{"db": []string{"db0"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"1"}},
 			command: `select sum(*) from mst where tk1='tv4'`,
@@ -11910,47 +11907,47 @@ func TestServer_SubscriptionCommands(t *testing.T) {
 
 	test := Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    `CREATE SUBSCRIPTION`,
 				command: fmt.Sprintf("create subscription subs0 on db0.rp0 destinations all \"%s\", \"%s\"", server1.URL, server2.URL),
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `SHOW SUBSCRIPTIONS`,
 				command: "SHOW SUBSCRIPTIONS",
 				exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["rp0","subs0","ALL",["%s","%s"]]]}]}]}`, server1.URL, server2.URL),
 			},
-			&Query{
+			{
 				name:    `DROP SUBSCRIPTION subs0`,
 				command: "drop subscription subs0 on db0.rp0",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `SHOW SUBSCRIPTIONS AFTER DROP`,
 				command: "SHOW SUBSCRIPTIONS",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `RECREATE SUBSCRIPTION AFTER DROP`,
 				command: fmt.Sprintf("create subscription subs0 on db0.rp0 destinations all \"%s\", \"%s\"", server1.URL, server2.URL),
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `SHOW SUBSCRIPTIONS`,
 				command: "SHOW SUBSCRIPTIONS",
 				exp:     fmt.Sprintf(`{"results":[{"statement_id":0,"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["rp0","subs0","ALL",["%s","%s"]]]}]}]}`, server1.URL, server2.URL),
 			},
-			&Query{
+			{
 				name:    `DROP ALL SUBSCRIPTIONS ON db0`,
 				command: "DROP ALL SUBSCRIPTIONS ON db0",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `SHOW SUBSCRIPTIONS AFTER DROP`,
 				command: "SHOW SUBSCRIPTIONS",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `CREATE SUBSCRIPTION WITH INVALID URL`,
 				command: "create subscription subs0 on db0.rp0 destinations all \"127.0.0.3:8086\"",
 				exp:     `{"results":[{"statement_id":0,"error":"invalid url 127.0.0.3:8086"}]}`,
@@ -12012,17 +12009,17 @@ func TestServer_SubscriptionForward(t *testing.T) {
 	}
 	test := &Test{
 		queries: []*Query{
-			&Query{
+			{
 				name:    `CREATE ALL MODE SUBSCRIPTION`,
 				command: fmt.Sprintf("create subscription subs0 on db0.rp0 destinations all \"%s\", \"%s\"", server1.URL, server2.URL),
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `DROP SUBSCRIPTION subs0`,
 				command: "drop subscription subs0 on db0.rp0",
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
-			&Query{
+			{
 				name:    `CREATE ANY MODE SUBSCRIPTION`,
 				command: fmt.Sprintf("create subscription subs0 on db0.rp0 destinations any \"%s\", \"%s\"", server1.URL, server2.URL),
 				exp:     `{"results":[{"statement_id":0}]}`,
@@ -12171,7 +12168,7 @@ func TestServer_ParallelQuery(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "order on points",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from "cpu" ORDER BY time DESC;select value from "power" ORDER BY time DESC;select used, free from "mem" ORDER BY time DESC`,
@@ -12216,7 +12213,7 @@ func TestServer_TSSubQueryHasDifferentAscending(t *testing.T) {
 	}
 
 	test.addQueries([]*Query{
-		&Query{
+		{
 			name:    "different ascending",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select f1 from (select f1 from mem order by time asc) order by time desc`,


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
the test code uses a lot of `fmt.Sprintf`, which is unnecessary in some use cases.

### What is changed and how it works?
Following staticcheck's style standard [S1039](https://staticcheck.dev/docs/checks/#S1039), I optimized the use of `fmt.Sprintf` in  test cases.
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules