### PR TITLE
fix: support explain analyze with select into

### DIFF
--- a/lib/util/lifted/influx/coordinator/statement_executor.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor.go
@@ -940,12 +940,21 @@ func (e *StatementExecutor) executeExplainStatement(q *influxql.ExplainStatement
 	return nil, meta2.ErrUnsupportCommand
 }
 
+// explainAnalyzeWriter is a no-op point writer used so that EXPLAIN ANALYZE can
+// trace a SELECT ... INTO plan without persisting any rows to the target.
+type explainAnalyzeWriter struct{}
+
+func (w *explainAnalyzeWriter) RetryWritePointRows(database, retentionPolicy string, points []influx.Row) error {
+	return nil
+}
+
 func (e *StatementExecutor) executeExplainAnalyzeStatement(q *influxql.ExplainStatement, ectx *query.ExecutionContext) (models.Rows, error) {
 	stmt := q.Statement
 	trace, span := tracing.NewTrace("SELECT")
 	stmt.OmitTime = true
 	ctx := tracing.NewContextWithTrace(ectx.Context, trace)
 	ctx = tracing.NewContextWithSpan(ctx, span)
+	ctx = context.WithValue(ctx, executor.WRITER_CONTEXT, &explainAnalyzeWriter{})
 	span.AppendNameValue("statement", q.String())
 	span.Finish()
 

--- a/lib/util/lifted/influx/coordinator/statement_executor_test.go
+++ b/lib/util/lifted/influx/coordinator/statement_executor_test.go
@@ -1,12 +1,14 @@
 package coordinator
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openGemini/openGemini/engine/executor"
 	"github.com/openGemini/openGemini/lib/errno"
 	Logger "github.com/openGemini/openGemini/lib/logger"
 	meta "github.com/openGemini/openGemini/lib/metaclient"
@@ -15,6 +17,7 @@ import (
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/influxql"
 	meta2 "github.com/openGemini/openGemini/lib/util/lifted/influx/meta"
 	"github.com/openGemini/openGemini/lib/util/lifted/influx/query"
+	"github.com/openGemini/openGemini/lib/util/lifted/vm/protoparser/influx"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
@@ -35,6 +38,22 @@ func TestLimitStringSlice(t *testing.T) {
 	copy(series, originSeries)
 	res = limitStringSlice(series, 7, 0)
 	assert.Equal(t, true, res == nil)
+}
+
+// TestExplainAnalyzeWriter verifies that the writer attached by
+// executeExplainAnalyzeStatement satisfies the point writer contract that
+// TargetTransform looks up via executor.WRITER_CONTEXT, so EXPLAIN ANALYZE of a
+// SELECT ... INTO statement traces the plan without failing, and that it writes
+// nothing (an analyze must not persist rows). Regression test for #309.
+func TestExplainAnalyzeWriter(t *testing.T) {
+	w := &explainAnalyzeWriter{}
+	assert.NoError(t, w.RetryWritePointRows("db0", "rp0", []influx.Row{{Name: "mst0"}}))
+
+	ctx := context.WithValue(context.Background(), executor.WRITER_CONTEXT, w)
+	_, ok := ctx.Value(executor.WRITER_CONTEXT).(interface {
+		RetryWritePointRows(database, retentionPolicy string, points []influx.Row) error
+	})
+	assert.True(t, ok)
 }
 
 type MockMetaClient struct {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #309

`EXPLAIN ANALYZE` of a `SELECT ... INTO` statement fails with:

```
ERR: no point writer can be worked for into target transform
```

A plain `SELECT ... INTO ...` works; only the `EXPLAIN ANALYZE` variant errors.

Reproduce on `main` against a single-node ts-server:

```sql
CREATE DATABASE NOAA_water_database;
CREATE DATABASE mydb;
-- write one point to NOAA_water_database..h2o_feet, then:

SELECT * INTO mydb..h2o_feet FROM NOAA_water_database..h2o_feet GROUP BY *;
-- {"columns":["time","written"],"values":[[...,0]]}   (OK)

EXPLAIN ANALYZE SELECT * INTO mydb..h2o_feet FROM NOAA_water_database..h2o_feet GROUP BY *;
-- {"error":"no point writer can be worked for into target transform"}
```

**Root cause.** An `INTO` plan contains a `TargetTransform`, which at
`engine/executor/target_transform.go:161` requires a point writer from the
execution context:

```go
if trans.writer, ok = ctx.Value(WRITER_CONTEXT).(pointerWriter); !ok {
    return fmt.Errorf("no point writer can be worked for into target transform")
}
```

The normal `SELECT` path supplies one
(`statement_executor.go:1132`,
`context.WithValue(..., executor.WRITER_CONTEXT, ctx.PointsWriter)`), but
`executeExplainAnalyzeStatement` builds its context without
`executor.WRITER_CONTEXT`, so the `TargetTransform` finds no writer and errors.

### What is changed and how it works?

Attach a writer to the analyze context so the plan can be traced, but use a
**no-op** writer rather than the real `PointsWriter`: an `EXPLAIN ANALYZE` must
trace the plan **without persisting any rows** to the target measurement.

In `executeExplainAnalyzeStatement`
(`lib/util/lifted/influx/coordinator/statement_executor.go`):

```go
// explainAnalyzeWriter is a no-op point writer used so that EXPLAIN ANALYZE can
// trace a SELECT ... INTO plan without persisting any rows to the target.
type explainAnalyzeWriter struct{}

func (w *explainAnalyzeWriter) RetryWritePointRows(database, retentionPolicy string, points []influx.Row) error {
    return nil
}

// ... inside executeExplainAnalyzeStatement, after the trace/span context is built:
ctx = context.WithValue(ctx, executor.WRITER_CONTEXT, &explainAnalyzeWriter{})
```

`pointerWriter` (the interface `TargetTransform` looks up) is unexported in
`engine/executor`, so the no-op implementation lives where the writer is
attached, mirroring how the package's own tests stub it
(`MockPointWriter` in `mock_tsdb_system_test.go`). No interface, no
`TargetTransform`, and no change to the normal `SELECT ... INTO` hot path.

### How Has This Been Tested?

- [x] `go build ./lib/util/lifted/influx/coordinator/ ./engine/executor/` and the full `ts-server` build pass.
- [x] `gofmt -l` and `go vet` clean on the changed files (vet reports only pre-existing, unrelated `unreachable code` notes elsewhere in the package).
- [x] `go test ./lib/util/lifted/influx/coordinator/` passes, including the new `TestExplainAnalyzeWriter`; `engine/executor` `SELECT ... INTO` / `TargetTransform` tests pass.
- [x] Manual end-to-end on a single-node ts-server: before this change the `EXPLAIN ANALYZE SELECT ... INTO` query returns the "no point writer" error; after it, the query returns an `EXPLAIN ANALYZE` trace, and the target measurement is unchanged (no rows written by the analyze).

```
GOTOOLCHAIN=go1.24.5 CGO_ENABLED=0 go build ./lib/util/lifted/influx/coordinator/ ./engine/executor/
GOTOOLCHAIN=go1.24.5 CGO_ENABLED=0 go test  ./lib/util/lifted/influx/coordinator/ -run TestExplainAnalyzeWriter -v
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
