### PR TITLE
fix: auto build docker when create new tag

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  release:
+    types: [ created ]
 
 jobs:
   nightly-docker:


### PR DESCRIPTION
The existing `release-tag` task can only trigger the Docker image building task after creating a tag locally and pushing it to GitHub. Now, the release creation event integrated with GitHub can also trigger the creation of Docker images when a release is created.