### PR TITLE
fix: clamp undersized bloom filter buffers to avoid panic

### DIFF
--- a/lib/bloomfilter/bloomfilter.go
+++ b/lib/bloomfilter/bloomfilter.go
@@ -203,7 +203,24 @@ func NewOneHitBloomFilter(bytes []byte, version uint32) Bloomfilter {
 	}
 }
 
+// Minimum buffer sizes accepted by DefaultOneHitBloomFilter. Add/Hit derive the
+// byte offset from the hash and read an 8-byte word, so the buffer must cover the
+// largest possible offset plus 8. V0/V1 use hash>>49 (max offset 32767), V2/V3 use
+// hash>>46 (max offset 262143). Sizes below these would panic with a slice bounds
+// error, so they are clamped up here.
+const (
+	minBloomFilterSizeV01 = 32775
+	minBloomFilterSizeV2  = 262151
+)
+
 func DefaultOneHitBloomFilter(version uint32, bloomfiterSize int64) Bloomfilter {
+	minSize := int64(minBloomFilterSizeV01)
+	if version >= 2 {
+		minSize = minBloomFilterSizeV2
+	}
+	if bloomfiterSize < minSize {
+		bloomfiterSize = minSize
+	}
 	bytes := make([]byte, bloomfiterSize)
 	return NewOneHitBloomFilter(bytes, version)
 }

--- a/lib/bloomfilter/bloomfilter_test.go
+++ b/lib/bloomfilter/bloomfilter_test.go
@@ -57,6 +57,18 @@ func TestBloomFilterWithConflict(t *testing.T) {
 	}
 }
 
+func TestBloomFilterUndersizedNoPanic(t *testing.T) {
+	// version, worst-case max-offset hash: V0/V1 use hash>>49 (max 32767),
+	// V2/V3 use hash>>46 (max 262143). Requesting size 8 is far below the
+	// minimum; the buffer must be clamped so Add/Hit do not panic.
+	cases := [][2]uint64{{0, 0x7fff << 49}, {2, 0x3ffff << 46}, {3, 0x3ffff << 46}}
+	for _, c := range cases {
+		bf := DefaultOneHitBloomFilter(uint32(c[0]), 8)
+		bf.Add(c[1])
+		assert.True(t, bf.Hit(c[1]))
+	}
+}
+
 const (
 	Prime_64 uint64 = 0x9E3779B185EBCA87
 )


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #940

`DefaultOneHitBloomFilter` allocated a buffer of exactly the requested size and
passed it straight to the version implementation, with no minimum-size check. The
Add/Hit paths derive a byte offset from the hash and read an 8-byte word at that
offset (`b.bytes[offset:offset+8]`), so a buffer smaller than the largest possible
offset+8 panics with `slice bounds out of range`. Required minimums: 32775 bytes
for V0/V1 (offset = hash>>49, max 32767) and 262151 bytes for V2/V3
(offset = hash>>46, max 262143).

### What is changed and how it works?

Clamp `bloomfiterSize` up to the version minimum inside `DefaultOneHitBloomFilter`
before allocating, so an undersized request can never produce a filter that
panics. The two minimums are added as named constants. The `Bloomfilter` interface
is unchanged (Add/Hit stay void) and no hot-path indexing is touched. Production
callers already size from `logstore` constants (32832 / 262208), both above the
minimum, so this is invisible in production and only removes the panic surface.

### How Has This Been Tested?

- [x] Added `TestBloomFilterUndersizedNoPanic`: requests size 8 and adds the
      worst-case max-offset hash for V0/V2/V3; asserts no panic and that the value
      Hits. It panics at bloomfilter.go:94 without the clamp and passes with it.
- [x] Existing `TestBloomFilter` / `TestBloomFilterWithConflict` still pass.
- [ ] No code

Commands (pinned toolchain; a dependency breaks on Go 1.26):

```
GOTOOLCHAIN=go1.24.5 CGO_ENABLED=0 go test ./lib/bloomfilter/ -count=1
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
