### PR TITLE
fix: drop measurement can not specify retention policy from request options

### DIFF
--- a/lib/util/lifted/influx/coordinator/statement_executor.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor.go
@@ -2288,6 +2288,10 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 			if node.Database == "" {
 				node.Database = defaultDatabase
 			}
+		case *influxql.DropMeasurementStatement:
+			if node.RpName == "" {
+				node.RpName = defaultRetentionPolicy
+			}
 		case *influxql.ShowMeasurementsDetailStatement:
 			if node.Database == "" {
 				node.Database = defaultDatabase


### PR DESCRIPTION
When I execute the drop measurement command, I find that I cannot specify the RP parameter through the URL payload. I can only delete the measurement through `drop measurement rp.mst`. However, in version 1.2, this operation is supported. I hope to fix it.

![18a33c8d2a59c07c52464f5896009b7a](https://github.com/user-attachments/assets/e731632b-a8f2-48a0-af2a-5ba438d56b6a)
