### PR TITLE
feat: implement prometheus pull monitoring metrics data by ts-monitor

### DIFF
--- a/app/ts-monitor/collector/report.go
+++ b/app/ts-monitor/collector/report.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openGemini/openGemini/lib/errno"
 	"github.com/openGemini/openGemini/lib/fileops"
 	"github.com/openGemini/openGemini/lib/logger"
+	"github.com/openGemini/openGemini/lib/metrics"
 	"github.com/openGemini/openGemini/lib/statisticsPusher/pusher"
 	"github.com/openGemini/openGemini/lib/util"
 	"go.uber.org/zap"
@@ -102,6 +103,9 @@ type ReportJob struct {
 
 	compress   bool // is metric file compressed
 	reportStat *ReportStat
+
+	mux            *sync.RWMutex
+	indexModuleMap map[string][]*metrics.ModuleIndex
 }
 
 func NewReportJob(logger *logger.Logger, c *config.TSMonitor, gzipped bool, errLogHistory string) *ReportJob {
@@ -130,20 +134,22 @@ func NewReportJob(logger *logger.Logger, c *config.TSMonitor, gzipped bool, errL
 	queryHeader.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	mr := &ReportJob{
-		storeDatabase: r.Database,
-		storeRP:       r.Rp,
-		storeDuration: time.Duration(r.RpDuration),
-		writeUrl:      writeUrl,
-		writeHeader:   writeHeader,
-		queryUrl:      queryUrl,
-		queryHeader:   queryHeader,
-		compress:      m.Compress,
-		gzipped:       gzipped,
-		done:          make(chan struct{}),
-		logger:        logger,
-		errLogHistory: errLogHistory,
-		errLogStat:    make(map[string]string),
-		reportStat:    NewReportStat(),
+		storeDatabase:  r.Database,
+		storeRP:        r.Rp,
+		storeDuration:  time.Duration(r.RpDuration),
+		writeUrl:       writeUrl,
+		writeHeader:    writeHeader,
+		queryUrl:       queryUrl,
+		queryHeader:    queryHeader,
+		compress:       m.Compress,
+		gzipped:        gzipped,
+		done:           make(chan struct{}),
+		logger:         logger,
+		errLogHistory:  errLogHistory,
+		errLogStat:     make(map[string]string),
+		reportStat:     NewReportStat(),
+		mux:            new(sync.RWMutex),
+		indexModuleMap: make(map[string][]*metrics.ModuleIndex),
 	}
 	mr.Client = defaultClient
 	return mr
@@ -274,6 +280,7 @@ func (rb *ReportJob) ReportMetric(filename string) error {
 			buf.WriteByte('\n')
 
 			pusher.PutBuffer(line)
+			rb.parseIndex(line)
 			if err := rb.postData(&buf, &batch, MinBatchSize); err != nil {
 				return err
 			}
@@ -288,6 +295,67 @@ func (rb *ReportJob) ReportMetric(filename string) error {
 			return nil
 		}
 	}
+}
+
+func (rb *ReportJob) parseIndex(line []byte) {
+	var (
+		moduleName  string
+		metricSlice = make([]*metrics.ModuleIndex, 0)
+	)
+
+	lines := strings.Split(string(line), "\n")
+
+	//Data format of each row: {table name},{labels} {indicator data} {timestamp}
+	for _, value := range lines {
+		m := metrics.ModuleIndex{
+			LabelValues: make(map[string]string),
+			MetricsMap:  make(map[string]interface{}),
+			Timestamp:   time.Now(),
+		}
+		parts := strings.Split(value, " ")
+		if len(parts) != 3 {
+			rb.logger.Error("invalid metric line:", zap.String("line", value))
+			continue
+		}
+		tmp := strings.Split(parts[0], ",")
+		if len(tmp) != 2 {
+			rb.logger.Error("invalid metric line:", zap.String("line", value))
+			continue
+		}
+		moduleName = tmp[0]
+		// parse labels
+		labels := tmp[1:]
+		for _, label := range labels {
+			labelKv := strings.Split(label, "=")
+			m.LabelValues[labelKv[0]] = labelKv[1]
+		}
+		// parse index
+		indexes := strings.Split(parts[1], ",")
+		for _, index := range indexes {
+			indexKv := strings.Split(index, "=")
+			if len(indexKv) != 2 {
+				rb.logger.Error("invalid metric index:", zap.String("index", index))
+				continue
+			}
+			value, err := strconv.ParseFloat(indexKv[1], 64)
+			if err != nil {
+				rb.logger.Error("parse index failed", zap.String("file", moduleName), zap.String("index", index), zap.Error(err))
+				m.MetricsMap[indexKv[0]] = indexKv[1]
+			} else {
+				m.MetricsMap[indexKv[0]] = value
+			}
+		}
+		metricSlice = append(metricSlice, &m)
+	}
+	rb.mux.Lock()
+	rb.indexModuleMap[moduleName] = metricSlice
+	rb.mux.Unlock()
+}
+
+func (rb *ReportJob) GetIndexModuleMap() map[string][]*metrics.ModuleIndex {
+	rb.mux.RLock()
+	defer rb.mux.RUnlock()
+	return rb.indexModuleMap
 }
 
 func (rb *ReportJob) postData(buf *bytes.Buffer, batch *int, minSize int) error {

--- a/app/ts-monitor/run/handler_metrics.go
+++ b/app/ts-monitor/run/handler_metrics.go
@@ -1,0 +1,81 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"net/http"
+
+	"github.com/openGemini/openGemini/app/ts-monitor/collector"
+	"github.com/openGemini/openGemini/lib/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	metricMsts = []string{"httpd", "performance", "io", "executor", "system", "runtime",
+		"spdy", "measurement_metric", "cluster_metric", "sql_slow_queries", "errno"}
+	namespace = "opengemini"
+)
+
+type MonitorCollector struct {
+	metricsCollector *collector.Collector
+}
+
+func NewMonitorCollector(metricsCollector *collector.Collector) *MonitorCollector {
+	c := &MonitorCollector{
+		metricsCollector: metricsCollector,
+	}
+	return c
+}
+
+func (c *MonitorCollector) Describe(ch chan<- *prometheus.Desc) {
+
+}
+
+func (c *MonitorCollector) Collect(ch chan<- prometheus.Metric) {
+	indexMap := c.metricsCollector.Reporter.GetIndexModuleMap()
+	for _, moduleName := range metricMsts {
+		metricSlice, ok := indexMap[moduleName]
+		if !ok {
+			continue
+		}
+		for _, metricIndex := range metricSlice {
+			for metricName, metricValue := range metricIndex.MetricsMap {
+
+				var labelKeys, labelValues []string
+				for key, value := range metricIndex.LabelValues {
+					labelKeys = append(labelKeys, key)
+					labelValues = append(labelValues, value)
+				}
+
+				var desc = metrics.NewDesc(namespace+"_"+moduleName, metricName, "", labelKeys)
+
+				metric, ok := metricValue.(float64)
+				if !ok {
+					continue
+				}
+				m := prometheus.MustNewConstMetric(desc, prometheus.GaugeValue,
+					metric, labelValues...)
+
+				ch <- prometheus.NewMetricWithTimestamp(metricIndex.Timestamp, m)
+
+			}
+		}
+	}
+}
+
+func serveMetrics(w http.ResponseWriter, r *http.Request) {
+	promhttp.Handler().ServeHTTP(w, r)
+}

