### PR TITLE
ci: pr title checker handled separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ env:
   GOSUMDB: off
 
 jobs:
-  PrTitleLint:
-    name: pr title lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: PR Title Lint
-        uses: openGemini/pr-title-checker@v1.0.1
   CommitLint:
     name: commit lint
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  PrTitleLint:
+    name: pr title lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Title Lint
+        uses: openGemini/pr-title-checker@v1.0.2


### PR DESCRIPTION
Since the previous task triggering method did not include `edited` action, the task became invalid after re-editing the pr title. Now the task will be processed separately.