### PR TITLE
chore: fix test case 'TestServer_Query_By_Chunked_SingleMst'

### DIFF
--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -8875,65 +8875,65 @@ func TestServer_Query_By_Chunked_SingleMst(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"1"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
 		{
 			name:    "query with a single measurement by chunk size 4",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"4"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false],["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true],["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true],["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
 		{
 			name:    "query with a single measurement by chunk size 3 and inner chunk size 4",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"3"}, "inner_chunk_size": []string{"4"}},
 			command: `SELECT * FROM survey`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu","China",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen","China",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai","China",150,"demon",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false],["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true],["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing","China",167,"king",false],["2021-07-06T07:57:22.121Z",31,"elilansa","Egypt",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo","Egypt",178,"daisy",true]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","columns":["time","age","city","country","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris","France",164,"paul",true],["2021-07-06T07:57:22.124Z",35,"bakeli","Germany",169,"frank",true],["2021-07-06T07:57:22.125Z",21,"dongjin","Japan",190,"jack",true]]}]}]}`,
 		},
 		{
 			name:    "query with a single measurement by chunk size 1 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"1"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false]],"partial":true}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
 		{
 			name:    "query with a single measurement by chunk size 3 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"3"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false]],"partial":true}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
 		{
 			name:    "query with a single measurement by chunk size 5 and inner chunk size 3",
 			params:  url.Values{"db": []string{"db0"}, "chunked": []string{"true"}, "chunk_size": []string{"5"}, "inner_chunk_size": []string{"3"}},
 			command: `SELECT * FROM survey group by country`,
 			exp: `{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"China"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:20.121Z",15,"chengdu",170,"ada",false],["2021-07-06T07:57:20.122Z",27,"shenzhen",165,"billy",false],["2021-07-06T07:57:20.123Z",57,"shanghai",150,"demon",false],["2021-07-06T07:57:20.124Z",22,"beijing",167,"king",false]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
-		{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Egypt"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.121Z",31,"elilansa",159,"chris",false],["2021-07-06T07:57:22.122Z",40,"gunilanduo",178,"daisy",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"France"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.123Z",45,"paris",164,"paul",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Germany"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.124Z",35,"bakeli",169,"frank",true]]}],"partial":true}]}
+{"results":[{"statement_id":0,"series":[{"name":"survey","tags":{"country":"Japan"},"columns":["time","age","city","height","name","sex"],"values":[["2021-07-06T07:57:22.125Z",21,"dongjin",190,"jack",true]]}]}]}`,
 		},
 	}...)
 


### PR DESCRIPTION
Every time I submit a PR, CI fails. The reason is that the test case `TestServer_Query_By_Chunked_SingleMst` fails. 
The test data format set for this test case is the same as the returned result data content, but the data format is inconsistent, with two extra `\t` symbols in each line.
This PR mainly solves the problem of this test case failing.

```
> URL=http://127.0.0.1:8086 go test -mod=mod -test.parallel 1 -timeout 10m ./tests -v -run TestServer_Query_By_Chunked_SingleMst GOCACHE=off
============= Running all tests for "tsi" index =============
=== RUN   TestServer_Query_By_Chunked_SingleMst
=== PAUSE TestServer_Query_By_Chunked_SingleMst
=== CONT  TestServer_Query_By_Chunked_SingleMst
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_1
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_4
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_3_and_inner_chunk_size_4
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_1_and_inner_chunk_size_3
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_3_and_inner_chunk_size_3
=== RUN   TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_5_and_inner_chunk_size_3
--- PASS: TestServer_Query_By_Chunked_SingleMst (4.73s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_1 (1.46s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_4 (0.00s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_3_and_inner_chunk_size_4 (0.00s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_1_and_inner_chunk_size_3 (0.00s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_3_and_inner_chunk_size_3 (0.00s)
    --- PASS: TestServer_Query_By_Chunked_SingleMst/query_with_a_single_measurement_by_chunk_size_5_and_inner_chunk_size_3 (0.00s)
PASS

ok  	github.com/openGemini/openGemini/tests	9.233s
```