### PR TITLE
perf: reuse the allocated record.Record and influx.Row struct

### DIFF
--- a/lib/codec/binary_decoder.go
+++ b/lib/codec/binary_decoder.go
@@ -306,3 +306,7 @@ func (c *BinaryDecoder) copy(size int) []byte {
 	c.offset += size
 	return b
 }
+
+func (c *BinaryDecoder) noCopy(size int) []byte {
+	return c.buf[c.offset : c.offset+size]
+}

--- a/lib/record/column_codec.go
+++ b/lib/record/column_codec.go
@@ -40,6 +40,19 @@ func (cv *ColVal) Unmarshal(buf []byte) {
 	return
 }
 
+func (cv *ColVal) UnmarshalUnsafe(buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+	dec := codec.NewBinaryDecoder(buf)
+	cv.Len = dec.Int()
+	cv.NilCount = dec.Int()
+	cv.BitMapOffset = dec.Int()
+	cv.Val = dec.BytesNoCopy()
+	cv.Bitmap = dec.BytesNoCopy()
+	cv.Offset = dec.Uint32SliceSafe()
+}
+
 func (cv *ColVal) Size() int {
 	size := 0
 	size += codec.SizeOfInt()                  // Len

--- a/lib/record/record_codec.go
+++ b/lib/record/record_codec.go
@@ -67,6 +67,44 @@ func (rec *Record) Unmarshal(buf []byte) {
 	return
 }
 
+// UnmarshalUnsafe use pointers instead of copied slices when unmarshalling ColVals.
+// After calling this function, the buf []byte must not be modified.
+func (rec *Record) UnmarshalUnsafe(buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+	dec := codec.NewBinaryDecoder(buf)
+
+	// Schema
+	fieldLen := int(dec.Uint32())
+	if fieldLen > cap(rec.Schema) {
+		rec.Schema = make(Schemas, fieldLen)
+	}
+	rec.Schema = rec.Schema[:fieldLen]
+	for i := 0; i < fieldLen; i++ {
+		subBuf := dec.BytesNoCopy()
+		if len(subBuf) == 0 {
+			continue
+		}
+		rec.Schema[i].Unmarshal(subBuf)
+	}
+
+	// ColVal
+	colLen := int(dec.Uint32())
+	if colLen > cap(rec.ColVals) {
+		rec.ColVals = make([]ColVal, colLen)
+	}
+	rec.ColVals = rec.ColVals[:colLen]
+	for i := 0; i < colLen; i++ {
+		subBuf := dec.BytesNoCopy()
+		if len(subBuf) == 0 {
+			continue
+		}
+		rec.ColVals[i].UnmarshalUnsafe(subBuf)
+	}
+	return
+}
+
 func (rec *Record) CodecSize() int {
 	size := 0
 


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

close #824 and #816

### What is changed and how it works?
This PR aims at reducing GC cost in record writing.  First, it introduced a new sync.Pool to re-use the allocated record.Record struct. Also, it reduce times of memory allocation in creating influx.Row slice.

**Main results:**

| Type | Speed (metrics/sec) | Compared with HTTP(%) |
|--------|--------|--------|
| HTTP(influx line protocol) | 6656546.78 | - |
| gRPC | 6706914.51 | +0.76% |
| gRPC+Row Map, Record Map | 7809961.07 | +17.33%| 
| gRPC+Row Map, Record Map, Record.UnmarshalUnsafe | 8022532.14 | +20.52%| 
 > All the result was measured when writing 15552000 rows (1745280000 metrics) into openGemini, using 8 writers. 
 > The data was generated by TSBS generate data: dev-ops.


**Comparison between Unmarshal and UnmarshalUnsafe:**
```go
// 13170    ns/op
func BenchmarkRecord_Marshal2(b *testing.B) {
	r := generateLargeRecord()
	size := r.CodecSize()
	buf := make([]byte, 0, size)
	for i := 0; i < b.N; i++ {
		buf = buf[:0]
		buf = r.Marshal(buf)
		newO := &record.Record{}
		newO.UnmarshalUnsafe(buf)
	}
}

//32124    ns/op
func BenchmarkRecord_Marshal(b *testing.B) {
	r := generateLargeRecord()
	size := r.CodecSize()
	buf := make([]byte, 0, size)
	for i := 0; i < b.N; i++ {
		buf = buf[:0]
		buf = r.Marshal(buf)
		newO := &record.Record{}
		newO.Unmarshal(buf)
	}
}
``` 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
