### PR TITLE
fix: routing compatibility with the stdlib pprof.Index

### DIFF
--- a/lib/util/lifted/influx/httpd/pprof.go
+++ b/lib/util/lifted/influx/httpd/pprof.go
@@ -27,6 +27,9 @@ func (h *Handler) handleProfiles(w http.ResponseWriter, r *http.Request) {
 		httppprof.Symbol(w, r)
 	case "/debug/pprof/all":
 		h.archiveProfilesAndQueries(w, r)
+	case "/debug/pprof":
+		// redirect /debug/pprof to /debug/pprof/ to maintain routing compatibility with the stdlib pprof.Index
+		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
 	default:
 		httppprof.Index(w, r)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

When accessing `/debug/pprof`, the hyperlink rendering of the pprof page is incorrect, need to redirect `/debug/pprof` to `/debug/pprof/`

I found that when I run `ts-server`, whether it is Linux or Windows, this problem occurs.

### What is changed and how it works?
redirect `/debug/pprof` to `/debug/pprof/` to maintain routing compatibility with the stdlib `pprof.Index`

