### PR TITLE
fix: release file handle before delete index file

### DIFF
--- a/lib/util/lifted/vm/mergeset/table.go
+++ b/lib/util/lifted/vm/mergeset/table.go
@@ -258,16 +258,17 @@ func (pw *partWrapper) decRef() {
 		return
 	}
 
+	// Release the file handle before deleting the file to prevent the service from panicking when running on Windows.
+	pw.p.MustClose()
 	if pw.removeWG != nil {
 		fs.MustRemoveAllWithDoneCallback(pw.p.path, pw.lock, pw.removeWG.Done)
 	}
+	pw.p = nil
 
 	if pw.mp != nil {
 		putInmemoryPart(pw.mp)
 		pw.mp = nil
 	}
-	pw.p.MustClose()
-	pw.p = nil
 }
 
 // OpenTable opens a table on the given path.


### PR DESCRIPTION
### What problem does this PR solve?

When running the `ts-server` process on a local Windows machine and inserting data into the DB continuously, the service will crash after a period of time. The reason is that when Windows compresses the index file, it cannot delete the opened file handle.

### What is changed and how it works?

Before deleting a file, close the file handle to be compatible with the Windows file system.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
