### PR TITLE
fix: preserve newlines in quoted string fields

### DIFF
--- a/lib/util/lifted/vm/protoparser/influx/parser.go
+++ b/lib/util/lifted/vm/protoparser/influx/parser.go
@@ -1484,8 +1484,12 @@ func (f *Field) unmarshal(s string, noEscapeChars, hasQuotedFields bool) error {
 func unmarshalRows(dst []Row, s string, tagsPool []Tag, fieldsPool []Field, enableTagArray bool) ([]Row, []Tag, []Field, error) {
 	var err error
 	noEscapeChars := strings.IndexByte(s, '\\') < 0
+	// A quoted string field value may legitimately contain a literal '\n'. Quotes are only
+	// meaningful within a line's fields section, so hasQuotedFields is checked once here
+	// purely as a cheap skip for the common case where no line in the batch has any.
+	hasQuotedFields := strings.IndexByte(s, '"') >= 0
 	for len(s) > 0 {
-		n := strings.IndexByte(s, '\n')
+		n := nextRowEnd(s, noEscapeChars, hasQuotedFields, enableTagArray)
 		if n < 0 {
 			// The last line.
 			return unmarshalRow(dst, s, tagsPool, fieldsPool, noEscapeChars, enableTagArray)
@@ -1494,6 +1498,29 @@ func unmarshalRows(dst []Row, s string, tagsPool []Tag, fieldsPool []Field, enab
 		s = s[n+1:]
 	}
 	return dst, tagsPool, fieldsPool, err
+}
+
+// nextRowEnd returns the index of the '\n' terminating the line starting at s, or -1 if s
+// contains no more terminated lines. Measurement names and tag values never quote a '"'
+// (only comma/equals/space/backslash are escaped there), so quoting only ever delimits a
+// string field value. Quote-tracking is therefore scoped to each line's fields section
+// (everything after its first unescaped space) so a stray '"' in tags/measurement of one
+// line can't desync the quoting state used to find the next line's terminator.
+func nextRowEnd(s string, noEscapeChars, hasQuotedFields, enableTagArray bool) int {
+	// Row.unmarshal skips leading whitespace before locating this same boundary space;
+	// mirror that here so a line's leading whitespace isn't mistaken for its fields section.
+	start := checkWhitespace(s, 0)
+	sp := nextUnescapedChar(s[start:], ' ', noEscapeChars, enableTagArray, false)
+	if sp < 0 {
+		// No fields section; let per-row parsing report the error.
+		return nextUnescapedChar(s, '\n', noEscapeChars, false, false)
+	}
+	sp += start
+	n := nextUnquotedChar(s[sp+1:], '\n', noEscapeChars, hasQuotedFields)
+	if n < 0 {
+		return -1
+	}
+	return sp + 1 + n
 }
 
 func unmarshalRow(dst []Row, s string, tagsPool []Tag, fieldsPool []Field, noEscapeChars, enableTagArray bool) ([]Row, []Tag, []Field, error) {

--- a/lib/util/lifted/vm/protoparser/influx/parser_test.go
+++ b/lib/util/lifted/vm/protoparser/influx/parser_test.go
@@ -53,6 +53,50 @@ func TestUnmarshalRows(t *testing.T) {
 	rows, tagsPool, fieldsPool = f(rows[:0], req, tagsPool[:0], fieldsPool[:0], 0)
 }
 
+// TestUnmarshalRows_NewlineInQuotedStringField verifies that a literal newline byte
+// embedded in a quoted string field value does not get mistaken for a line separator.
+// See https://github.com/openGemini/openGemini/issues/746.
+func TestUnmarshalRows_NewlineInQuotedStringField(t *testing.T) {
+	enableTagArray := false
+	var rows []Row
+	var tagsPool []Tag
+	var fieldsPool []Field
+
+	req := "json1,a=1,b=2 data=\"{\n\t\\\"a\\\": 1,\n\t\\\"b\\\": \\\"s\\\"\n}\" 1622851200000000000\n"
+	rows, tagsPool, fieldsPool, err := unmarshalRows(rows[:0], req, tagsPool[:0], fieldsPool[:0], enableTagArray)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Fields, 1)
+	require.Equal(t, "{\n\t\"a\": 1,\n\t\"b\": \"s\"\n}", rows[0].Fields[0].StrValue)
+
+	// A quoted field containing a newline followed by another line must still split correctly.
+	req = "json1,a=1,b=2 data=\"line1\nline2\" 1622851200000000000\ncpu,host=h value=1i 1622851200000000000\n"
+	rows, _, _, err = unmarshalRows(rows[:0], req, tagsPool[:0], fieldsPool[:0], enableTagArray)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "line1\nline2", rows[0].Fields[0].StrValue)
+	require.Equal(t, "cpu", rows[1].Name)
+
+	// A stray, unescaped '"' in a tag value (legal, since tags never quote) must not be
+	// mistaken for the start of a string field value and desync line splitting for the
+	// rest of the batch.
+	req = "cpu,host=serv\"er value=1 1622851200000000000\ncpu2,host=h2 value=2 1622851200000000000\n"
+	rows, _, _, err = unmarshalRows(rows[:0], req, tagsPool[:0], fieldsPool[:0], enableTagArray)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "cpu", rows[0].Name)
+	require.Equal(t, "cpu2", rows[1].Name)
+
+	// Leading whitespace on a line (tolerated elsewhere via checkWhitespace) combined with
+	// a stray tag quote must not misidentify the line's fields-section boundary either.
+	req = " cpu,host=h\"x value=1 1622851200000000000\ncpu2,host=h2 value=2 1622851200000000000\n"
+	rows, _, _, err = unmarshalRows(rows[:0], req, tagsPool[:0], fieldsPool[:0], enableTagArray)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "cpu", rows[0].Name)
+	require.Equal(t, "cpu2", rows[1].Name)
+}
+
 func TestUnmarshalRows_error(t *testing.T) {
 	enableTagArray := false
 	f := func(dst []Row, s string, tagsPool []Tag, fieldsPool []Field, expectedErr string) {


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close","fix", "resolve" or "ref".
-->

Issue Number: close #746

When a quoted string field value in the line protocol write payload contains a literal
(raw) newline byte — e.g. an unescaped multi-line JSON blob stored in a string field —
the server fails to parse the write request. `unmarshalRows` in
`lib/util/lifted/vm/protoparser/influx/parser.go` split the whole payload into lines
using a plain `strings.IndexByte(s, '\n')`, with no awareness of whether that `\n` fell
inside an open quoted string. This causes the embedded newline to be treated as a line
separator, splitting the quoted string mid-value and producing errors such as
`missing closing quote for quoted field value` or (as in the issue's HTTP capture)
`parse fail, point without fields is unsupported`.

### What is changed and how it works?
`unmarshalRows` now calls a new helper, `nextRowEnd`, instead of doing a raw newline
search. `nextRowEnd` first locates the boundary between a line's measurement+tags
section and its fields section (the same unescaped-space search `Row.unmarshal` already
uses, including skipping leading whitespace via the existing `checkWhitespace`).
Quote-tracking (via the existing `nextUnquotedChar`/`isInQuote` helpers, already used
elsewhere in this file to split fields on commas while respecting quoted values) is then
scoped to just that line's fields section when searching for the terminating `\n`. This
matters because measurement names and tag values never treat `"` as special (only
comma/equals/space/backslash are escaped there), so quoting only ever delimits a string
field value — resetting the quote-parity search at each line's own tags/fields boundary
prevents a stray, legal `"` in one line's tags (or leading whitespace before it) from
desyncing the newline search for later lines in the same write request.

### How Has This Been Tested?

Added `TestUnmarshalRows_NewlineInQuotedStringField` to
`lib/util/lifted/vm/protoparser/influx/parser_test.go`, covering:
- A quoted string field containing embedded literal newlines parses as one row with the
  newline-preserving value intact (the case from the issue).
- A quoted field with an embedded newline followed by a second, normal line still splits
  into two correctly-parsed rows.
- A stray unescaped `"` in a tag value does not corrupt parsing of a later line in the
  same batch.
- The same stray-tag-quote case combined with leading whitespace on the line.

Ran, from the repo root:
- `go build ./...` — succeeds.
- `go test ./lib/util/lifted/vm/protoparser/influx/... -v` — all tests pass, including
  the new cases and the full pre-existing suite in this package.
- `gofmt -l` and `go vet ./lib/util/lifted/vm/protoparser/influx/...` — clean.

I confirmed the new test actually exercises the bug: reverting `parser.go` while keeping
the test causes it to fail with `parse fail, point without fields is unsupported`,
matching the error reported in the issue; with the fix applied it passes.

This repo's `static-check` (staticcheck) target explicitly excludes packages matching
`lifted` in `scripts/ci/static_check.sh`, so it does not apply to this file. I did not
run the repo's `integration-test` target (requires a live running server); this change
is scoped to a pure parsing function covered directly by unit tests, so I believe that is
sufficient for this fix.

Note: this repo's PR-triggered CI (`.github/workflows/ci.yml`, `GoLint` job → `go version
check`) is currently failing on essentially every recent PR regardless of diff content,
due to a go-version mismatch between the CI matrix (go 1.24) and `go.mod`'s `go 1.25.0`
directive — a pre-existing base-branch issue unrelated to this change.

- [ ] Test A
- [ ] Test B
- [x] Test cases to be added
- [ ] No code

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules