### PR TITLE
chore: fix dockerfile nightly when ts-cli is removed

### DIFF
--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -4,6 +4,7 @@ WORKDIR /build
 
 ENV GOPROXY=https://mirrors.huaweicloud.com/repository/goproxy/,https://goproxy.cn,https://proxy.golang.org,direct
 ENV CGO_ENABLED=1
+ENV GOBIN=/build/bin
 
 RUN dnf install golang gcc gcc-c++ -y --setopt=tsflags=nodocs && dnf clean all
 
@@ -11,8 +12,8 @@ COPY . .
 
 RUN rm -rf go.sum && go mod tidy
 
-RUN go build -ldflags "-s -w" -o ./bin/ts-cli ./app/ts-cli/ &&\
-    go build -ldflags "-s -w" -o ./bin/ts-server ./app/ts-server/
+RUN go build -ldflags "-s -w" -o ./bin/ts-server ./app/ts-server/ &&\
+    go install github.com/openGemini/openGemini-cli/cmd/ts-cli@latest
 
 FROM fedora:latest
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Refer to cluster deployments in [User Guide](https://docs.opengemini.org/guide/q
 
 #### Using openGemini
 
-Use the client to connect to openGemini
+Use the [openGemini-cli](https://github.com/openGemini/openGemini-cli) to connect to openGemini
 
 ```shell
 > ts-cli --host 127.0.0.1 --port 8086


### PR DESCRIPTION
Due to the removal of the `ts-cli` application from the main branch, compatibility repairs are now required for `Dockerfile.nightly`.