### PR TITLE
chore: set epoch rfc3339 default ( v1.3.0-release branch)

### DIFF
--- a/CONTRIBUTION_CN.md
+++ b/CONTRIBUTION_CN.md
@@ -277,5 +277,3 @@ openGemini是一个开放的社区，我们希望所有参与社区的人都能�
 ### 6.2 技术委员会
 
 openGemini技术委员会（Technical Committee，简称TC）是openGemini社区的技术决策机构，负责社区技术决策和技术资源的协调。
-
-

--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -1058,6 +1058,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta2.
 	}
 
 	epoch := strings.TrimSpace(r.FormValue("epoch"))
+	if epoch == "" {
+		epoch = "rfc3339"
+	}
 
 	db := r.FormValue("db")
 	var qDuration *statistics.SQLSlowQueryStatistics

--- a/scripts/ci/go_generate.sh
+++ b/scripts/ci/go_generate.sh
@@ -54,4 +54,3 @@ else
   git diff | tee
   exit 1
 fi
-


### PR DESCRIPTION
Set epoch "rfc3339" default, if you use the Influxdb Java client to access openGemini without epoch. 
Similarly, we considered compatibility with InfluxDB.