### PR TITLE
fix: fix memory monitoring bug in low kernel systems

### DIFF
--- a/lib/memory/sysmemory_test.go
+++ b/lib/memory/sysmemory_test.go
@@ -51,3 +51,69 @@ func BenchmarkReadSysMemory_Parallel(b *testing.B) {
 	}
 	wg.Wait()
 }
+
+func TestGetMemInt64(t *testing.T) {
+
+	type testCase struct {
+		info   string
+		prefix string
+		left   int
+		ans    int64
+	}
+
+	testCases := []testCase{
+		{
+			"MemTotal:       14528572 kB",
+			"MemTotal:",
+			0,
+			14528572,
+		},
+		{
+			"MemFree:         6194012 kB",
+			"MemFree:",
+			0,
+			6194012,
+		},
+		{
+			"MemAvailable:    6254489 kB",
+			"MemAvailable:",
+			0,
+			6254489,
+		},
+		{
+			"Buffers:           34032 kB",
+			"Buffers:",
+			0,
+			34032,
+		},
+		{
+			"Cached:           188576 kB",
+			"Cached:",
+			0,
+			188576,
+		},
+		{
+			"SwapCached:            0 kB",
+			"SwapCached:",
+			0,
+			0,
+		},
+		{
+			"HugePages_Total:       0",
+			"HugePages_Total:",
+			0,
+			0,
+		},
+		{
+			"   test:       55 kB",
+			"test:",
+			3,
+			55,
+		},
+	}
+
+	for _, tcase := range testCases {
+		act := getMemInt64([]byte(tcase.info), tcase.prefix, tcase.left)
+		require.Equal(t, tcase.ans, act)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #894 

### What is changed and how it works?
Through the log, I locate the function that reads memory information in the code: `ReadSysMemoryLinux`. From the source code, we can see that the code reads `MemTotal` and `MemAvailable` from the memory monitoring file `/proc/meminfo` of the Linux system as the total memory capacity and free memory capacity respectively. However, in some Linux systems with lower kernel versions, `MemAvailable` does not exist in the memory monitoring file, as shown in the following area:
```shell
MemTotal:       14528572 kB
MemFree:         6194012 kB
Buffers:           34032 kB
Cached:           188576 kB
SwapCached:            0 kB
Active:           167556 kB
Inactive:         157876 kB
...
```
Therefore, for the old version, we can roughly get `MemAvailable` through the three fields of `MemFree + Buffers + Cached`. At the same time, for the new version, we still use direct reading of `MemAvailable` as the free memory capacity.

### How Has This Been Tested?
Now, we can execute commands normally in low-kernel systems (such as ubuntu18.04.5).
```shell
openGemini CLI 1.3.1 (rev-revision)
Please use `quit`, `exit` or `Ctrl-D` to exit this program.
> show databases
name: databases 
+-----------+
|   name    | 
+-----------+
| _internal |
| db0       |
+-----------+
1 columns, 2 rows in set
>
```

I also added unit tests `TestGetMemInt64` to the newly added code.
✅  TestGetMemInt64

# Checklist:

✅ My code follows the style guidelines of this project
✅ I have performed a self-review of my own code
✅ I have commented my code, particularly in hard-to-understand areas
❌ I have made corresponding changes to the documentation
✅ My changes generate no new warnings
✅ I have added tests that prove my fix is effective or that my feature works
✅ New and existing unit tests pass locally with my changes
✅ Any dependent changes have been merged and published in downstream modules
