### PR TITLE
fix: ts-cli support tag array write

### DIFF
--- a/app/ts-cli/geminiql/lexer.go
+++ b/app/ts-cli/geminiql/lexer.go
@@ -45,6 +45,14 @@ func isSplitChar(ch rune) bool {
 	return ch == ',' || ch == ' ' || ch == '=' || ch == '.'
 }
 
+func isLBracket(ch rune) bool {
+	return ch == '['
+}
+
+func isRBracket(ch rune) bool {
+	return ch == ']'
+}
+
 type Tokenizer struct {
 	r        io.RuneScanner
 	keywords map[string]int
@@ -158,6 +166,7 @@ func (t *Tokenizer) scanKeywords(s string) int {
 func (t *Tokenizer) scanRaw() (int, string) {
 	var buf bytes.Buffer
 	isString := false
+	var bracket bool
 	for {
 		ch := t.read()
 		if !isString && ch == '"' {
@@ -185,7 +194,7 @@ func (t *Tokenizer) scanRaw() (int, string) {
 				buf.WriteRune(ch)
 				ch = t.read()
 				buf.WriteRune(ch)
-			} else if ch == ',' || ch == ' ' {
+			} else if (ch == ',' || ch == ' ') && !bracket {
 				if err := t.unRead(); err != nil {
 					return BAD_STRING, buf.String()
 				}
@@ -193,7 +202,13 @@ func (t *Tokenizer) scanRaw() (int, string) {
 			} else if ch == EOF {
 				return RAW, buf.String()
 			} else {
+				if isLBracket(ch) {
+					bracket = true
+				}
 				buf.WriteRune(ch)
+				if isRBracket(ch) {
+					return RAW, buf.String()
+				}
 			}
 		}
 	}

--- a/app/ts-cli/geminiql/parser_test.go
+++ b/app/ts-cli/geminiql/parser_test.go
@@ -276,6 +276,42 @@ func TestParser(t *testing.T) {
 				Precision: "ns",
 			},
 		},
+		{
+			name: "tag array write with multi values",
+			cmd:  "insert cpu,t1=1,t2=[a,b] value=3",
+			expect: &InsertStatement{
+				DB:           "",
+				RP:           "",
+				LineProtocol: `cpu,t1=1,t2=[a,b] value=3`,
+			},
+		},
+		{
+			name: "tag array write with single value",
+			cmd:  "insert cpu,t1=1,t2=[a] value=3",
+			expect: &InsertStatement{
+				DB:           "",
+				RP:           "",
+				LineProtocol: `cpu,t1=1,t2=[a] value=3`,
+			},
+		},
+		{
+			name: "tag array write with multi values and escape value",
+			cmd:  "insert cpu,t1=[aaaaa,\"bbbbb\"] value=3",
+			expect: &InsertStatement{
+				DB:           "",
+				RP:           "",
+				LineProtocol: `cpu,t1=[aaaaa,"bbbbb"] value=3`,
+			},
+		},
+		{
+			name: "tag array write with multi values and single quota",
+			cmd:  "insert cpu,t1=[aaaaa,'bbbbb'] value=3",
+			expect: &InsertStatement{
+				DB:           "",
+				RP:           "",
+				LineProtocol: `cpu,t1=[aaaaa,'bbbbb'] value=3`,
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ast := &QLAst{}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: fix #510, fix #507

### What is changed and how it works?
Affected by the `goyacc` rules, applying `LINE_PROTOCOL` syntax will cause `COMMA` to split all `RAW` options, you can review from this link:
https://github.com/openGemini/openGemini/blob/7c7888cd22584fb18bcccbd59c6357fb503b2472/app/ts-cli/geminiql/parser.y#L272

https://github.com/openGemini/openGemini/blob/7c7888cd22584fb18bcccbd59c6357fb503b2472/app/ts-cli/geminiql/parser.y#L266

By adding a flag `bracket`, the delimiter is prevented from being over-parsed when `[` appears, make ts-cli supports parsing LeftBracket `[` and RightBracket `]`

![PixPin_2024-09-15_02-39-25](https://github.com/user-attachments/assets/adfdeb0a-4c65-4fa4-930a-fcf42bf42092)

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
