### PR TITLE
chore: cleanup python deprecated  method of datetime.datetime.utcnow

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,7 +4,7 @@ import sys
 import os
 import platform
 import subprocess
-from datetime import datetime
+import datetime
 import shutil
 import re
 import logging
@@ -394,10 +394,10 @@ def build(version=None,
                 commit = get_current_commit())
 
         build_command += path
-        start_time = datetime.utcnow()
+        start_time = datetime.datetime.now(datetime.UTC)
         logging.info(build_command)
         run(build_command, shell=True)
-        end_time = datetime.utcnow()
+        end_time = datetime.datetime.now(datetime.UTC)
         logging.info("Time taken: %ss", (end_time - start_time).total_seconds())
     return True
 
@@ -427,7 +427,7 @@ def main(args):
     if args.nightly:
         args.version = increment_minor_version(args.version)
         args.version = "{}~n{}".format(args.version,
-                                       datetime.utcnow().strftime("%Y%m%d%H%M"))
+        datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M"))
         args.iteration = 0
 
     # Pre-build checks


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close/fix/resolve/ref #xxx

just got some warning when i run the command:`make go-build`, so this PR is working for cleanup the warning, change datetime.datetime.utcnow() to datetime.datetime.now(datetime.UTC)
```shell
[INFO] build: GOOS=linux GOARCH=amd64 go build -mod=mod -o openGemini/build/ts-data -ldflags="-X github.com/openGemini/openGemini/app.Version=1.3.0 -X github.com/openGemini/openGemini/app.GitBranch=main -X github.com/openGemini/openGemini/app.GitCommit=58f551b4b930afe7c8f5598cdd4744e2fc708f03" ./app/ts-data
openGemini/build.py:400: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  end_time = datetime.utcnow()
[INFO] build: Time taken: 7.641667s
[INFO] build: Building target: ts-recover
openGemini/build.py:397: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  start_time = datetime.utcnow()
[INFO] build: GOOS=linux GOARCH=amd64 go build -mod=mod -o openGemini/build/ts-recover -ldflags="-X github.com/openGemini/openGemini/app.Version=1.3.0 -X github.com/openGemini/openGemini/app.GitBranch=main -X github.com/openGemini/openGemini/app.GitCommit=58f551b4b930afe7c8f5598cdd4744e2fc708f03" ./app/ts-recover
openGemini/build.py:400: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  end_time = datetime.utcnow()
[INFO] build: Time taken: 6.907977s
```

### What is changed and how it works?
Please describe how it works

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
