### PR TITLE
fix: standalone server support write points

### DIFF
--- a/config/monitor.conf
+++ b/config/monitor.conf
@@ -50,4 +50,3 @@
   max-num = 30
   max-age = 7
   compress-enabled = true
-

--- a/config/openGemini.singlenode.conf
+++ b/config/openGemini.singlenode.conf
@@ -1,6 +1,6 @@
 [common]
   meta-join = ["127.0.0.1:8092"]
-  ha-policy = "replication"
+  ha-policy = "write-available-first"
   ignore-empty-tag = true
 
 [meta]
@@ -35,28 +35,17 @@
 [gossip]
   enabled = false
 
-[clv_config]
-  enabled = false
-  # q-max is maximum token length of V-token(Variable Length Token) tokenizer.
-  q-max = 7
-  # document-count indicates how many documents are collected for generating V-token tokenizer.
-  document-count = 500000
-  # token-threshold indicates the pruning frequency of all tokens for the collected documents.
-  token-threshold = 100
-
-[castor]
-  enabled = false
-  pyworker-addr = ["127.0.0.1:6666"]  # format: ip:port
-  # connect-pool-size = 30  # connection pool to pyworker
-  # result-wait-timeout = 10  # unit: second
-  [castor.detect]
-    algorithm = ['BatchDIFFERENTIATEAD','DIFFERENTIATEAD','IncrementalAD','ThresholdAD','ValueChangeAD']
-    config_filename = ['detect_base']
-  [castor.fit_detect]
-    algorithm = ['BatchDIFFERENTIATEAD','DIFFERENTIATEAD','IncrementalAD','ThresholdAD','ValueChangeAD']
-    config_filename = ['detect_base']
-
 [spec-limit]
   enable-query-when-exceed = true
   query-series-limit = 0
   query-schema-limit = 0
+
+[monitor]
+  pushers = "http"
+  store-enabled = true
+  store-database = "_internal"
+  store-interval = "10s"
+  store-path = "/tmp/openGemini/metric/{{id}}/metric.data"
+  compress = false
+  https-enabled = false
+  http-endpoint = "127.0.0.1:8086"


### PR DESCRIPTION
1. ha-policy `replication` to `write-available-first`
2. add monitor module to stand-alone service configuration
3. remove `[clv_config]` and `[castor]` config node, those features does not necessarily have to be the default option
4. delete the empty line at the end of the configuration file