### PR TITLE
test: assert decoded chunk meta in self-compress round-trip

### DIFF
--- a/engine/immutable/chunk_meta_codec_test.go
+++ b/engine/immutable/chunk_meta_codec_test.go
@@ -116,7 +116,8 @@ func TestChunkMetaCodec(t *testing.T) {
 		other.Validation()
 		require.NoError(t, err)
 
-		got, err := marshalChunkMetaNormal(cm)
+		got, err := marshalChunkMetaNormal(other)
+		require.NoError(t, err)
 		require.Equal(t, exp, got)
 	})
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: N/A (no tracked issue; a self-contained test-correctness fix)

`TestChunkMetaCodec` in `engine/immutable/chunk_meta_codec_test.go` is the primary
round-trip test for the self-compress `ChunkMeta` codec. Its round-trip assertion
does not actually assert the round trip.

Inside the first `iterateChunkMeta` closure it computes the reference encoding from
the original chunk meta:

```go
exp, err := marshalChunkMetaNormal(cm)
```

then encodes `cm` with the self-compress codec, decodes it back into a fresh
`other`, and is meant to compare the decoded object against the reference. But the
final step re-marshalled the *original* `cm` again:

```go
got, err := marshalChunkMetaNormal(cm) // same input as exp
require.Equal(t, exp, got)             // effectively X == X
```

Because `marshalChunkMetaNormal` is a pure function of its argument and does not
mutate `cm`, `exp` and `got` are derived from the same unmutated `cm`, so
`require.Equal(t, exp, got)` is `X == X` and passes regardless of what the
self-compress encode/decode produced. The decoded `other` is only run through
`other.Validation()`, which checks structural counts (series id, time-range slice
length, column count, per-column entry counts) and never inspects the decoded
time-range values, per-column offsets/sizes, names, or types. As a result a
value-level defect in the self-compress decode path (a wrong scale, an off-by-one
in accumulated column offsets, a swapped column order) would leave `other` corrupt
while this test stayed green.

### What is changed and how it works?

Marshal the decoded `other` instead of the original `cm`, and check the marshal
error that was previously dropped:

```go
got, err := marshalChunkMetaNormal(other)
require.NoError(t, err)
require.Equal(t, exp, got)
```

Now `exp` is the reference normal encoding of the original chunk meta and `got` is
the normal encoding of the object that has been through a full self-compress
encode -> decode cycle, so `require.Equal` is a genuine value-level round-trip
check. The added `require.NoError(t, err)` matches every other marshal/unmarshal in
the same closure (they are all error-checked). No production code changes; the diff
is +2/-1 in a single test file.

### How Has This Been Tested?

This is a test-only change (no production code touched). It runs under the existing
unit-test job:

```
make gotest   # exercises ./engine/immutable/..., including TestChunkMetaCodec
```

`gofmt -l engine/immutable/chunk_meta_codec_test.go` reports no diff. The corrected
assertion now compares the self-compress-decoded chunk meta against the original's
normal encoding, so the round trip is value-checked rather than compared to itself.

- [x] `TestChunkMetaCodec` (`engine/immutable`) via `make gotest`
- [ ] Test cases to be added
- [x] No code (production changes)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
