### PR TITLE
fix: omit SetInfosAndTraits when hybridqp.Trait is nil

### DIFF
--- a/engine/executor/select.go
+++ b/engine/executor/select.go
@@ -252,7 +252,7 @@ func (p *preparedStatement) Select(ctx context.Context) (hybridqp.Executor, erro
 		executorBuilder.Analyze(span)
 	}
 	// ts-server + tsEngine remove node_exchange
-	if localStorageForQuery != nil {
+	if localStorageForQuery != nil && req != nil {
 		executorBuilder.(*ExecutorBuilder).SetInfosAndTraits(req.([]*MultiMstReqs), ctx)
 	}
 	return executorBuilder.Build(best)


### PR DESCRIPTION
when running `ts-server` locally, if `p.stmt.Fields` is empty during called `BuildLogicalPlan`, `hybridqp.Trait` (variable `req`) will be nil and the program will be panic due to `req.([]*MultiMstReqs)`
https://github.com/openGemini/openGemini/blob/8edd60e87beaec6a9ce82f37879c33577534efab/engine/executor/select.go#L256