--- a/app/ts-monitor/run/server.go
+++ b/app/ts-monitor/run/server.go
@@ -77,7 +77,7 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *logger.Logger) (a
 	}()
 	http.HandleFunc("/metrics", serveMetrics)
 	go func() {
-		err := http.ListenAndServe("127.0.0.1:6066", nil)
+		err := http.ListenAndServe(c.MonitorConfig.HttpEndpoint, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/app/ts-monitor/run/server.go
+++ b/app/ts-monitor/run/server.go
@@ -17,6 +17,7 @@ package run
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,6 +27,7 @@ import (
 	"github.com/openGemini/openGemini/app/ts-monitor/collector"
 	"github.com/openGemini/openGemini/lib/config"
 	"github.com/openGemini/openGemini/lib/logger"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -62,6 +64,8 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *logger.Logger) (a
 	s.nodeMonitor.Reporter = reporterJob
 	s.queryMetric.Reporter = reporterJob
 
+	monitorCollector := NewMonitorCollector(s.collector)
+	prometheus.MustRegister(monitorCollector)
 	go func() {
 		for {
 			err := s.collector.Reporter.CreateDatabase()
@@ -71,7 +75,13 @@ func NewServer(conf config.Config, cmd *cobra.Command, logger *logger.Logger) (a
 			time.Sleep(time.Second)
 		}
 	}()
-	go func() { _ = http.ListenAndServe("127.0.0.1:6066", nil) }()
+	http.HandleFunc("/metrics", serveMetrics)
+	go func() {
+		err := http.ListenAndServe("127.0.0.1:6066", nil)
+		if err != nil {
+			panic(err)
+		}
+	}()
 
 	// Prevent ts-monitor from preempting CPU resources.
 	// Set Two CPUs that can be executing.

--- a/config/monitor.conf
+++ b/config/monitor.conf
@@ -18,6 +18,8 @@
   history-file = "history.txt"
   # Is the metric compressed.
   compress = false
+  # The port and IP of the metircs reporting interface                                                                                                  ok | 08:02:05 下午 
+  http-endpoint = "{{addr}}:9098"
 
 [query]
   # query for some DDL. Report for these data to monitor cluster.

--- a/lib/config/monitor.go
+++ b/lib/config/monitor.go
@@ -107,14 +107,15 @@ func (c *TSMonitor) GetLogStoreConfig() *LogStoreConfig {
 }
 
 type MonitorMain struct {
-	Host        string `toml:"host"`
-	MetricPath  string `toml:"metric-path"`
-	ErrLogPath  string `toml:"error-log-path"`
-	Process     string `toml:"process"`
-	DiskPath    string `toml:"disk-path"`
-	AuxDiskPath string `toml:"aux-disk-path"`
-	History     string `toml:"history-file"`
-	Compress    bool   `toml:"compress"`
+	Host         string `toml:"host"`
+	MetricPath   string `toml:"metric-path"`
+	ErrLogPath   string `toml:"error-log-path"`
+	Process      string `toml:"process"`
+	DiskPath     string `toml:"disk-path"`
+	AuxDiskPath  string `toml:"aux-disk-path"`
+	History      string `toml:"history-file"`
+	Compress     bool   `toml:"compress"`
+	HttpEndpoint string `toml:"http-endpoint"`
 }
 
 func newMonitor() MonitorMain {


### PR DESCRIPTION
…table and write them to Prometheus

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
Implement openGeminicon to read monitoring indicators from the table and write them to Prometheus
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->


### What is changed and how it works?
Implemented the /metrics interface to read metrics from db for reporting.


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### How to use it?
Use the following example.
Add the following to the ```monitor.conf``` file.
```toml
[monitor]
  host = "127.0.0.1"
  metric-path = "/tmp/openGemini/metric"
  error-log-path = "/tmp/openGemini/logs"
  disk-path = "/tmp/openGemini/data"
  aux-disk-path = "/tmp/openGemini/data/wal"
  process = "ts-store,ts-sql,ts-meta"
  history-file = "history.txt"
  compress = false
  http-endpoint = "127.0.0.1:9098"
```
Start   ts-monitor
At this point, can get the metrics from an HTTP request
```shell
"http://127.0.0.1:9098/metrics"
```