### PR TITLE
fix: forward write precision to data subscription destinations

### DIFF
--- a/coordinator/subscriber.go
+++ b/coordinator/subscriber.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Client interface {
-	Send(db, rp string, lineProtocol []byte) error
+	Send(db, rp, precision string, lineProtocol []byte) error
 	Destination() string
 }
 
@@ -42,7 +42,7 @@ type HTTPClient struct {
 	url    *url.URL
 }
 
-func (c *HTTPClient) Send(db, rp string, lineProtocol []byte) error {
+func (c *HTTPClient) Send(db, rp, precision string, lineProtocol []byte) error {
 	r := bytes.NewReader(lineProtocol)
 	req, err := http.NewRequest("POST", c.url.String()+"/write", r)
 	if err != nil {
@@ -52,6 +52,9 @@ func (c *HTTPClient) Send(db, rp string, lineProtocol []byte) error {
 	params := req.URL.Query()
 	params.Set("db", db)
 	params.Set("rp", rp)
+	if precision != "" {
+		params.Set("precision", precision)
+	}
 	req.URL.RawQuery = params.Encode()
 
 	resp, err := c.client.Do(req)
@@ -102,6 +105,7 @@ func NewHTTPSClient(url *url.URL, timeout time.Duration, skipVerify bool, certs 
 
 type WriteRequest struct {
 	Client       int
+	Precision    string
 	LineProtocol []byte
 }
 
@@ -129,7 +133,7 @@ func (w *BaseWriter) Send(wr *WriteRequest) {
 
 func (w *BaseWriter) Run() {
 	for wr := range w.ch {
-		err := w.clients[wr.Client].Send(w.db, w.rp, wr.LineProtocol)
+		err := w.clients[wr.Client].Send(w.db, w.rp, wr.Precision, wr.LineProtocol)
 		if err != nil {
 			w.logger.Error("failed to forward write request", zap.String("dest", w.clients[wr.Client].Destination()),
 				zap.String("db", w.db), zap.String("rp", w.rp), zap.Error(err))
@@ -157,7 +161,7 @@ func (w *BaseWriter) Stop() {
 }
 
 type SubscriberWriter interface {
-	Write(lineProtocol []byte)
+	Write(precision string, lineProtocol []byte)
 	Name() string
 	Run()
 	Start(concurrency, buffersize int)
@@ -169,10 +173,11 @@ type AllWriter struct {
 	BaseWriter
 }
 
-func (w *AllWriter) Write(lineProtocol []byte) {
+func (w *AllWriter) Write(precision string, lineProtocol []byte) {
 	for i := 0; i < len(w.clients); i++ {
 		wr := &WriteRequest{}
 		wr.Client = i
+		wr.Precision = precision
 		wr.LineProtocol = make([]byte, len(lineProtocol))
 		copy(wr.LineProtocol, lineProtocol)
 		w.Send(wr)
@@ -184,9 +189,9 @@ type RoundRobinWriter struct {
 	i int32
 }
 
-func (w *RoundRobinWriter) Write(lineProtocol []byte) {
+func (w *RoundRobinWriter) Write(precision string, lineProtocol []byte) {
 	i := atomic.AddInt32(&w.i, 1) % int32(len(w.clients))
-	wr := &WriteRequest{Client: int(i), LineProtocol: lineProtocol}
+	wr := &WriteRequest{Client: int(i), Precision: precision, LineProtocol: lineProtocol}
 	w.Send(wr)
 }
 
@@ -332,7 +337,7 @@ func (s *SubscriberManager) UpdateWriters() {
 	})
 }
 
-func (s *SubscriberManager) Send(db, rp string, lineProtocol []byte) {
+func (s *SubscriberManager) Send(db, rp, precision string, lineProtocol []byte) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -352,7 +357,7 @@ func (s *SubscriberManager) Send(db, rp string, lineProtocol []byte) {
 
 	if writer, ok := s.writers[db][rp]; ok {
 		for _, w := range writer {
-			w.Write(lineProtocol)
+			w.Write(precision, lineProtocol)
 		}
 	}
 }

--- a/coordinator/subscriber_test.go
+++ b/coordinator/subscriber_test.go
@@ -39,7 +39,7 @@ type MockSubscriberClient struct {
 	dest string
 }
 
-func (c *MockSubscriberClient) Send(db, rp string, lineProtocol []byte) error {
+func (c *MockSubscriberClient) Send(db, rp, precision string, lineProtocol []byte) error {
 	return nil
 }
 
@@ -59,10 +59,11 @@ func TestAllWriter(t *testing.T) {
 	w.ch = ch
 
 	line := "cpu_load,host=\"server-01\",region=\"west_cn\" value=75.31"
-	w.Write([]byte(line))
+	w.Write("ms", []byte(line))
 	for i := 0; i < 3; i++ {
 		wr := <-ch
 		assert2.Equal(t, wr.Client, i)
+		assert2.Equal(t, wr.Precision, "ms")
 		assert2.Equal(t, string(wr.LineProtocol), line)
 	}
 
@@ -87,9 +88,10 @@ func TestAnyWriter(t *testing.T) {
 
 	line := "cpu_load,host=\"server-01\",region=\"west_cn\" value=75.31"
 	for i := 0; i < 6; i++ {
-		w.Write([]byte(line))
+		w.Write("ms", []byte(line))
 		wr := <-ch
 		assert2.Equal(t, wr.Client, (i+1)%3)
+		assert2.Equal(t, wr.Precision, "ms")
 		assert2.Equal(t, string(wr.LineProtocol), line)
 		select {
 		case <-ch:
@@ -303,12 +305,13 @@ func TestSendWriteRequest(t *testing.T) {
 	type Request struct {
 		db           string
 		rp           string
+		precision    string
 		lineProtocol []byte
 	}
 	ch := make(chan Request, 10)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/write", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		wr := Request{db: r.URL.Query().Get("db"), rp: r.URL.Query().Get("rp")}
+		wr := Request{db: r.URL.Query().Get("db"), rp: r.URL.Query().Get("rp"), precision: r.URL.Query().Get("precision")}
 		wr.lineProtocol, _ = io.ReadAll(r.Body)
 		ch <- wr
 		w.WriteHeader(http.StatusNoContent)
@@ -334,13 +337,14 @@ func TestSendWriteRequest(t *testing.T) {
 
 	// test ALL mode
 	for i := 0; i < 5; i++ {
-		s.Send("db0", "rp0", []byte(line))
+		s.Send("db0", "rp0", "ns", []byte(line))
 	}
 
 	for i := 0; i < 10; i++ {
 		r := <-ch
 		assert2.Equal(t, r.db, "db0")
 		assert2.Equal(t, r.rp, "rp0")
+		assert2.Equal(t, r.precision, "ns")
 		assert2.Equal(t, string(r.lineProtocol), line)
 	}
 
@@ -358,13 +362,14 @@ func TestSendWriteRequest(t *testing.T) {
 	}
 	dbi.DefaultRetentionPolicy = "rp1"
 	for i := 0; i < 5; i++ {
-		s.Send("db1", "", []byte(line))
+		s.Send("db1", "", "s", []byte(line))
 	}
 
 	for i := 0; i < 5; i++ {
 		r := <-ch
 		assert2.Equal(t, r.db, "db1")
 		assert2.Equal(t, r.rp, "rp1")
+		assert2.Equal(t, r.precision, "s")
 		assert2.Equal(t, string(r.lineProtocol), line)
 	}
 

--- a/lib/util/lifted/influx/httpd/handler.go
+++ b/lib/util/lifted/influx/httpd/handler.go
@@ -116,7 +116,7 @@ type Route struct {
 }
 
 type SubscriberManager interface {
-	Send(db, rp string, lineProtocol []byte)
+	Send(db, rp, precision string, lineProtocol []byte)
 }
 
 type PointsWriter interface {
@@ -1618,7 +1618,7 @@ func (h *Handler) serveWrite(database string, rp string, w http.ResponseWriter, 
 			} else {
 				if h.SubscriberManager != nil {
 					// uw.ReqBuf is the line protocol
-					h.SubscriberManager.Send(db, rp, uw.ReqBuf)
+					h.SubscriberManager.Send(db, rp, precision, uw.ReqBuf)
 				}
 				handlerStat.PointsWrittenOK.Add(int64(len(rows)))
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #943

When data subscription is enabled, writes forwarded to subscriber destinations
lose the client's write precision. The primary scales the client's timestamps
into nanoseconds locally using the `precision` query param from the original
write request, but the raw (unscaled) line-protocol bytes forwarded to the
subscriber are POSTed without a `precision` query param. A client writing with
`precision=s` (or `ms`/`us`) therefore produces correctly-scaled data on the
primary, while the subscriber-side copy misinterprets the same raw timestamp
values as nanoseconds, causing the primary and subscriber to end up with
divergent timestamps for what should be identical data.

### What is changed and how it works?

Threads the original request's `precision` string through the subscription
forwarding path in `coordinator/subscriber.go` so the subscriber HTTP request
carries the same `precision` query param the client originally supplied:

- `Client.Send` / `HTTPClient.Send` gain a `precision` parameter; `HTTPClient.Send`
  sets `precision` on the outgoing `/write` request when non-empty.
- `WriteRequest` gains a `Precision` field, threaded through `BaseWriter`,
  `AllWriter.Write` and `RoundRobinWriter.Write`.
- `SubscriberManager.Send` gains a `precision` parameter (and the matching
  interface in `lib/util/lifted/influx/httpd/handler.go`).
- `serveWrite` now passes the `precision` value it already parsed from the
  original request (`urlValues.Get("precision")`) through to
  `SubscriberManager.Send`, instead of dropping it.

When precision is empty (client didn't specify one), the param is still
omitted, which is behaviorally equivalent since both the primary and the
subscriber default to nanosecond precision in that case.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A
- [ ] Test B
- [ ] Test cases to be added
- [ ] No code

Updated `coordinator/subscriber_test.go` to assert the previously-missing
behavior end to end:
- `TestAllWriter` / `TestAnyWriter` now assert `WriteRequest.Precision` is
  propagated from `Write(precision, lineProtocol)` through to the queued
  request.
- `TestSendWriteRequest` now runs a mock HTTP `/write` handler and asserts it
  actually receives `precision=ns` / `precision=s` as a query parameter for
  writes sent via `SubscriberManager.Send(db, rp, precision, lineProtocol)` —
  this is the exact defect: before this change, `HTTPClient.Send` never set
  `precision` on the outgoing request at all.

Commands run and their results:
- `go build ./...` — passes, no errors.
- `go test ./coordinator/... -run 'TestAllWriter|TestAnyWriter|TestSendWriteRequest|TestInitWriter|TestUpdateWriter|TestUpdate|TestNewHTTPSClient' -v` — all pass.
- `go test ./coordinator/...` (full package) — passes except two pre-existing,
  unrelated failures (`TestRetryWriteRecord`, `TestWriteLogRecord`) that bind
  to `127.0.0.10:8491`; confirmed via `git stash` that these fail identically
  on the unmodified base branch (sandbox loopback-alias restriction, not
  caused by this change).
- `go test ./lib/util/lifted/influx/httpd/...` — the write/subscriber-relevant
  tests (`TestHandler_Disabled_Write_Read`, `TestHandler_ServeWrite_ReadOnly`,
  `TestHandler_ServeWrite_TooBig`, etc.) pass; two unrelated pre-existing
  failures (a timezone-dependent Prometheus test and a loopback-bind test) are
  environmental, not caused by this change.
- `go vet ./coordinator/...` — clean.
- `staticcheck -tests=false ./coordinator/...` (mirroring `scripts/ci/static_check.sh`'s
  invocation) — clean.

Not run locally: this repo's CI also runs a full multi-service cluster
integration test (`make start-subscriber` + `scripts/install_cluster.sh` +
`make integration-test`), which requires standing up ts-meta/ts-sql/ts-store
processes and is out of scope for local validation of this change; the fix
is a straightforward parameter-threading change fully covered by the unit
test asserting the wire-level `precision` query parameter reaches the
subscriber.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules