### PR TITLE
fix: add metrics name prefix opengemini_module

### DIFF
--- a/lib/util/lifted/influx/httpd/handler_metrics.go
+++ b/lib/util/lifted/influx/httpd/handler_metrics.go
@@ -37,6 +37,7 @@ import (
 const (
 	internalDatabase       = "_internal"
 	defaultRetentionPolicy = "autogen"
+	namespace              = "opengemini"
 )
 
 var (
@@ -80,8 +81,7 @@ func (c *OpenGeminiCollector) Collect(ch chan<- prometheus.Metric) {
 					labelValues = append(labelValues, value)
 				}
 
-				var desc = metrics.NewDesc("", metricName, "", labelKeys)
-
+				var desc = metrics.NewDesc(namespace+"_"+moduleName, metricName, "", labelKeys)
 				metric, ok := metricValue.(float64)
 				if !ok {
 					continue


### PR DESCRIPTION
the indicator names of the current indicator system do not use special prefixes as identifiers, which is prone to conflicts. this pr adds `opengemini_module` as the indicator prefix.