### PR TITLE
fix: correct the compressor choose

### DIFF
--- a/lib/util/lifted/influx/httpd/handler_compress.go
+++ b/lib/util/lifted/influx/httpd/handler_compress.go
@@ -37,14 +37,14 @@ type lazyCompressResponseWriter struct {
 func compressFilter(inner http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var writer io.Writer = w
-		contentEncoding := r.Header.Get("Content-Encoding")
+		acceptEncoding := r.Header.Get("Accept-Encoding")
 		switch {
-		case strings.Contains(contentEncoding, "gzip"):
+		case strings.Contains(acceptEncoding, "gzip"):
 			gz := getGzipWriter(w)
 			defer gz.Close()
 			writer = gz
 			w.Header().Set("Content-Encoding", "gzip")
-		case strings.Contains(contentEncoding, "zstd"):
+		case strings.Contains(acceptEncoding, "zstd"):
 			enc := getZstdWriter(w)
 			defer enc.Close()
 			writer = enc

--- a/lib/util/lifted/influx/httpd/handler_compress_test.go
+++ b/lib/util/lifted/influx/httpd/handler_compress_test.go
@@ -1,0 +1,147 @@
+// Copyright 2024 openGemini Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package httpd
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+func TestCompressFilter_Gzip(t *testing.T) {
+	handler := compressFilter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test response"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Encoding") != "gzip" {
+		t.Errorf("expected gzip encoding, got %s", resp.Header.Get("Content-Encoding"))
+	}
+
+	gzReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer gzReader.Close()
+
+	body, err := io.ReadAll(gzReader)
+	if err != nil {
+		t.Fatalf("failed to read gzip body: %v", err)
+	}
+
+	if string(body) != "test response" {
+		t.Errorf("expected body 'test response', got %s", string(body))
+	}
+}
+
+func TestCompressFilter_Zstd(t *testing.T) {
+	handler := compressFilter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test response"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "zstd")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Encoding") != "zstd" {
+		t.Errorf("expected zstd encoding, got %s", resp.Header.Get("Content-Encoding"))
+	}
+
+	zstdReader, err := zstd.NewReader(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to create zstd reader: %v", err)
+	}
+	defer zstdReader.Close()
+
+	body, err := io.ReadAll(zstdReader)
+	if err != nil {
+		t.Fatalf("failed to read zstd body: %v", err)
+	}
+
+	if string(body) != "test response" {
+		t.Errorf("expected body 'test response', got %s", string(body))
+	}
+}
+
+func TestCompressFilter_NoEncoding(t *testing.T) {
+	handler := compressFilter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test response"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Errorf("expected no encoding, got %s", resp.Header.Get("Content-Encoding"))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	if string(body) != "test response" {
+		t.Errorf("expected body 'test response', got %s", string(body))
+	}
+}
+
+func TestCompressFilter_UnsupportedEncoding(t *testing.T) {
+	handler := compressFilter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("test response"))
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "br")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Errorf("expected no encoding, got %s", resp.Header.Get("Content-Encoding"))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	if string(body) != "test response" {
+		t.Errorf("expected body 'test response', got %s", string(body))
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #791 

### What is changed and how it works?

Prior to the PR, there were two issues:
1. We should use the HTTP header **Accept-Encoding** instead of content-encoding to determine the compressor.

## Todo
  - [ ]  we also need to consider the content negotiation if http headers contains a list of accept encoding suits.


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Test 
- [x] Integration Test 
- [ ] Test cases to be added
- [ ] No code

## validation
![image](https://github.com/user-attachments/assets/ee189ee7-5776-4f17-b4c2-9a6882f57e9f)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
