### PR TITLE
fix: fix memory monitoring bug in low kernel systems & refactor memory monitoring code

### DIFF
--- a/app/operation.go
+++ b/app/operation.go
@@ -178,7 +178,7 @@ func (pm *ProactiveManager) inspectMem() {
 	if !sysconfig.GetInterruptQuery() {
 		return
 	}
-	currMemPct := memory.MemUsedPct()
+	currMemPct := memory.GetMemMonitor().MemUsedPct()
 	pm.interruptQuery(currMemPct)
 }
 

--- a/engine/immutable/hot.go
+++ b/engine/immutable/hot.go
@@ -166,7 +166,7 @@ func (m *HotFileManager) Run() {
 		return
 	}
 
-	memoryTotal, _ := memory.SysMem()
+	memoryTotal, _ := memory.GetMemMonitor().SysMem()
 	m.SetMaxMemorySize(config.KB * memoryTotal * m.conf.GetMemoryAllowedPercent() / 100)
 	hotFileWriterPool = pool.NewUnionPool[HotFileWriter](m.conf.PoolObjectCnt, int(m.conf.MaxCacheSize),
 		int(m.conf.MaxCacheSize), func() *HotFileWriter {

--- a/engine/sysctrl.go
+++ b/engine/sysctrl.go
@@ -295,7 +295,7 @@ func IsMemUsageExceeded() bool {
 	if memLimitPct < 1 || memLimitPct >= 100 {
 		return false
 	}
-	memUsedPct := memory.MemUsedPct()
+	memUsedPct := memory.GetMemMonitor().MemUsedPct()
 	exceeded := memUsedPct > float64(memLimitPct)
 	log.Info("system mem usage", zap.Float64("memUsedPct", memUsedPct), zap.Float64("memLimitPct", float64(memLimitPct)), zap.Bool("exceeded", exceeded))
 	return exceeded

--- a/lib/config/readcache.go
+++ b/lib/config/readcache.go
@@ -37,7 +37,7 @@ type ReadCache struct {
 }
 
 func NewReadCacheConfig() ReadCache {
-	size, _ := memory.SysMem()
+	size, _ := memory.GetMemMonitor().SysMem()
 	memorySize := toml.Size(size * KB)
 	return ReadCache{
 		ReadPageSize:       "32kb",

--- a/lib/config/store.go
+++ b/lib/config/store.go
@@ -356,7 +356,7 @@ func (c *Store) Corrector(cpuNum int, memorySize toml.Size) {
 		cpuNum = runtime.NumCPU()
 	}
 	if memorySize == 0 {
-		size, _ := memory.SysMem()
+		size, _ := memory.GetMemMonitor().SysMem()
 		memorySize = toml.Size(size * KB)
 	}
 	if c.OpenShardLimit <= 0 {

--- a/lib/memory/sysmemory.go
+++ b/lib/memory/sysmemory.go
@@ -15,144 +15,80 @@
 package memory
 
 import (
-	"bytes"
-	"os"
-	"runtime"
 	"sync"
 	"time"
 
-	"github.com/openGemini/openGemini/lib/util"
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
-const maxMemUse = 64 * 1024 * 1024 * 1024
+type memoryMonitor struct {
+	lastGetTime    time.Time // the last time the memory was read
+	totalCache     int64     // total memory cache
+	availableCache int64     // available memory cache
+	lock           sync.RWMutex
+}
 
-var lastGetTime time.Time
-var sysMemTotal, sysMemFree, totalMemoryMax int64
-var readMemMu sync.Mutex
+var (
+	memMonitor *memoryMonitor // singleton
+)
 
 func init() {
-	sysMemTotal, sysMemFree = ReadSysMemory()
-	totalMemoryMax = sysMemTotal
-	lastGetTime = time.Now()
+	memMonitor = newMemMonitor()
 }
 
-func ReadSysMemory() (int64, int64) {
-	if runtime.GOOS == "linux" {
-		return ReadSysMemoryLinux()
+func newMemMonitor() *memoryMonitor {
+	total, available := ReadSysMemory()
+	m := &memoryMonitor{
+		lastGetTime:    time.Now(),
+		totalCache:     total,
+		availableCache: available,
 	}
-	info, _ := mem.VirtualMemory()
-	return int64(info.Total / 1024), int64(info.Available / 1024)
+	return m
 }
 
-func ReadSysMemoryLinux() (total int64, available int64) {
-	var buf [256]byte
-	n1 := readSysMemInfo(buf[:])
-	if n1 != 0 {
-
-		// the first 256 bytes
-		// MemTotal
-		mTotalLeft := bytes.Index(buf[:], []byte("MemTotal"))
-		// MemAvailable
-		mAvailableLeft := bytes.Index(buf[:], []byte("MemAvailable"))
-		// MemFree
-		mFreeLeft := bytes.Index(buf[:], []byte("MemFree"))
-		// Buffers
-		mBuffersLeft := bytes.Index(buf[:], []byte("Buffers"))
-		// Cached
-		mCachedLeft := bytes.Index(buf[:], []byte("Cached"))
-
-		if mTotalLeft == -1 {
-			return maxMemUse, maxMemUse
-		}
-		total = getMemInt64(buf[:], "MemTotal:", mTotalLeft)
-
-		if mAvailableLeft != -1 {
-			available = getMemInt64(buf[:], "MemAvailable:", mAvailableLeft)
-			return
-		}
-
-		// lower kernel system
-		// MemAvailable = MemFree + Buffers + Cached
-		if mFreeLeft != -1 {
-			available += getMemInt64(buf[:], "MemFree:", mFreeLeft)
-		}
-
-		if mBuffersLeft != -1 {
-			available += getMemInt64(buf[:], "Buffers:", mBuffersLeft)
-		}
-
-		if mCachedLeft != -1 {
-			available += getMemInt64(buf[:], "Cached:", mCachedLeft)
-		}
-
-		return
-	}
-	/*
-		output like:
-		MemTotal:       32505856 kB
-		MemFree:        28917428 kB
-		MemAvailable:   29288348 kB
-		Buffers:               0 kB
-		Cached:           370920 kB
-		SwapCached:            0 kB
-		Active:          3422876 kB
-	*/
-	return maxMemUse, maxMemUse
+// get memory monitor singleton
+func GetMemMonitor() MemoryMonitor {
+	return memMonitor
 }
-func SysMem() (total, free int64) {
-	t := time.Now()
-	readMemMu.Lock()
-	defer readMemMu.Unlock()
-	if t.Sub(lastGetTime) < 100*time.Millisecond {
-		total, free = sysMemTotal, sysMemFree
+
+// get the total amount of memory and remaining capacity (total, available (kB))
+func (m *memoryMonitor) SysMem() (total, available int64) {
+	now := time.Now()
+	m.lock.RLock()
+	if now.Sub(m.lastGetTime) < cacheInterval {
+		total, available = m.totalCache, m.availableCache
+		m.lock.RUnlock()
 		return
 	}
-	total, free = ReadSysMemory()
-	if total <= 0 || free <= 0 {
-		total, free = totalMemoryMax, totalMemoryMax
-		return
+	m.lock.RUnlock()
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	now = time.Now() // double check
+	if now.Sub(m.lastGetTime) < cacheInterval {
+		return m.totalCache, m.availableCache
 	}
-	lastGetTime = t
-	sysMemTotal = total
-	sysMemFree = free
+
+	total, available = ReadSysMemory()
+	m.lastGetTime = now
+	m.totalCache = total
+	m.availableCache = available
+
 	return
 }
 
-func readSysMemInfo(buf []byte) int {
-	f, err := os.Open("/proc/meminfo")
-	if err != nil {
-		return 0
-	}
-	defer util.MustClose(f)
-
-	n, err := f.ReadAt(buf, 0)
-	if err != nil || n < len(buf) {
-		return 0
-	}
-	return n
-}
-
-func bytes2Int(b []byte) int64 {
-	var v int64
-	for _, c := range b {
-		v = v*10 + int64(c-'0')
-	}
-	return v
-}
-
-func MemUsedPct() float64 {
-	total, available := SysMem()
+// memory usage percentage
+func (m *memoryMonitor) MemUsedPct() float64 {
+	total, available := m.SysMem()
 	return (1 - float64(available)/float64(total)) * 100
 }
 
-// converts a memory value string (e.g., "MemTotal:     789745 kB") into an integer (e.g., 789745).
-func getMemInt64(buf []byte, prefix string, left int) int64 {
-	left += len(prefix)
-	right := bytes.Index(buf[left:], []byte("kB")) + left
-	if left > right {
-		return 0
+// return total available memory (kB)
+func ReadSysMemory() (int64, int64) {
+	if info, err := mem.VirtualMemory(); err != nil { // can not read memory, block it.
+		return defaultMaxMem, 0
+	} else {
+		return int64(info.Total >> 10), int64(info.Available >> 10)
 	}
-	mByte := bytes.TrimSpace(buf[left:right]) // [left, right)
-	return bytes2Int(mByte)
 }

--- a/lib/memory/sysmemory_benchmark_test.go
+++ b/lib/memory/sysmemory_benchmark_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 openGemini Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/openGemini/openGemini/lib/memory"
+)
+
+func BenchmarkSysMem(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		memory.GetMemMonitor().SysMem()
+	}
+}
+
+// go test -bench=BenchmarkSysMem -benchtime=5s
+/*
+	goos: windows
+	goarch: amd64
+	pkg: github.com/openGemini/openGemini/lib/memory
+	cpu: AMD Ryzen 5 5600H with Radeon Graphics
+	BenchmarkSysMem-12      706152351                8.444 ns/op           0 B/op          0 allocs/op
+	PASS
+	ok      github.com/openGemini/openGemini/lib/memory     6.978s
+*/
+
+/*
+	goos: linux
+	goarch: amd64
+	pkg: github.com/openGemini/openGemini/lib/memory
+	cpu: AMD Ryzen 5 5600H with Radeon Graphics
+	BenchmarkSysMem-12        924720              1281 ns/op               0 B/op          0 allocs/op
+	PASS
+	ok      github.com/openGemini/openGemini/lib/memory     1.232s
+*/

--- a/lib/memory/sysmemory_monitor.go
+++ b/lib/memory/sysmemory_monitor.go
@@ -1,0 +1,27 @@
+// Copyright 2025 openGemini Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import "time"
+
+const (
+	defaultMaxMem = 64 << 30 // default memory value
+	cacheInterval = 100 * time.Millisecond
+)
+
+type MemoryMonitor interface {
+	MemUsedPct() float64    // memory usage percentage
+	SysMem() (int64, int64) // get the total amount of memory and remaining capacity (total, available (kB))
+}

--- a/lib/memory/sysmemory_test.go
+++ b/lib/memory/sysmemory_test.go
@@ -12,108 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory
+package memory_test
 
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/openGemini/openGemini/lib/memory"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReadSysMemory(t *testing.T) {
-	total, available := ReadSysMemory()
-	MemUsedPct()
-	readSysMemInfo(nil)
+	total, available := memory.ReadSysMemory()
+	memUsed := memory.GetMemMonitor().MemUsedPct()
+	t.Log(total, available, memUsed)
 	require.NotEmpty(t, total)
 	require.NotEmpty(t, available)
+	require.NotEmpty(t, memUsed)
 }
 
-func BenchmarkReadSysMemory(b *testing.B) {
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		MemUsedPct()
-	}
-}
-
-func BenchmarkReadSysMemory_Parallel(b *testing.B) {
-	b.ReportAllocs()
+func TestSysMem(t *testing.T) {
 	var wg sync.WaitGroup
-	f := func() {
-		defer wg.Done()
-		for i := 0; i < b.N; i++ {
-			MemUsedPct()
-		}
-	}
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 100; i++ {
+		time.Sleep(time.Millisecond)
 		wg.Add(1)
-		go f()
+		go func() {
+			defer wg.Done()
+			memory.GetMemMonitor().SysMem() // t.Log(memory.GetMemMonitor().SysMem())
+		}()
 	}
 	wg.Wait()
-}
-
-func TestGetMemInt64(t *testing.T) {
-
-	type testCase struct {
-		info   string
-		prefix string
-		left   int
-		ans    int64
-	}
-
-	testCases := []testCase{
-		{
-			"MemTotal:       14528572 kB",
-			"MemTotal:",
-			0,
-			14528572,
-		},
-		{
-			"MemFree:         6194012 kB",
-			"MemFree:",
-			0,
-			6194012,
-		},
-		{
-			"MemAvailable:    6254489 kB",
-			"MemAvailable:",
-			0,
-			6254489,
-		},
-		{
-			"Buffers:           34032 kB",
-			"Buffers:",
-			0,
-			34032,
-		},
-		{
-			"Cached:           188576 kB",
-			"Cached:",
-			0,
-			188576,
-		},
-		{
-			"SwapCached:            0 kB",
-			"SwapCached:",
-			0,
-			0,
-		},
-		{
-			"HugePages_Total:       0",
-			"HugePages_Total:",
-			0,
-			0,
-		},
-		{
-			"   test:       55 kB",
-			"test:",
-			3,
-			55,
-		},
-	}
-
-	for _, tcase := range testCases {
-		act := getMemInt64([]byte(tcase.info), tcase.prefix, tcase.left)
-		require.Equal(t, tcase.ans, act)
-	}
 }

--- a/lib/memory/sysmemory_test.go
+++ b/lib/memory/sysmemory_test.go
@@ -51,3 +51,69 @@ func BenchmarkReadSysMemory_Parallel(b *testing.B) {
 	}
 	wg.Wait()
 }
+
+func TestGetMemInt64(t *testing.T) {
+
+	type testCase struct {
+		info   string
+		prefix string
+		left   int
+		ans    int64
+	}
+
+	testCases := []testCase{
+		{
+			"MemTotal:       14528572 kB",
+			"MemTotal:",
+			0,
+			14528572,
+		},
+		{
+			"MemFree:         6194012 kB",
+			"MemFree:",
+			0,
+			6194012,
+		},
+		{
+			"MemAvailable:    6254489 kB",
+			"MemAvailable:",
+			0,
+			6254489,
+		},
+		{
+			"Buffers:           34032 kB",
+			"Buffers:",
+			0,
+			34032,
+		},
+		{
+			"Cached:           188576 kB",
+			"Cached:",
+			0,
+			188576,
+		},
+		{
+			"SwapCached:            0 kB",
+			"SwapCached:",
+			0,
+			0,
+		},
+		{
+			"HugePages_Total:       0",
+			"HugePages_Total:",
+			0,
+			0,
+		},
+		{
+			"   test:       55 kB",
+			"test:",
+			3,
+			55,
+		},
+	}
+
+	for _, tcase := range testCases {
+		act := getMemInt64([]byte(tcase.info), tcase.prefix, tcase.left)
+		require.Equal(t, tcase.ans, act)
+	}
+}

--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -2062,7 +2062,7 @@ func (t *Throttler) Handler(h http.Handler) http.Handler {
 			// If there is no limit for concurrent queries and queues, the memory usage
 			// exceeds the threshold the new query is canceled and an error is reported
 			if t.query && sysconfig.GetInterruptQuery() {
-				memUsed := memory.MemUsedPct()
+				memUsed := memory.GetMemMonitor().MemUsedPct()
 				memThre := float64(sysconfig.GetUpperMemPct())
 				if memUsed > memThre {
 					resMsg := "request throttled, query memory exceeds the threshold, query is canceled"
@@ -2095,7 +2095,7 @@ func (t *Throttler) Handler(h http.Handler) http.Handler {
 				// the new query is blocked and wait until the memory is less than the threshold the query
 				// queue is full, or the query times out
 				if t.query && sysconfig.GetInterruptQuery() {
-					memUsed := memory.MemUsedPct()
+					memUsed := memory.GetMemMonitor().MemUsedPct()
 					memThre := float64(sysconfig.GetUpperMemPct())
 					if memUsed < memThre {
 						break
@@ -2107,7 +2107,7 @@ func (t *Throttler) Handler(h http.Handler) http.Handler {
 					for {
 						select {
 						case <-ticker.C:
-							if memory.MemUsedPct() < float64(sysconfig.GetUpperMemPct()) {
+							if memory.GetMemMonitor().MemUsedPct() < float64(sysconfig.GetUpperMemPct()) {
 								break
 							}
 						case <-timerCh:

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -11274,7 +11274,7 @@ func TestServer_Write_OutOfOrder(t *testing.T) {
 		queries: []*Query{
 			{
 				name:    "create database with shard group duration and index duration should succeed",
-				command: `CREATE DATABASE db3 WITH SHARD DURATION 12h index duration 24h name rp3`,
+				command: `CREATE DATABASE db4 WITH SHARD DURATION 12h index duration 24h name rp3`,
 				exp:     `{"results":[{"statement_id":0}]}`,
 			},
 		},
@@ -11308,7 +11308,7 @@ func TestServer_Write_OutOfOrder(t *testing.T) {
 		&Write{data: fmt.Sprintf(`cpu,host=serverA,region=uswest val=100 %d`, mustParseTime(time.RFC3339Nano, "2021-11-26T09:00:00Z").UnixNano())},
 		&Write{data: fmt.Sprintf(`cpu,host=serverB,region=uswest val=200 %d`, mustParseTime(time.RFC3339Nano, "2021-11-26T10:00:00Z").UnixNano())},
 	}
-	test.db = "db3"
+	test.db = "db4"
 	test.rp = "rp3"
 	if err := test.init(s); err != nil {
 		t.Fatalf("test init failed: %s", err)
@@ -11317,17 +11317,17 @@ func TestServer_Write_OutOfOrder(t *testing.T) {
 	test.queries = []*Query{
 		{
 			name:    "select val from in date 2021-11-26 should success",
-			command: `select val from db3.rp3.cpu where time>='2021-11-26T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
+			command: `select val from db4.rp3.cpu where time>='2021-11-26T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`,
 		},
 		{
 			name:    "select val from in date 2021-11-27 should success",
-			command: `select val from db3.rp3.cpu where time>='2021-11-27T00:00:00Z' and time<='2021-11-27T23:00:00Z' and "host"='serverB'`,
+			command: `select val from db4.rp3.cpu where time>='2021-11-27T00:00:00Z' and time<='2021-11-27T23:00:00Z' and "host"='serverB'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-27T10:00:00Z",106]]}]}]}`,
 		},
 		{
 			name:    "select val from 25 to 26 should success",
-			command: `select val from db3.rp3.cpu where time>='2021-11-25T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
+			command: `select val from db4.rp3.cpu where time>='2021-11-25T00:00:00Z' and time<='2021-11-26T23:00:00Z' and "host"='serverB'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","val"],"values":[["2021-11-25T13:00:00Z",23.3],["2021-11-26T10:00:00Z",200],["2021-11-26T14:00:00Z",23.2]]}]}]}`,
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: fix #894 

### What is changed and how it works?
Through the log, I locate the function that reads memory information in the code: `ReadSysMemoryLinux`. From the source code, we can see that the code reads `MemTotal` and `MemAvailable` from the memory monitoring file `/proc/meminfo` of the Linux system as the total memory capacity and free memory capacity respectively. However, in some Linux systems with lower kernel versions, `MemAvailable` does not exist in the memory monitoring file, as shown in the following area:
```shell
MemTotal:       14528572 kB
MemFree:         6194012 kB
Buffers:           34032 kB
Cached:           188576 kB
SwapCached:            0 kB
Active:           167556 kB
Inactive:         157876 kB
...
```
Therefore, for the old version, We can call method [mem.VirtualMemory()](https://github.com/shirou/gopsutil/blob/eecb04b99876a0cc722328d488bde054184225e4/mem/mem_linux.go#L21) of third-party package [gopsutil](https://github.com/shirou/gopsutil). 
1. Optimized `SysMem()` by replacing write lock with read-write lock, enhancing performance in high-concurrency query scenarios.
2. The original code had poor readability and a chaotic structure, which did not conform to structured design principles. I abstracted a memory monitoring interface, standardizing the code and enhancing its extensibility.
3. Resolved memory monitoring compatibility issues.

### How Has This Been Tested?
Now, we can execute commands normally in low-kernel systems (such as ubuntu18.04.5).
```shell
openGemini CLI 1.3.1 (rev-revision)
Please use `quit`, `exit` or `Ctrl-D` to exit this program.
> show databases
name: databases 
+-----------+
|   name    | 
+-----------+
| _internal |
| db0       |
+-----------+
1 columns, 2 rows in set
>
```

I also added unit tests to the newly added code.
✅  BenchmarkSysMem
```shell
goos: windows
goarch: amd64
pkg: github.com/openGemini/openGemini/lib/memory
cpu: AMD Ryzen 5 5600H with Radeon Graphics
BenchmarkSysMem-12      706152351                8.444 ns/op           0 B/op          0 allocs/op
PASS
ok      github.com/openGemini/openGemini/lib/memory     6.978s

goos: linux
goarch: amd64
pkg: github.com/openGemini/openGemini/lib/memory
cpu: AMD Ryzen 5 5600H with Radeon Graphics
BenchmarkSysMem-12        924720              1281 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/openGemini/openGemini/lib/memory     1.232s
```
✅  TestReadSysMemory
✅  TestSysMem

# Checklist:

✅ My code follows the style guidelines of this project
✅ I have performed a self-review of my own code
✅ I have commented my code, particularly in hard-to-understand areas
❌ I have made corresponding changes to the documentation
✅ My changes generate no new warnings
✅ I have added tests that prove my fix is effective or that my feature works
✅ New and existing unit tests pass locally with my changes
✅ Any dependent changes have been merged and published in downstream modules
