### PR TITLE
fix: bound parameter mode cannot be used properly

### DIFF
--- a/lib/util/lifted/influx/influxql/yyParser.go
+++ b/lib/util/lifted/influx/influxql/yyParser.go
@@ -118,14 +118,18 @@ func (p *YyParser) Lex(lval *yySymType) int {
 			}
 		case BOUNDPARAM:
 			{
-				k := strings.TrimPrefix(val, "$")
-				if len(k) == 0 {
-					p.Error("empty bound parameter")
+				if !strings.HasPrefix(val, "$") {
+					p.Error(fmt.Sprintf("illegal bound parameter: %s, must start with $ the symbol", val))
+					break
 				}
-
-				v := p.Params[k]
+				trimParameter := strings.TrimPrefix(val, "$")
+				if len(trimParameter) == 0 {
+					p.Error("empty bound parameter")
+					break
+				}
+				v := p.Params[val]
 				if v == nil {
-					p.Error(fmt.Sprintf("missing parameter: %s", k))
+					p.Error(fmt.Sprintf("missing parameter: %s", trimParameter))
 					break
 				}
 


### PR DESCRIPTION
The `bound parameter` is a practical feature, but it now has a bug that prevents the feature from working properly. When using `yy_parser` for syntax analysis, the `$` symbol of the parameter is mistakenly ignored, causing variables to not match fields.

HOW TO REPRODUCE:
```bash
# INSERT weather,location=us-midwest temperature=82
# INSERT weather,location=us-midwest temperature=83
# INSERT weather,location=us-midwest temperature=84
curl "localhost:8086/query?db=test_db" --data-urlencode "q=select * from weather where temperature=\$temperature" --data-urlencode 'params={"$temperature":"83"}'
# {"results":[{"statement_id":0}]}
#
# server log: error parsing query: missing parameter: temperature
```
