### PR TITLE
fix: correct addMax tie-break in Float/BooleanPreAgg

### DIFF
--- a/engine/immutable/pre_aggregation.go
+++ b/engine/immutable/pre_aggregation.go
@@ -599,9 +599,9 @@ func (m *FloatPreAgg) addMax(v float64, tm int64) {
 	if m.maxV < v {
 		m.maxV = v
 		m.maxTime = tm
-	} else if m.minV == v {
-		if tm < m.minTime {
-			m.minTime = tm
+	} else if m.maxV == v {
+		if tm < m.maxTime {
+			m.maxTime = tm
 		}
 	}
 }
@@ -786,9 +786,9 @@ func (m *BooleanPreAgg) addMax(v float64, tm int64) {
 	if bv > m.maxV {
 		m.maxV = bv
 		m.maxTime = tm
-	} else if m.minV == bv {
-		if tm < m.minTime {
-			m.minTime = tm
+	} else if m.maxV == bv {
+		if tm < m.maxTime {
+			m.maxTime = tm
 		}
 	}
 }

--- a/engine/immutable/pre_aggregation_test.go
+++ b/engine/immutable/pre_aggregation_test.go
@@ -139,6 +139,54 @@ func TestFloatPreAgg_add(t *testing.T) {
 	assertMax(2.0, 30)
 }
 
+// TestFloatPreAgg_addMax_minTimeNotCorrupted is a regression test for a bug where
+// FloatPreAgg.addMax compared the incoming value against minV instead of maxV,
+// and on a coincidental tie overwrote minTime with an unrelated timestamp. That
+// decoupled the min value from its recorded time, which surfaced as first()
+// returning a correct value paired with a wrong time when the pre-aggregated
+// min/max metadata was merged across chunks.
+func TestFloatPreAgg_addMax_minTimeNotCorrupted(t *testing.T) {
+	agg := NewFloatPreAgg()
+
+	agg.addMin(1, 100)
+	agg.addMax(5, 50)
+
+	// v equals the current minV (1), not maxV (5). This must not touch min at all.
+	agg.addMax(1, 5)
+	require.Equal(t, 1.0, agg.minV)
+	require.Equal(t, int64(100), agg.minTime)
+	require.Equal(t, 5.0, agg.maxV)
+	require.Equal(t, int64(50), agg.maxTime)
+
+	// A genuine max-value tie with an earlier time must update maxTime.
+	agg.addMax(5, 10)
+	require.Equal(t, 5.0, agg.maxV)
+	require.Equal(t, int64(10), agg.maxTime)
+}
+
+// TestBooleanPreAgg_addMax_minTimeNotCorrupted mirrors
+// TestFloatPreAgg_addMax_minTimeNotCorrupted for BooleanPreAgg, which had the
+// same addMin/addMax copy-paste bug.
+func TestBooleanPreAgg_addMax_minTimeNotCorrupted(t *testing.T) {
+	agg := NewBooleanPreAgg()
+	agg.reset()
+
+	agg.addMin(0, 100)
+	agg.addMax(1, 50)
+
+	// v equals the current minV (0), not maxV (1). This must not touch min at all.
+	agg.addMax(0, 5)
+	require.EqualValues(t, 0, agg.minV)
+	require.Equal(t, int64(100), agg.minTime)
+	require.EqualValues(t, 1, agg.maxV)
+	require.Equal(t, int64(50), agg.maxTime)
+
+	// A genuine max-value tie with an earlier time must update maxTime.
+	agg.addMax(1, 10)
+	require.EqualValues(t, 1, agg.maxV)
+	require.Equal(t, int64(10), agg.maxTime)
+}
+
 func TestFloatPreAggVLC(t *testing.T) {
 	var assert = func(agg *FloatPreAgg) {
 		buf := agg.marshal(nil)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: ref #899

### What is changed and how it works?

`FloatPreAgg.addMax` and `BooleanPreAgg.addMax` in `engine/immutable/pre_aggregation.go`
had a copy-paste bug (present since 2023-04-15, commit 3408178eb): on the branch handling
a non-new-max value, they compared the incoming value against `minV` instead of `maxV`,
and on a match overwrote `minTime` instead of `maxTime`. `IntegerPreAgg.addMax` in the
same file has the correct pattern for comparison.

Effect: any call to `addMax` with a value that coincidentally equals the accumulator's
*unrelated* `minV` silently corrupts `minTime` with a timestamp that has nothing to do
with the min value, decoupling `(minV, minTime)` into an inconsistent pair. This is
reachable in production via `FloatPreAgg.merge`/`BooleanPreAgg.merge` (called from
`mergeFloatPreAgg` during compaction in `engine/immutable/stream_compact.go`), which
calls `addMin` then `addMax` while folding one chunk's pre-aggregated min/max metadata
into another's. The corrupted `minTime` then flows into `ColumnMeta.preAgg`, which is
exactly what `FirstLastReader.ReadMinFromPreAgg` (`engine/immutable/first_last_reader.go`)
consumes for the `first()` aggregate's pre-aggregation fast path.

This is a plausible, demonstrated root-cause candidate for the symptom reported in
issue #899 ("first() returns the correct value but the wrong time", described as rare
and hard to reproduce, present for only one tag/time-range). It requires the coincidence
that some chunk's max value being merged in equals the accumulator's current min value
during compaction — data-dependent and rare, matching the report. I have not reproduced
the original reporter's exact query against a live cluster, so I'm not claiming this is
confirmed as *the* cause, only that it is a real, independently provable bug in the code
path a maintainer already suspected (see the issue thread, which points at the
pre-aggregation path via the `Exact_Static_Query` hint suggestion).

Fix: compare against `maxV`/update `maxTime` in both `addMax` implementations, mirroring
`IntegerPreAgg.addMax`'s already-correct logic. `StringPreAgg`/`TimePreAgg` `addMin`/`addMax`
are no-op stubs and are unaffected.

### How Has This Been Tested?

Added `TestFloatPreAgg_addMax_minTimeNotCorrupted` and
`TestBooleanPreAgg_addMax_minTimeNotCorrupted` in `engine/immutable/pre_aggregation_test.go`,
each of which sets up a min/max pair, then calls `addMax` with a value equal to the
*min* (not max) and asserts neither min nor max is touched, then calls `addMax` with a
genuine max-tie and asserts `maxTime` updates correctly.

Verified both tests fail against the pre-fix code with exactly the corruption described
(`minTime` overwritten from an unrelated call: expected 100, got 5), and pass after the
fix.

This sandbox's only available Go toolchain (1.26.5) cannot build this repo at all, even
with zero code changes, because the pinned `github.com/bytedance/sonic` v1.13.3 dependency
declares an explicit `!go1.25` build constraint while `go.mod` requires `go >= 1.25.0`
(reproduced identically on a clean, unmodified checkout via `git stash`). To validate, I
built a throwaway `/tmp` copy of the repo (not part of this commit; `go.mod`/`go.sum` here
are unchanged) with `sonic` bumped to v1.15.2 purely to unblock local compilation, and ran:

- `go test ./engine/immutable/... -run 'TestFloatPreAgg|TestIntegerPreAgg|TestBoolean|TestConvert|TestDecodeAggTimes'` — all pass
- `go vet ./engine/immutable/...` — passes
- `gofmt -l` on both changed files — no issues

A full, unfiltered `go test ./engine/immutable/...` also surfaced two failures
(`TestLazyInitError`/`TestFileHandlesRef_EnableMmap`, and `TestMergeWithParquetTask`)
that I independently confirmed are pre-existing and unrelated to this change — both
reproduce identically against pristine, unmodified code from HEAD (likely macOS-specific
mmap/filesystem environment issues in this sandbox, unrelated to pre-aggregation).

I could not run this against the real reported query on a live cluster.

- [x] Test A
- [x] Test B
- [ ] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Fixes #899