### PR TITLE
fix: inverted index of text does not guarantee the orderliness of the last few items during merging

### DIFF
--- a/engine/index/clv/merger.go
+++ b/engine/index/clv/merger.go
@@ -145,21 +145,20 @@ func mergeDocIdxItems(data []byte, items []mergeset.Item) ([]byte, []mergeset.It
 	dstData := data[:0]
 	dstItems := items[:0]
 
-	// The merged item of multiple items may be smaller than the old items. Special
-	// processing is required for the first item: Items with the same key as the first item will not be merged.
-	var noMerge bool
-	var item0 []byte
+	// The merged item of multiple items may be smaller than the old items.
+	// Special processing is required for the first and last item:
+	// Items with the same key as the first item or last item will not be merged.
+	noMerge := false
+	comFirstItem := true
 	m := mergerPool.Get()
 	for i, it := range items {
 		item := it.Bytes(data)
-
-		if i == 0 {
-			item0 = item
-			noMerge = true
+		if comFirstItem {
+			noMerge = keysEqual(firstItem, item)
+			comFirstItem = noMerge
 		}
-
-		if noMerge {
-			noMerge = keysEqual(item0, item)
+		if !comFirstItem {
+			noMerge = keysEqual(lastItem, item)
 		}
 
 		if len(item) == 0 || item[0] != txPrefixPos || i == 0 || i == len(items)-1 || noMerge {


### PR DESCRIPTION
inverted index of text does not guarantee the orderliness of the last few items during merging

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #699 

### What is changed and how it works?
inverted index of text does not guarantee the orderliness of the last few items during merging

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Test cases to be added
- [ ] No code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
