### PR TITLE
fix: revise the SQL syntax for querying metrics when mst is keyword

### DIFF
--- a/lib/util/lifted/influx/httpd/handler_metrics.go
+++ b/lib/util/lifted/influx/httpd/handler_metrics.go
@@ -108,7 +108,7 @@ func getMetrics(h *Handler, r *http.Request, user meta.User, tableName string) (
 	nodeID, _ := strconv.ParseUint(r.FormValue("node_id"), 10, 64)
 	var q *influxql.Query
 	var err error
-	sql := fmt.Sprintf("select last(*) from %s where time >= now()-1m group by *", tableName)
+	sql := fmt.Sprintf("select last(*) from '%s' where time >= now()-1m group by *", tableName)
 
 	qr := strings.NewReader(sql)
 	q, err, _ = h.getSqlQuery(r, qr)


### PR DESCRIPTION
When the table name of internal is a keyword, the data in this table cannot be queried, such as `compact`, please use quotation marks to wrap it