### PR TITLE
fix: avoid data race on ProcessorOptions.Sources in cluster query planner

### DIFF
--- a/coordinator/shard_mapper.go
+++ b/coordinator/shard_mapper.go
@@ -680,6 +680,7 @@ func (csm *ClusterShardMapping) RemoteQueryETraitsAndSrc(ctx context.Context, op
 	eTraits := make([]hybridqp.Trait, 0, len(shardsMapByNode))
 	var muList = sync.Mutex{}
 	var errs error
+	var resultSrc influxql.Sources
 	once := sync.Once{}
 	wg := sync.WaitGroup{}
 	for nodeID, shardsByPtId := range shardsMapByNode {
@@ -709,7 +710,7 @@ func (csm *ClusterShardMapping) RemoteQueryETraitsAndSrc(ctx context.Context, op
 				}
 
 				muList.Lock()
-				opts.Sources = src
+				resultSrc = src
 				eTraits = append(eTraits, rq)
 				muList.Unlock()
 			}(nodeID, pId, sIds)
@@ -719,7 +720,11 @@ func (csm *ClusterShardMapping) RemoteQueryETraitsAndSrc(ctx context.Context, op
 	if errs != nil {
 		return nil, errs
 	}
-	if schema.Options().(*query.ProcessorOptions).Sources == nil {
+	// Assign the resolved sources once the fan-out has completed. Setting
+	// opts.Sources inside the goroutines races the unlocked *opts copy that
+	// each goroutine passes to makeRemoteQuery.
+	opts.Sources = resultSrc
+	if opts.Sources == nil {
 		return nil, nil
 	}
 	return eTraits, nil


### PR DESCRIPTION

```markdown
### What problem does this PR solve?

Issue Number: fix #<ISSUE>

`ClusterShardMapping.RemoteQueryETraitsAndSrc` (coordinator/shard_mapper.go) fans
out one goroutine per (node, pt) pair. Each goroutine passes the shared
`*query.ProcessorOptions` to `makeRemoteQuery` by value (`*opts`), which copies
the whole struct including the `Sources` slice header without holding a lock,
while a sibling goroutine writes `opts.Sources = src` under `muList`. The mutex
guards only the write, so the unlocked read-copies race it: with two or more
(node, pt) pairs (the common distributed multi-shard query) this is a Go data
race on `opts.Sources`.

### What is changed and how it works?

The write is not redundant. `opts` is `schema.Options().(*ProcessorOptions)`, and
after planning the logical-plan builders read `schema.Options().Sources[0]` to set
the measurement name (`mstName`). So rather than dropping the write, this hoists
it out of the fan-out:

- capture the resolved source in a local `resultSrc` under the existing `muList`
  lock (replacing the in-goroutine `opts.Sources = src`);
- assign `opts.Sources = resultSrc` exactly once after `wg.Wait()`, when the
  concurrent phase has only read `opts`.

During the concurrent phase `opts` is now read-only, so the `*opts` copies no
longer race any write, and the post-`wg.Wait()` assignment is ordered by the
WaitGroup happens-before. The final value of `opts.Sources` is unchanged (a
resolved `src`, or nil when no goroutine produced a result), and the nil-check
reads the same object as before, so behavior is preserved and the race is removed.

### How Has This Been Tested?

- [x] `gofmt`/`go vet`/`go build` on `./coordinator/` are clean for the changed file.
- [x] Modeled the exact concurrency shape (shared `*Options`, per-goroutine
      by-value copy vs a locked `opts.Sources` write) under `go test -race`: the
      pre-fix shape reports a data race, the post-fix shape is clean.
- [ ] `go test -race ./coordinator/` on a full checkout (see note below).
- [ ] No code

Note: I could not run `go test -race ./coordinator/` end to end in my environment
because the `coordinator` package currently fails to compile against
`github.com/bytedance/sonic@v1.13.3` on Go >= 1.25 (`internal/rt`:
`undefined: GoMapIterator`), while `go.mod` floors `go 1.25.0`. Unmodified `main`
fails to build identically, so this is a pre-existing toolchain/dependency issue,
not a result of this change. A reviewer with a working toolchain can confirm the
fix via `go test -race ./coordinator/`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
```
