### PR TITLE
fix(cache): lock Size reads to prevent data race

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -143,6 +143,9 @@ func (c *Cache) Put(key string, value Entry, needUpdate func(old Entry, new Entr
 }
 
 func (c *Cache) Size() int64 {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
 	return c.usedBytes
 }
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -15,6 +15,8 @@
 package cache_test
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -118,4 +120,32 @@ func testIncIterNumCacheGetPutFunc(t *testing.T) {
 		t.Fatalf("can not get the global iter num ")
 	}
 	assert.Equal(t, iterNum, int32(4))
+}
+
+// TestCacheSizeConcurrent runs Size concurrently with Put to ensure the read of
+// usedBytes is synchronized. Run with -race to detect the data race.
+func TestCacheSizeConcurrent(t *testing.T) {
+	c := cache.NewCache(cache.IncIterNumCacheSize, cache.IncIterNumCacheTTL)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			queryID := strconv.Itoa(i)
+			entry := cache.NewIncIterNumEntry(queryID)
+			entry.SetValue(int32(i))
+			c.Put(queryID, entry, cache.UpdateIterNumFunc)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = c.Size()
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: ref #xxx

`Cache.Size()` in `lib/cache/cache.go` returned `c.usedBytes` without holding
the lock, while `Put` and `removeElement` mutate `c.usedBytes` under
`c.mutex.Lock()`. The immediately adjacent `Len()` already takes an `RLock()`
for its analogous read of `c.ll.Len()`, so `Size()` was missing the same guard.
That makes the read of `usedBytes` an unsynchronized concurrent access (a Go
data race, and a torn read on 32-bit) whenever another goroutine is inside
`Put`/`Get`/`Remove` updating `usedBytes` under the write lock.

The path is genuinely concurrent:
- `MemCacheAdapter.Put` calls `adapter.memCache.Size()` at the end of the HTTP
  query-result cache path (`lib/resultcache/adapter.go`), which runs per query
  request.
- The same `Cache` type backs the process-global `cache.NodeIncIterNumCache` /
  `cache.GlobalIncIterNumCache` read and written by concurrent query executors.

### What is changed and how it works?

`Size()` now takes `c.mutex.RLock()` / `defer c.mutex.RUnlock()` around the
read, mirroring `Len()` exactly. There is no behavior change beyond
synchronization: it still returns the current `usedBytes`. No hot path or public
signature changes.

A concurrent regression test (`TestCacheSizeConcurrent`) runs `Put` and `Size`
in two goroutines over the same cache. The Go race detector flags the
unsynchronized read at `cache.go` without the fix and the test passes with it.

### How Has This Been Tested?

- [x] Added `TestCacheSizeConcurrent` in `lib/cache/cache_test.go`, using only
      the public API (`NewCache`, `NewIncIterNumEntry`, `SetValue`, `Put`,
      `Size`, `UpdateIterNumFunc`). Under `-race` it reports `DATA RACE` (write
      at `cache.go` in `Put` vs read in `Size`) and FAILs without the guard;
      with the guard it PASSes.
- [x] `go test -race ./lib/cache/` passes (all package tests green) with the
      fix; `gofmt` and `go vet ./lib/cache/` are clean.
- [ ] No code

Command (race detector needs cgo):

```
CGO_ENABLED=1 go test -race ./lib/cache/ -run TestCacheSizeConcurrent -count=1
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
