### PR TITLE
chore: replace deprecated function calls with their recommended alternatives

### DIFF
--- a/app/ts-meta/meta/cluster_manager.go
+++ b/app/ts-meta/meta/cluster_manager.go
@@ -455,8 +455,8 @@ func (cm *ClusterManager) chooseNodeByPtNum(nodePtNumMap *map[uint64]uint32) uin
 }
 
 func (cm *ClusterManager) chooseNodeRandom(nodeIds []int) uint64 {
-	rand.Seed(time.Now().UnixNano())
-	i := rand.Intn(len(nodeIds))
+	source := rand.New(rand.NewSource(time.Now().UnixNano()))
+	i := source.Intn(len(nodeIds))
 	return uint64(nodeIds[i])
 }
 

--- a/app/ts-meta/meta/raft_wrapper.go
+++ b/app/ts-meta/meta/raft_wrapper.go
@@ -120,7 +120,8 @@ func (r *raftWrapper) Leader() string {
 	if r == nil || r.raft == nil {
 		return ""
 	}
-	return string(r.raft.Leader())
+	id, _ := r.raft.LeaderWithID()
+	return string(id)
 }
 
 func (r *raftWrapper) UserSnapshot() error {

--- a/lib/util/lifted/hashicorp/serf/serf/snapshot.go
+++ b/lib/util/lifted/hashicorp/serf/serf/snapshot.go
@@ -3,6 +3,7 @@ package serf
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -540,7 +541,7 @@ func (s *Snapshotter) compact() error {
 // state
 func (s *Snapshotter) replay() error {
 	// Seek to the beginning
-	if _, err := s.fh.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := s.fh.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 
@@ -620,7 +621,7 @@ func (s *Snapshotter) replay() error {
 	}
 
 	// Seek to the end
-	if _, err := s.fh.Seek(0, os.SEEK_END); err != nil {
+	if _, err := s.fh.Seek(0, io.SeekEnd); err != nil {
 		return err
 	}
 	return nil

--- a/lib/util/lifted/influx/httpd/consume/consume.go
+++ b/lib/util/lifted/influx/httpd/consume/consume.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package consume
 
 import (
@@ -20,7 +21,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -351,7 +352,7 @@ func decompress(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	output, err := ioutil.ReadAll(comp)
+	output, err := io.ReadAll(comp)
 	comp.Close()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

This PR addresses the usage of several deprecated functions in project. We are updating these calls to use their recommended alternatives to ensure our codebase remains up-to-date and to avoid potential issues in future go and dependencies versions.

### What is changed and how it works?
The following deprecated functions have been replaced:

1. `ioutil.ReadAll` -> `io.ReadAll`
2. `rand.Seed` -> `rand.NewSource`
3. `raft.Leader` -> `raft.LeaderWithID`
4. `os.SEEK_SET` -> `io.SeekStart`
5. `os.SEEK_END` -> `io.SeekeND`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
