### PR TITLE
fix: set epoch rfc3339 default merge to main branch

### DIFF
--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -1059,6 +1059,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta2.
 	}
 
 	epoch := strings.TrimSpace(r.FormValue("epoch"))
+	if epoch == "" {
+		epoch = "rfc3339"
+	}
 
 	db := r.FormValue("db")
 	var qDuration *statistics.SQLSlowQueryStatistics


### PR DESCRIPTION
Set epoch "rfc3339" default, if you use the Influxdb Java client to access openGemini without epoch.
Similarly, we considered compatibility with InfluxDB.