### PR TITLE
feat: remove error returning and make ColVal codec bound to little endian in record codec methods

### DIFF
--- a/coordinator/record_writer.go
+++ b/coordinator/record_writer.go
@@ -539,7 +539,7 @@ func MarshalWithMeasurements(buf []byte, mst string, rec *record.Record) ([]byte
 	buf = append(buf, uint8(len(name)))
 	buf = append(buf, name...)
 
-	return rec.Marshal(buf)
+	return rec.Marshal(buf), nil
 }
 
 func UnmarshalWithMeasurements(buf []byte, rec *record.Record) (string, error) {
@@ -552,7 +552,8 @@ func UnmarshalWithMeasurements(buf []byte, rec *record.Record) (string, error) {
 
 	name := util.Bytes2str(buf[:mLen])
 	buf = buf[mLen:]
-	return name, rec.Unmarshal(buf)
+	rec.Unmarshal(buf)
+	return name, nil
 }
 
 func IsKeepWritingErr(err error) bool {

--- a/lib/codec/binary_decoder.go
+++ b/lib/codec/binary_decoder.go
@@ -55,6 +55,12 @@ func (c *BinaryDecoder) Uint32() uint32 {
 	return i
 }
 
+func (c *BinaryDecoder) Uint32LE() uint32 {
+	i := binary.LittleEndian.Uint32(c.buf[c.offset : c.offset+4])
+	c.offset += 4
+	return i
+}
+
 func (c *BinaryDecoder) Uint64() uint64 {
 	i := binary.BigEndian.Uint64(c.buf[c.offset : c.offset+8])
 	c.offset += 8
@@ -166,6 +172,18 @@ func (c *BinaryDecoder) Uint32Slice() []uint32 {
 
 	size := int(l) * util.Uint32SizeBytes
 	a := util.Bytes2Uint32Slice(c.copy(size))
+	return a
+}
+
+func (c *BinaryDecoder) Uint32SliceSafe() []uint32 {
+	l := c.Uint32()
+	if l == 0 {
+		return nil
+	}
+	a := make([]uint32, l)
+	for i := range a {
+		a[i] = c.Uint32LE()
+	}
 	return a
 }
 

--- a/lib/codec/binary_encoder.go
+++ b/lib/codec/binary_encoder.go
@@ -15,6 +15,8 @@
 package codec
 
 import (
+	"encoding/binary"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/encoding"
 	"github.com/openGemini/openGemini/lib/util"
 )
@@ -130,6 +132,17 @@ func AppendUint32Slice(b []byte, a []uint32) []byte {
 	}
 
 	b = append(b, util.Uint32Slice2byte(a)...)
+	return b
+}
+
+func AppendUint32SliceSafe(b []byte, a []uint32) []byte {
+	b = AppendUint32(b, uint32(len(a)))
+	if len(a) == 0 {
+		return b
+	}
+	for _, v := range a {
+		b = binary.LittleEndian.AppendUint32(b, v)
+	}
 	return b
 }
 

--- a/lib/record/column_codec.go
+++ b/lib/record/column_codec.go
@@ -16,19 +16,19 @@ package record
 
 import "github.com/openGemini/openGemini/lib/codec"
 
-func (cv *ColVal) Marshal(buf []byte) ([]byte, error) {
+func (cv *ColVal) Marshal(buf []byte) []byte {
 	buf = codec.AppendInt(buf, cv.Len)
 	buf = codec.AppendInt(buf, cv.NilCount)
 	buf = codec.AppendInt(buf, cv.BitMapOffset)
 	buf = codec.AppendBytes(buf, cv.Val)
 	buf = codec.AppendBytes(buf, cv.Bitmap)
-	buf = codec.AppendUint32Slice(buf, cv.Offset)
-	return buf, nil
+	buf = codec.AppendUint32SliceSafe(buf, cv.Offset)
+	return buf
 }
 
-func (cv *ColVal) Unmarshal(buf []byte) error {
+func (cv *ColVal) Unmarshal(buf []byte) {
 	if len(buf) == 0 {
-		return nil
+		return
 	}
 	dec := codec.NewBinaryDecoder(buf)
 	cv.Len = dec.Int()
@@ -36,8 +36,8 @@ func (cv *ColVal) Unmarshal(buf []byte) error {
 	cv.BitMapOffset = dec.Int()
 	cv.Val = dec.Bytes()
 	cv.Bitmap = dec.Bytes()
-	cv.Offset = dec.Uint32Slice()
-	return nil
+	cv.Offset = dec.Uint32SliceSafe()
+	return
 }
 
 func (cv *ColVal) Size() int {

--- a/lib/record/record_codec.go
+++ b/lib/record/record_codec.go
@@ -18,35 +18,27 @@ import (
 	"github.com/openGemini/openGemini/lib/codec"
 )
 
-func (rec *Record) Marshal(buf []byte) ([]byte, error) {
-	var err error
+func (rec *Record) Marshal(buf []byte) []byte {
 	// Schema
 	buf = codec.AppendUint32(buf, uint32(len(rec.Schema)))
 	for i := 0; i < len(rec.Schema); i++ {
 		buf = codec.AppendUint32(buf, uint32(rec.Schema[i].Size()))
-		buf, err = rec.Schema[i].Marshal(buf)
-		if err != nil {
-			return nil, err
-		}
+		buf = rec.Schema[i].Marshal(buf)
 	}
 
 	// ColVal
 	buf = codec.AppendUint32(buf, uint32(len(rec.ColVals)))
 	for i := 0; i < len(rec.ColVals); i++ {
 		buf = codec.AppendUint32(buf, uint32(rec.ColVals[i].Size()))
-		buf, err = rec.ColVals[i].Marshal(buf)
-		if err != nil {
-			return nil, err
-		}
+		buf = rec.ColVals[i].Marshal(buf)
 	}
-	return buf, nil
+	return buf
 }
 
-func (rec *Record) Unmarshal(buf []byte) error {
+func (rec *Record) Unmarshal(buf []byte) {
 	if len(buf) == 0 {
-		return nil
+		return
 	}
-	var err error
 	dec := codec.NewBinaryDecoder(buf)
 
 	// Schema
@@ -58,9 +50,7 @@ func (rec *Record) Unmarshal(buf []byte) error {
 			continue
 		}
 		rec.Schema[i] = Field{}
-		if err = rec.Schema[i].Unmarshal(subBuf); err != nil {
-			return err
-		}
+		rec.Schema[i].Unmarshal(subBuf)
 	}
 
 	// ColVal
@@ -72,11 +62,9 @@ func (rec *Record) Unmarshal(buf []byte) error {
 			continue
 		}
 		rec.ColVals[i] = ColVal{}
-		if err = rec.ColVals[i].Unmarshal(subBuf); err != nil {
-			return err
-		}
+		rec.ColVals[i].Unmarshal(subBuf)
 	}
-	return nil
+	return
 }
 
 func (rec *Record) CodecSize() int {

--- a/lib/record/record_codec_test.go
+++ b/lib/record/record_codec_test.go
@@ -37,21 +37,14 @@ func TestRecodeCodec(t *testing.T) {
 		[]int{1, 1, 1, 0}, []bool{true, true, true, false},
 		[]int64{1, 2, 3, 4})
 
-	var err error
 	pc := make([]byte, 0, rec.CodecSize())
-	pc, err = rec.Marshal(pc)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
+	pc = rec.Marshal(pc)
 	if len(pc) != rec.CodecSize() {
 		t.Fatalf("error size, exp: %d; got: %d", len(pc), rec.CodecSize())
 	}
 
 	newRec := &record.Record{}
-	err = newRec.Unmarshal(pc)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
+	newRec.Unmarshal(pc)
 
 	if !reflect.DeepEqual(rec.Schema, newRec.Schema) {
 		t.Fatalf("marshal schema failed")

--- a/lib/record/schema_codec.go
+++ b/lib/record/schema_codec.go
@@ -16,21 +16,21 @@ package record
 
 import "github.com/openGemini/openGemini/lib/codec"
 
-func (f *Field) Marshal(buf []byte) ([]byte, error) {
+func (f *Field) Marshal(buf []byte) []byte {
 	buf = codec.AppendString(buf, f.Name)
 	buf = codec.AppendInt(buf, f.Type)
-	return buf, nil
+	return buf
 }
 
-func (f *Field) Unmarshal(buf []byte) error {
+func (f *Field) Unmarshal(buf []byte) {
 	if len(buf) == 0 {
-		return nil
+		return
 	}
 
 	dec := codec.NewBinaryDecoder(buf)
 	f.Name = dec.String()
 	f.Type = dec.Int()
-	return nil
+	return
 }
 
 func (f *Field) Size() int {

--- a/services/writer/service.go
+++ b/services/writer/service.go
@@ -292,10 +292,8 @@ func uncompress(algo pb.CompressMethod, data []byte) ([]byte, error) {
 
 func unmarshal(data []byte) (*record.Record, error) {
 	rec := &record.Record{}
-	err := rec.Unmarshal(data)
-	if err != nil {
-		return nil, err
-	}
+	var err error
+	rec.Unmarshal(data)
 	func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/services/writer/service_test.go
+++ b/services/writer/service_test.go
@@ -138,14 +138,8 @@ func mockCompressedPartialRecords() []*pb.Record {
 	mockRecord := NewRecord()
 	buf := make([]byte, 0)
 	invalidBuf := make([]byte, 0)
-	buf, err := mockRecord.Marshal(buf)
-	if err != nil {
-		panic(err)
-	}
-	invalidBuf, err = mockInvalidRecord.Marshal(invalidBuf)
-	if err != nil {
-		panic(err)
-	}
+	buf = mockRecord.Marshal(buf)
+	invalidBuf = mockInvalidRecord.Marshal(invalidBuf)
 
 	compressedBuf, err := compress(pb.CompressMethod_ZSTD_FAST, buf)
 	if err != nil {
@@ -166,10 +160,7 @@ func mockAllValidRecords() []*pb.Record {
 	mockRecord := NewRecord()
 	record.CheckRecord(mockRecord)
 	buf := make([]byte, 0)
-	buf, err := mockRecord.Marshal(buf)
-	if err != nil {
-		panic(err)
-	}
+	buf = mockRecord.Marshal(buf)
 	mockRow1 := &pb.Record{Measurement: "mst204", Block: buf}
 	mockRow2 := &pb.Record{Measurement: "mst205", Block: buf}
 	mockRow3 := &pb.Record{Measurement: "mst206", Block: buf}
@@ -179,10 +170,7 @@ func mockAllValidRecords() []*pb.Record {
 func mockAllInvalidRecords() []*pb.Record {
 	mockRecord := NewInvalidRecord()
 	buf := make([]byte, 0)
-	buf, err := mockRecord.Marshal(buf)
-	if err != nil {
-		panic(err)
-	}
+	buf = mockRecord.Marshal(buf)
 	mockRow1 := &pb.Record{Measurement: "mst204", Block: buf}
 	mockRow2 := &pb.Record{Measurement: "mst205", Block: buf}
 	mockRow3 := &pb.Record{Measurement: "mst206", Block: buf}
@@ -194,14 +182,8 @@ func mockPartialRecords() []*pb.Record {
 	mockRecord := NewRecord()
 	buf := make([]byte, 0)
 	invalidBuf := make([]byte, 0)
-	buf, err := mockRecord.Marshal(buf)
-	if err != nil {
-		panic(err)
-	}
-	invalidBuf, err = mockInvalidRecord.Marshal(invalidBuf)
-	if err != nil {
-		panic(err)
-	}
+	buf = mockRecord.Marshal(buf)
+	invalidBuf = mockInvalidRecord.Marshal(invalidBuf)
 	mockRow1 := &pb.Record{Measurement: "mst204", Block: buf}
 	mockRow2 := &pb.Record{Measurement: "mst205", Block: buf}
 	mockRow3 := &pb.Record{Measurement: "mst206", Block: invalidBuf}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

ref #816 

### What is changed and how it works?
This PR remove unnecessary error returning in record marshal and unmarshal methods and make AppendUint32Slice bound to little endian.

Considering most machine running openGemini now are all little endian, use little endian in AppendUint32Slice may bring us most compatibility.

