### PR TITLE
fix: fix the subscription errors when data synchronization

### DIFF
--- a/coordinator/subscriber.go
+++ b/coordinator/subscriber.go
@@ -171,7 +171,10 @@ type AllWriter struct {
 
 func (w *AllWriter) Write(lineProtocol []byte) {
 	for i := 0; i < len(w.clients); i++ {
-		wr := &WriteRequest{i, lineProtocol}
+		wr := &WriteRequest{}
+		wr.Client = i
+		wr.LineProtocol = make([]byte, len(lineProtocol))
+		copy(wr.LineProtocol, lineProtocol)
 		w.Send(wr)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #765 

### What is changed and how it works?

The data is encapsulated in the `uw` structure during the writing process. After writing, this structure must be recycled. Data subscription also forwards data from this structure, but forwarding is asynchronous. Data errors may occur when `uw` is recycled and the data has not been forwarded.

The current solution is to copy the data to prevent data errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
