### PR TITLE
test(metaclient): assert GetSgEndTime happy-path return value

### DIFF
--- a/lib/metaclient/meta_client_test.go
+++ b/lib/metaclient/meta_client_test.go
@@ -3469,8 +3469,9 @@ func TestClient_GetSgEndTimeErr(t *testing.T) {
 	_, err = c.GetSgEndTime("db0", "rp0", time.Unix(1, 0), config.TSSTORE)
 	assert.NotEqual(t, err, nil)
 	c.cacheData.Databases["db0"].RetentionPolicies["rp0"].ShardGroups = append(c.cacheData.Databases["db0"].RetentionPolicies["rp0"].ShardGroups, sg1)
-	endTime, _ := c.GetSgEndTime("db0", "rp0", time.Unix(1, 0), config.TSSTORE)
-	assert.NotEqual(t, endTime, 2000000000)
+	endTime, err := c.GetSgEndTime("db0", "rp0", time.Unix(1, 0), config.TSSTORE)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, int64(2000000000), endTime)
 }
 
 func TestClient_ShowClusterWithCondition(t *testing.T) {


### PR DESCRIPTION

<!-- Thank you for contributing to openGemini! -->

### What problem does this PR solve?

Issue Number: none (self-found test-correctness defect; no tracked issue)

`TestClient_GetSgEndTimeErr` in `lib/metaclient/meta_client_test.go` covers the
error paths of `Client.GetSgEndTime` (`lib/metaclient/meta_client_impl.go`), but
its single success-path assertion never actually verifies anything:

```go
endTime, _ := c.GetSgEndTime("db0", "rp0", time.Unix(1, 0), config.TSSTORE)
assert.NotEqual(t, endTime, 2000000000)
```

`GetSgEndTime` returns `sg.EndTime.UnixNano()`, an `int64`, while the literal
`2000000000` is an untyped constant that defaults to `int`. For non-`[]byte`
operands, testify's `ObjectsAreEqual` compares with `reflect.DeepEqual`, and
`reflect.DeepEqual(int64(x), int(x))` is always false because the dynamic types
differ. So this `assert.NotEqual` succeeds for every possible return value: the
branch that returns a real shard group end time has effectively zero coverage. A
regression that made `GetSgEndTime` return `0`, the wrong shard group's end time,
or any other value would keep the test green. The assertion is also logically
inverted, since the correct return for this input is exactly `2000000000`.

### What is changed and how it works?

Replace the no-op assertion with genuine, correctly typed checks of the success
path:

```go
endTime, err := c.GetSgEndTime("db0", "rp0", time.Unix(1, 0), config.TSSTORE)
assert.Equal(t, nil, err)
assert.Equal(t, int64(2000000000), endTime)
```

For this test's setup, `sg1` spans `[time.Unix(0), time.Unix(2))` and the query
timestamp `time.Unix(1, 0)` falls inside it, with `config.TSSTORE` (== 0)
matching the shard group's zero-value engine type, so the success branch returns
`time.Unix(2, 0).UnixNano()` == `2000000000` with a nil error. Using
`int64(2000000000)` makes the comparison type-correct, and asserting `err == nil`
documents that this is the happy path. No production code is changed; this only
fixes the test so it can catch a regression.

### How Has This Been Tested?

- [x] `gofmt -l lib/metaclient/meta_client_test.go` reports no changes.
- [ ] `go test ./lib/metaclient/ -run '^TestClient_GetSgEndTimeErr$'` (blocked
  before tests run because `bytedance/sonic v1.13.3` does not compile with Go
  1.25 or newer)
- [ ] Test cases to be added
- [ ] No code

Confirmed with an isolated testify v1.11.1 harness that the change is a real
red-to-green improvement: the old assertion passes for both the correct value
and a wrong value such as `0`, while the new assertion passes for the correct
value and fails for the wrong value. The package test remains for CI verification
once the repository's existing `sonic` toolchain incompatibility is resolved.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
