### PR TITLE
ci: add docker nightly build image task

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -1,0 +1,30 @@
+name: release-nightly
+
+on:
+  push:
+    branches: [main, v*, release/v*]
+
+jobs:
+  nightly-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: build opengemini docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile.nightly
+          tags: opengeminidb/opengemini-server:nightly

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,0 +1,30 @@
+FROM fedora:latest AS builder
+
+WORKDIR /build
+
+ENV GOPROXY=https://mirrors.huaweicloud.com/repository/goproxy/,https://goproxy.cn,https://proxy.golang.org,direct
+ENV CGO_ENABLED=1
+
+RUN dnf install golang gcc gcc-c++ -y --setopt=tsflags=nodocs && dnf clean all
+
+COPY . .
+
+RUN rm -rf go.sum && go mod tidy
+
+RUN go build -ldflags "-s -w" -o ./bin/ts-cli ./app/ts-cli/ &&\
+    go build -ldflags "-s -w" -o ./bin/ts-server ./app/ts-server/
+
+FROM fedora:latest
+
+WORKDIR /home/opengemini
+
+ENV PATH=$PATH:/home/opengemini/bin
+
+RUN dnf install -y --setopt=tsflags=nodocs net-tools curl bind-utils procps && dnf clean all
+
+COPY --from=builder /build/bin/* /home/opengemini/bin/
+COPY --from=builder /build/config/openGemini.singlenode.conf /home/opengemini/config/opengemini.conf
+
+EXPOSE 8086
+
+ENTRYPOINT ["/home/opengemini/bin/ts-server", "-config", "/home/opengemini/config/opengemini.conf"]


### PR DESCRIPTION
Add daily builds for the opengemini project, which will trigger Docker image builds when there are code changes in the `main` or `release` branch.

Known issue: 
1. Using GitHub actions for Docker image cross building can cause slow build on the arm64 platform, possibly lasting for more than an hour.
2. Dependency updates may have stalled, resulting in failed pull of dependencies during build. We need to configure GOPROXY to resolve the issue.