### PR TITLE
chore: remove sqlite-enabled configuration item

### DIFF
--- a/config/openGemini.singlenode.conf
+++ b/config/openGemini.singlenode.conf
@@ -10,7 +10,6 @@
   dir = "/tmp/openGemini/meta"
   num-of-shards = 2
   ptnum-pernode = 3
-  sqlite-enabled = true
 
 [http]
   bind-address = "127.0.0.1:8086"


### PR DESCRIPTION
openGemini single-node no need SQLite-enabled item
If SQLite-enabled is true, ts-store will report the file information when writing to meta for read-write separation. Not applicable for single-node.