### PR TITLE
fix: fix some panic error when use replication

### DIFF
--- a/engine/partition_raft.go
+++ b/engine/partition_raft.go
@@ -102,7 +102,10 @@ func dealCommitData(node *raftconn.RaftNode, client metaclient.MetaClient, stora
 	} else if dataWrapper.DataType == raftlog.ClearEntryLog {
 		bytes := dataWrapper.Data
 		index := encoding.UnmarshalUint64(bytes)
-		node.Store.DeleteBefore(index)
+		err := node.Store.DeleteBefore(index)
+		if err != nil {
+			logger.GetLogger().Error("deleting entryLog err when dealCommitData", zap.Error(err), zap.String("db", database), zap.Uint32("pt", ptId))
+		}
 	} else {
 		logger.GetLogger().Error("not support this data type")
 	}

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 h1:sO0/P7g68FrryJzljemN+6GTssUXdANk6aJ7T1ZxnsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1/go.mod h1:h8hyGFDsU5HMivxiS2iYFZsgDbU9OnnJ163x5UGVKYo=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 h1:U2rTu3Ef+7w9FHKIAXM6ZyqF3UOWJZ12zIm8zECAFfg=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0/go.mod h1:9kIvujWAA58nmPmWB1m23fyWic1kYZMxD9CxaWn4Qpg=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 h1:jBQA3cKT4L2rWMpgE7Yt3Hwh2aUj8KXjIGLxjHeYNNo=
@@ -43,8 +41,6 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 h1:bXwSugBiSbgtz7rOtbfGf+woewp4f06orW9OP5BjHLA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0/go.mod h1:Y/HgrePTmGy9HjdSGTqZNa+apUpTVIEVKXJyARP2lrk=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 h1:DzHpqpoJVaCgOUdVHxE8QB52S6NiVdDQvGlny1qvPqA=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/lib/raftlog/log.go
+++ b/lib/raftlog/log.go
@@ -260,6 +260,10 @@ func (lf *logFile) firstIndex() uint64 {
 	return lf.getEntry(0).Index()
 }
 
+func (lf *logFile) firstEntry() entry {
+	return lf.getEntry(0)
+}
+
 // firstEmptySlot returns the index of the first empty slot in the file.
 func (lf *logFile) firstEmptySlot() int {
 	return sort.Search(maxNumEntries, func(i int) bool {


### PR DESCRIPTION
When you use openGemini replication mode, a panic may occur after a period of normal system running. The reason is that when reading the raft log file, the read-write lock used causes the file offset to be incorrect, which ultimately prevents the WAL data from being cleaned up normally. The WAL file may become larger and larger, but the data will still normally be synchronized between replicas.