### PR TITLE
fix: return ReplicaN as integer in SHOW DATABASES DETAIL

### DIFF
--- a/lib/util/lifted/influx/coordinator/statement_executor.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1297,7 +1296,7 @@ func (e *StatementExecutor) executeShowDatabasesStatement(q *influxql.ShowDataba
 				} else {
 					tagAttr = "default"
 				}
-				row.Values = append(row.Values, []interface{}{di.Name, strconv.Itoa(di.ReplicaN), tagAttr})
+				row.Values = append(row.Values, []interface{}{di.Name, di.ReplicaN, tagAttr})
 			}
 		}
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -950,6 +950,11 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","hot duration","warm duration","index duration","replicaN","default"],"values":[["autogen","0s","168h0m0s","0s","0s","168h0m0s",1,false],["rp0","0s","168h0m0s","0s","0s","168h0m0s",1,true]]}]}]}`,
 		},
 		{
+			name:    "show databases detail returns ReplicaN as integer",
+			command: `show databases detail`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name","ReplicaN","Tag Attribute"],"values":[["db0",1,"default"]]}]}]}`,
+		},
+		{
 			name:    "default rp",
 			command: `SELECT * FROM db0..cpu GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T01:00:00Z",1]]}]}]}`,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #641

`SHOW DATABASES DETAIL` returned the `ReplicaN` column as a JSON string (`"1"`),
while `SHOW RETENTION POLICIES` returns `replicaN` as a JSON integer (`1`). The
issue asks for the `replicaN` value to always be an integer, so the two commands
agree.

### What is changed and how it works?

In `executeShowDatabasesStatement`, the `ReplicaN` value was being appended to the
result row via `strconv.Itoa(di.ReplicaN)`, which serializes it as a quoted
string. It now appends the raw `int` (`di.ReplicaN`), so the HTTP API serializes
it as a JSON number, matching how `SHOW RETENTION POLICIES` builds its row in
`meta/data.go` (`rp.ReplicaN` appended directly). `strconv` was used nowhere else
in the file, so its import was removed. Scope is limited to the integer type fix
the issue describes; the broader column-name casing nits raised in a comment are
left for a separate change.

### How Has This Been Tested?

- [x] Added a server-level test in `tests/server_test.go`
  (`TestServer_Query_DefaultDBAndRP`) asserting `show databases detail` returns
  `["db0",1,"default"]` with `ReplicaN` as an unquoted integer.
- [x] Verified end-to-end against a local single-node `ts-server`: the new case
  passes; reverting the fix makes it fail with `["db0","1","default"]`.
- [x] `go build` / `go vet` / `go test` on the touched coordinator package pass;
  `gofmt` clean.
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
