### PR TITLE
fix: fix parse schema,etc

### DIFF
--- a/lib/util/lifted/vm/protoparser/influx/parser.go
+++ b/lib/util/lifted/vm/protoparser/influx/parser.go
@@ -1624,7 +1624,7 @@ func parseFieldNumValue(s string) (float64, int32, error) {
 		// Unsigned integer value
 		return 0, Field_Type_Unknown, fmt.Errorf("invalid number")
 	}
-	if ch == 'f' {
+	if ch == 'f' && len(s) > 1 {
 		// Unsigned integer value
 		ss := s[:len(s)-1]
 		n := fastfloat.ParseBestEffort(ss)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

1.Issue Number: fix #904.
2.In the case of memory overflow, the `show queries` and `kill query` statements are released.
3.During the loop, if it is found that the memory usage has decreased, it is impossible to exit the loop and continue execution, but it is still blocked until the timeout.

### What is changed and how it works?
Now I insert `f` and it can be correctly parsed as bool type.
```shell
> insert new_mf,t1=xxx v1=12,v2=2.5f,v3=5f,v4=f,v5=F,v6=False,v7=t
> show field keys on db9 from new_mf
name: new_mf
+----------+-----------+
| fieldKey | fieldType |
+----------+-----------+
| v1       | float     |
| v2       | float     |
| v3       | float     |
| v4       | boolean   |
| v5       | boolean   |
| v6       | boolean   |
| v7       | boolean   |
+----------+-----------+
2 columns, 7 rows in set
> select * from new_mf
name: new_mf
+---------------------+-----+----+-----+----+-------+-------+-------+------+
|        time         | t1  | v1 | v2  | v3 |  v4   |  v5   |  v6   |  v7  |
+---------------------+-----+----+-----+----+-------+-------+-------+------+
| 1755763357598421500 | xxx | 12 | 2.5 |  5 | false | false | false | true |
+---------------------+-----+----+-----+----+-------+-------+-------+------+
9 columns, 1 rows in set
```
Use flag `Loop` to break loop instead of select.
```go
Loop:
for {
    select {
        case <-ticker.C:  // 100ms
        	if memory.GetMemMonitor().MemUsedPct() < float64(sysconfig.GetUpperMemPct()) {
				break Loop  // break loop instead of select
			}
		case <-timerCh:  // block 5m0s
			t.Logger.Warn("request throttled, exceeds timeout", zap.Duration("d", timeout), zap.Int("current length", len(t.current)))
			http.Error(w, "request throttled, exceeds timeout", http.StatusServiceUnavailable)
			return
	}
}
```

When memory usage exceeds the threshold, statements `show queries` and `kill query` are allowed to execute to free up resources.

# Checklist:

✅ My code follows the style guidelines of this project
✅ I have performed a self-review of my own code
✅ I have commented my code, particularly in hard-to-understand areas
❌ I have made corresponding changes to the documentation
✅ My changes generate no new warnings
✅ I have added tests that prove my fix is effective or that my feature works
❌ New and existing unit tests pass locally with my changes
✅ Any dependent changes have been merged and published in downstream modules
