### PR TITLE
fix: ts-meta parse tls config

### DIFF
--- a/app/ts-meta/run/server.go
+++ b/app/ts-meta/run/server.go
@@ -91,7 +91,11 @@ func NewServer(conf config.Config, info app.ServerInfo, logger *Logger.Logger) (
 	// initialize log
 	metaConf := c.Meta
 	metaConf.Logging = c.Logging
-	s.MetaService = meta.NewService(metaConf, c.TLS)
+	tlsConfig, err := c.TLS.Parse()
+	if err != nil {
+		return nil, err
+	}
+	s.MetaService = meta.NewService(metaConf, tlsConfig)
 	s.MetaService.Version = s.info.Version
 	s.MetaService.Node = s.Node
 

--- a/lib/config/meta.go
+++ b/lib/config/meta.go
@@ -15,12 +15,12 @@
 package config
 
 import (
-	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/toml"
 	"github.com/openGemini/openGemini/lib/iodetector"
 	"github.com/openGemini/openGemini/lib/util/lifted/hashicorp/serf/serf"
@@ -74,7 +74,7 @@ type TSMeta struct {
 	Spdy    Spdy    `toml:"spdy"`
 
 	// TLS provides configuration options for all https endpoints.
-	TLS *tls.Config `toml:"-"`
+	TLS tlsconfig.Config `toml:"tls"`
 
 	Sherlock   *SherlockConfig    `toml:"sherlock"`
 	IODetector *iodetector.Config `toml:"io-detector"`


### PR DESCRIPTION
### What problem does this PR solve?
When `ts-meta` is running, the tls configuration item is not read, causing the server to become http instead of https

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
