### PR TITLE
chore: change owner of go-prompt

### DIFF
--- a/app/ts-cli/geminicli/cli.go
+++ b/app/ts-cli/geminicli/cli.go
@@ -29,10 +29,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/StepY1aoZz/go-prompt"
 	"github.com/influxdata/influxdb/client"
 	"github.com/influxdata/influxdb/models"
 	"github.com/olekukonko/tablewriter"
+	"github.com/openGemini/go-prompt"
 	"github.com/openGemini/openGemini/app"
 	"github.com/openGemini/openGemini/app/ts-cli/geminiql"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"

--- a/app/ts-cli/geminicli/completer.go
+++ b/app/ts-cli/geminicli/completer.go
@@ -15,7 +15,7 @@
 package geminicli
 
 import (
-	"github.com/StepY1aoZz/go-prompt"
+	"github.com/openGemini/go-prompt"
 )
 
 type Completer struct {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RoaringBitmap/roaring v0.9.1
-	github.com/StepY1aoZz/go-prompt v0.0.0-20240714073756-61a575943cba
 	github.com/VictoriaMetrics/VictoriaMetrics v1.67.0
 	github.com/VictoriaMetrics/fastcache v1.7.0
 	github.com/agiledragon/gomonkey/v2 v2.10.1
@@ -35,6 +34,7 @@ require (
 	github.com/mitchellh/cli v1.1.5
 	github.com/nxadm/tail v1.4.11
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
+	github.com/openGemini/go-prompt v0.0.0-20240906095849-29653678978f
 	github.com/panjf2000/ants/v2 v2.5.0
 	github.com/pierrec/lz4/v4 v4.1.17
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqR
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/StepY1aoZz/go-prompt v0.0.0-20240714073756-61a575943cba h1:zn8iUFVBcJohty5a9bBgrfxgvNLwIsIffMNOX77EXYs=
-github.com/StepY1aoZz/go-prompt v0.0.0-20240714073756-61a575943cba/go.mod h1:zWMLnPy1Vppwy3vwOssF01Sr4bWtzu7BBoia+QtVkDQ=
 github.com/VictoriaMetrics/VictoriaMetrics v1.67.0 h1:CS+AZT9rykvIPNiTzwdE5d894bUnkeXV4qStEA6ki/E=
 github.com/VictoriaMetrics/VictoriaMetrics v1.67.0/go.mod h1:cgL5RdFv2yZW8eCsRjpmsHghpHw30ZG/knU0t4cRH0E=
 github.com/VictoriaMetrics/fastcache v1.7.0 h1:E6GibaGI685TafrI7E/QqZPkMsOzRw+3gpICQx08ISg=
@@ -1379,6 +1377,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/openGemini/go-prompt v0.0.0-20240906095849-29653678978f h1:XT64FJ274ZW1RuV1pXM04ZYCQlfzXUbHPf4oUX6TJl0=
+github.com/openGemini/go-prompt v0.0.0-20240906095849-29653678978f/go.mod h1:oSS/OisE9pPJxF3TCpsXNUB6pXabgnjuCZv9H3DhhM4=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
Changed the owner of `go-prompt` to openGemini.
