### PR TITLE
fix: fix erro for agg sink with agg-subquery

### DIFF
--- a/engine/agg_tagset_cursor.go
+++ b/engine/agg_tagset_cursor.go
@@ -875,7 +875,12 @@ func (s *AggTagSetCursor) SinkPlan(plan hybridqp.QueryNode) {
 			}
 		}
 		s.aggOps = callOps
-		s.baseCursorInfo.keyCursor.SinkPlan(plan.Children()[0].Children()[0])
+		_, ok := plan.Children()[0].Children()[0].(*executor.LogicalAggregate)
+		if ok {
+			s.baseCursorInfo.keyCursor.SinkPlan(plan.Children()[0].Children()[0])
+		} else {
+			s.baseCursorInfo.keyCursor.SinkPlan(plan.Children()[0])
+		}
 	}
 	fieldSchema := s.GetSchema()
 	if len(s.baseCursorInfo.ctx.auxTags) == 0 {


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #701

在进行agg的sinkPlan时候，有可能agg只有一层，这时候对children()[0].children()[0]sinkPlan时会出现panic.

1.  一个agg的情况
```
select count(*) from (select field1 where tag1='t1' and field2='f2')
```
这种情况，经过优化器AggPushdownToSeriesRule的优化，子查询会下推一个agg，最终的子查询计划是LogicalReader->LogicalAggregate->LogicalSeries，此时下面的sinkPlan会引起panic
2.  两个agg的情况
```
select count(*) from (select count(field1) where tag1='t1' and field2='f2')
```
这种情况，经过优化器AggPushdownToSeriesRule的优化，子查询会下推一个agg，最终的子查询计划是LogicalReader->LogicalAggregate->LogicalAggregate->LogicalSeries，此时sinkPlan会正常执行

### What is changed and how it works?

正确的应该判断此时有多少个agg，然后使用最后一个agg进行sinkPlan。

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test_fileLoopCursor_SinkPlan2

# Checklist:

- [x] My code  #follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
